### PR TITLE
feat(onboarding): add first-run onboarding flow with Lucide icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.5.0",
-        "@tauri-apps/plugin-opener": "^2"
+        "@tauri-apps/plugin-opener": "^2",
+        "lucide-svelte": "^0.562.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -198,6 +199,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -241,6 +243,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -905,7 +908,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -916,7 +918,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -927,7 +928,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -937,14 +937,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1312,7 +1310,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
       "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1324,6 +1321,7 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -2033,7 +2031,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2088,6 +2085,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2414,8 +2412,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2497,7 +2495,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2517,7 +2514,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2608,7 +2604,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2779,7 +2774,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
       "integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -2884,6 +2878,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3019,7 +3014,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -3057,7 +3051,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
       "integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3376,7 +3369,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -3425,6 +3417,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -3786,7 +3779,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3822,6 +3814,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lucide-svelte": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.562.0.tgz",
+      "integrity": "sha512-kSJDH/55lf0mun/o4nqWBXOcq0fWYzPeIjbTD97ywoeumAB9kWxtM06gC7oynqjtK3XhAljWSz5RafIzPEYIQA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5.0.0-next.42"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3836,7 +3837,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -4032,6 +4032,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,6 +4060,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4192,6 +4194,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4460,8 +4463,8 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.1.tgz",
       "integrity": "sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -4687,6 +4690,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4742,6 +4746,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4837,6 +4842,7 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -5055,7 +5061,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.5.0",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "lucide-svelte": "^0.562.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import Onboarding from "./lib/components/Onboarding.svelte";
   import ReferencesPanel from "./lib/components/ReferencesPanel.svelte";
   import ScenePanel from "./lib/components/ScenePanel.svelte";
   import Sidebar from "./lib/components/Sidebar.svelte";
@@ -35,3 +36,6 @@
     <StartScreen {recentProjects} />
   {/if}
 </main>
+
+<!-- Onboarding overlay (shown on first launch) -->
+<Onboarding />

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -1,0 +1,684 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { open } from "@tauri-apps/plugin-dialog";
+  import {
+    ArrowDownAZ,
+    BookOpen,
+    Check,
+    ChevronDown,
+    ChevronLeft,
+    ChevronRight,
+    ChevronsRight,
+    FileText,
+    ListChevronsDownUp,
+    Kanban,
+    MapPin,
+    User,
+    Users,
+    Zap,
+  } from "lucide-svelte";
+  import { currentProject } from "../stores/project.svelte";
+  import { ui, type OnboardingStep } from "../stores/ui.svelte";
+  import type { Project } from "../types";
+
+  const STEP_ORDER: OnboardingStep[] = [
+    "welcome",
+    "tour-sidebar",
+    "tour-editor",
+    "tour-references",
+    "import",
+  ];
+
+  // Import handlers (same logic as StartScreen)
+  async function importPlottr() {
+    const path = await open({
+      multiple: false,
+      filters: [{ name: "Plottr", extensions: ["pltr"] }],
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_plottr", { path });
+        currentProject.setProject(project);
+        ui.completeOnboarding();
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Plottr file:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  async function importScrivener() {
+    const path = await open({
+      multiple: false,
+      directory: true,
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_scrivener", { path });
+        currentProject.setProject(project);
+        ui.completeOnboarding();
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Scrivener project:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  async function importMarkdown() {
+    const path = await open({
+      multiple: false,
+      filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_markdown", { path });
+        currentProject.setProject(project);
+        ui.completeOnboarding();
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Markdown file:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  function skipOnboarding() {
+    ui.completeOnboarding();
+  }
+</script>
+
+{#if ui.showOnboarding}
+  <div class="fixed inset-0 bg-bg-primary/95 flex items-center justify-center z-50 p-4">
+    <div class="max-w-2xl w-full">
+      <!-- Progress indicator -->
+      <div class="flex justify-center gap-2 mb-8">
+        {#each STEP_ORDER as step, i (step)}
+          <button
+            onclick={() => ui.goToStep(step)}
+            class="w-2 h-2 rounded-full transition-all {i === ui.currentStepIndex
+              ? 'bg-accent w-6'
+              : i < ui.currentStepIndex
+                ? 'bg-accent/50'
+                : 'bg-bg-card'}"
+            aria-label="Go to step {i + 1}"
+          ></button>
+        {/each}
+      </div>
+
+      <!-- Step content -->
+      <div class="bg-bg-panel rounded-xl p-8 shadow-xl">
+        {#if ui.onboardingStep === "welcome"}
+          <!-- STEP 1: Welcome -->
+          <div class="text-center">
+            <!-- Logo -->
+            <div class="flex justify-center mb-6">
+              <svg width="100" height="100" viewBox="0 0 1024 1024" class="drop-shadow-lg">
+                <defs>
+                  <linearGradient
+                    id="bookGradientOnboarding"
+                    x1="509"
+                    y1="739"
+                    x2="512"
+                    y2="609"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0" stop-color="#501D0F" />
+                    <stop offset="1" stop-color="#89492B" />
+                  </linearGradient>
+                </defs>
+                <path
+                  fill="#E25227"
+                  d="M495.154 288.138C498.378 289.608 505.914 297.445 508.313 300.3C526.269 321.669 539.502 342.79 542.378 370.879C549.115 436.662 490.007 467.903 476.848 526.209C472.415 545.849 474.731 568.443 482.366 587.122C483.763 590.541 490.702 602.324 490.569 604.62L489.492 604.081C466.698 587.526 440.031 561.25 430.639 534.248C403.556 456.377 485.481 402.143 496.346 330.247C498.679 314.804 498.133 303.222 495.154 288.138Z"
+                />
+                <path
+                  fill="url(#bookGradientOnboarding)"
+                  d="M679.512 611.655C679.948 623.671 679.803 636.504 679.711 648.539C679.819 650.345 679.874 650.354 679.431 652.203C678.578 653.105 645.852 669.482 641.946 671.541L551.504 719.091C543.78 723.161 536.109 727.33 528.491 731.597C523.974 734.127 516.055 738.826 511.383 740.578C504.39 737.13 495.509 731.912 488.494 728.114L438.452 701.202C418.928 690.993 399.491 680.618 380.143 670.078C368.598 663.83 355.674 656.975 344.543 650.136C344.526 637.556 344.602 624.446 344.219 611.898C359.414 619.412 379.065 631.083 394.357 639.52L470.64 681.021C479.247 685.796 487.81 690.649 496.33 695.578C500.794 698.136 506.902 701.896 511.48 703.945C532.487 690.677 560.415 676.473 582.602 664.63C615.066 647.267 647.37 629.608 679.512 611.655Z"
+                />
+                <path
+                  fill="#F0912D"
+                  d="M567.225 404.156C568.003 404.556 568.509 404.868 568.965 405.666C588.192 439.301 602.938 484.462 595.366 523.183C587.91 561.316 558.078 585.951 527.823 605.935L518.591 611.429C510.152 597.693 506.392 586.985 503.912 571.209C497.26 528.911 522.684 499.522 542.221 465.408C552.466 447.518 562.786 424.502 567.225 404.156Z"
+                />
+                <path
+                  fill="#F0912D"
+                  d="M359.24 550.125C365.269 552.715 379.71 564.412 385.223 568.751C425.497 600.45 464.809 634.729 496.049 675.611C499.494 680.119 508.175 690.937 510.126 695.939C503.857 692.741 497.548 689.208 491.532 685.547C448.751 659.511 402.641 638.037 359.663 612.561C359.387 591.884 359.872 570.732 359.24 550.125Z"
+                />
+                <path
+                  fill="#F0912D"
+                  d="M664.174 549.059L664.428 593.205C664.417 599.159 664.625 607.179 664.213 612.947C655.817 616.909 647.229 621.897 639.067 626.408L603.341 646.032C582.669 657.264 562.058 668.608 541.509 680.063C534.744 683.835 526.75 687.959 520.246 691.793C518.071 693.047 515.906 694.089 513.66 695.2L519.513 687.005C556.887 634.717 612.459 587.041 664.174 549.059Z"
+                />
+              </svg>
+            </div>
+
+            <h1 class="text-4xl font-heading font-semibold text-accent mb-3">
+              Welcome to Kindling
+            </h1>
+            <p class="text-text-secondary text-lg mb-8 max-w-md mx-auto">
+              Transform your outline into a finished draft. Import your story structure and start
+              writing scene by scene.
+            </p>
+
+            <div class="flex flex-col gap-3">
+              <button
+                onclick={() => ui.nextStep()}
+                class="w-full py-3 px-6 bg-accent hover:bg-flame-orange text-white font-medium rounded-lg transition-colors"
+              >
+                Take the Tour
+              </button>
+              <button
+                onclick={skipOnboarding}
+                class="text-text-secondary hover:text-text-primary text-sm transition-colors"
+              >
+                Skip and start importing
+              </button>
+            </div>
+          </div>
+        {:else if ui.onboardingStep === "tour-sidebar"}
+          <!-- STEP 2: Chapters & Scenes Tour -->
+          <div>
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-10 h-10 rounded-lg bg-accent/20 flex items-center justify-center">
+                <ArrowDownAZ class="w-5 h-5 text-accent" />
+              </div>
+              <div>
+                <h2 class="text-2xl font-heading font-semibold text-text-primary">
+                  Chapters & Scenes
+                </h2>
+                <p class="text-text-secondary text-sm">The left sidebar</p>
+              </div>
+            </div>
+
+            <!-- Visual mockup of sidebar -->
+            <div class="bg-bg-card rounded-lg p-4 mb-6">
+              <div class="space-y-3">
+                <!-- Chapter example -->
+                <div class="relative">
+                  <div class="flex items-center gap-2 p-2 rounded bg-bg-panel">
+                    <ChevronDown class="w-4 h-4 text-text-secondary" />
+                    <span class="text-text-primary font-medium">Chapter 1: The Beginning</span>
+                  </div>
+                  <!-- Label -->
+                  <div
+                    class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                  >
+                    <div class="w-8 h-px bg-accent"></div>
+                    <span class="text-accent text-xs font-medium whitespace-nowrap">Chapter</span>
+                  </div>
+                </div>
+
+                <!-- Scene examples -->
+                <div class="ml-6 space-y-2">
+                  <div class="relative">
+                    <div
+                      class="flex items-center gap-2 p-2 rounded bg-accent/10 border border-accent/30"
+                    >
+                      <FileText class="w-4 h-4 text-accent" />
+                      <span class="text-text-primary">Opening Scene</span>
+                    </div>
+                    <!-- Label -->
+                    <div
+                      class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                    >
+                      <div class="w-8 h-px bg-spark-gold"></div>
+                      <span class="text-spark-gold text-xs font-medium whitespace-nowrap"
+                        >Active Scene</span
+                      >
+                    </div>
+                  </div>
+
+                  <div class="relative">
+                    <div class="flex items-center gap-2 p-2 rounded hover:bg-bg-panel">
+                      <FileText class="w-4 h-4 text-text-secondary" />
+                      <span class="text-text-secondary">The Discovery</span>
+                    </div>
+                    <!-- Label -->
+                    <div
+                      class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                    >
+                      <div class="w-8 h-px bg-text-secondary"></div>
+                      <span class="text-text-secondary text-xs font-medium whitespace-nowrap"
+                        >Other Scene</span
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="bg-bg-card/50 rounded-lg p-4 mb-6">
+              <ul class="text-text-secondary text-sm space-y-2">
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Click a chapter</strong> to expand or collapse
+                    its scenes</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Click a scene</strong> to load it in the editor</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    >The <strong class="text-text-primary">highlighted scene</strong> is your current
+                    working scene</span
+                  >
+                </li>
+              </ul>
+            </div>
+
+            <div class="flex justify-between items-center pt-4 border-t border-bg-card">
+              <button
+                onclick={() => ui.previousStep()}
+                class="text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
+              >
+                <ChevronLeft class="w-4 h-4" />
+                Back
+              </button>
+              <button
+                onclick={() => ui.nextStep()}
+                class="py-2 px-4 bg-accent hover:bg-flame-orange text-white font-medium rounded-lg transition-colors flex items-center gap-1"
+              >
+                Next
+                <ChevronRight class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        {:else if ui.onboardingStep === "tour-editor"}
+          <!-- STEP 3: Synopsis & Beats Tour -->
+          <div>
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-10 h-10 rounded-lg bg-spark-gold/20 flex items-center justify-center">
+                <Zap class="w-5 h-5 text-spark-gold" />
+              </div>
+              <div>
+                <h2 class="text-2xl font-heading font-semibold text-text-primary">
+                  Synopsis & Beats
+                </h2>
+                <p class="text-text-secondary text-sm">The main editor area</p>
+              </div>
+            </div>
+
+            <!-- Visual mockup of editor -->
+            <div class="bg-bg-card rounded-lg p-4 mb-6 space-y-4">
+              <!-- Synopsis section -->
+              <div class="relative">
+                <div class="bg-bg-panel rounded-lg p-3">
+                  <h4 class="text-xs uppercase tracking-wide text-text-secondary mb-2">Synopsis</h4>
+                  <p class="text-text-primary text-sm">
+                    The hero receives the call to adventure and must decide whether to leave their
+                    ordinary world behind...
+                  </p>
+                </div>
+                <!-- Label -->
+                <div
+                  class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                >
+                  <div class="w-8 h-px bg-accent"></div>
+                  <span class="text-accent text-xs font-medium whitespace-nowrap"
+                    >Scene Synopsis</span
+                  >
+                </div>
+              </div>
+
+              <!-- Beats section -->
+              <div class="space-y-2">
+                <div class="relative">
+                  <div class="bg-beat-header rounded-lg p-3 border-l-2 border-accent">
+                    <div class="flex items-center justify-between mb-1">
+                      <span class="text-text-primary font-medium text-sm"
+                        >The Messenger Arrives</span
+                      >
+                      <span class="text-xs text-text-secondary">Beat 1</span>
+                    </div>
+                    <p class="text-text-secondary text-xs">
+                      A stranger appears at the door with urgent news...
+                    </p>
+                  </div>
+                  <!-- Label -->
+                  <div
+                    class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                  >
+                    <div class="w-8 h-px bg-spark-gold"></div>
+                    <span class="text-spark-gold text-xs font-medium whitespace-nowrap"
+                      >Story Beat</span
+                    >
+                  </div>
+                </div>
+
+                <div class="relative">
+                  <div class="bg-beat-header rounded-lg p-3 border-l-2 border-transparent">
+                    <div class="flex items-center justify-between mb-1">
+                      <span class="text-text-primary font-medium text-sm">The Decision</span>
+                      <span class="text-xs text-text-secondary">Beat 2</span>
+                    </div>
+                    <p class="text-text-secondary text-xs">
+                      Our hero weighs their options and makes a choice...
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="bg-bg-card/50 rounded-lg p-4 mb-6">
+              <ul class="text-text-secondary text-sm space-y-2">
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    >The <strong class="text-text-primary">synopsis</strong> gives you the scene overview
+                    from your outline</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Beats</strong> are the key story moments within
+                    each scene</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span>Use beats as your writing prompts to draft each section</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="flex justify-between items-center pt-4 border-t border-bg-card">
+              <button
+                onclick={() => ui.previousStep()}
+                class="text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
+              >
+                <ChevronLeft class="w-4 h-4" />
+                Back
+              </button>
+              <button
+                onclick={() => ui.nextStep()}
+                class="py-2 px-4 bg-accent hover:bg-flame-orange text-white font-medium rounded-lg transition-colors flex items-center gap-1"
+              >
+                Next
+                <ChevronRight class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        {:else if ui.onboardingStep === "tour-references"}
+          <!-- STEP 4: Reference Panel Tour -->
+          <div>
+            <div class="flex items-center gap-3 mb-4">
+              <div class="w-10 h-10 rounded-lg bg-success/20 flex items-center justify-center">
+                <Users class="w-5 h-5 text-success" />
+              </div>
+              <div>
+                <h2 class="text-2xl font-heading font-semibold text-text-primary">
+                  Reference Panel
+                </h2>
+                <p class="text-text-secondary text-sm">The right sidebar</p>
+              </div>
+            </div>
+
+            <!-- Visual mockup of reference panel -->
+            <div class="bg-bg-card rounded-lg p-4 mb-6">
+              <!-- Tab buttons mockup -->
+              <div class="relative flex gap-1 mb-4 bg-bg-panel rounded-lg p-1">
+                <div class="flex-1 py-2 px-3 rounded bg-bg-card text-center">
+                  <span class="text-text-primary text-sm font-medium">Characters</span>
+                </div>
+                <div class="flex-1 py-2 px-3 rounded text-center">
+                  <span class="text-text-secondary text-sm">Locations</span>
+                </div>
+                <!-- Label -->
+                <div
+                  class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                >
+                  <div class="w-8 h-px bg-accent"></div>
+                  <span class="text-accent text-xs font-medium whitespace-nowrap">Tab Switcher</span
+                  >
+                </div>
+              </div>
+
+              <!-- Character cards mockup -->
+              <div class="space-y-2">
+                <div class="relative">
+                  <div class="bg-bg-panel rounded-lg p-3">
+                    <div class="flex items-center gap-3">
+                      <div
+                        class="w-10 h-10 rounded-full bg-accent/20 flex items-center justify-center"
+                      >
+                        <User class="w-5 h-5 text-accent" />
+                      </div>
+                      <div>
+                        <span class="text-text-primary font-medium">Elena</span>
+                        <p class="text-text-secondary text-xs">Protagonist</p>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- Label -->
+                  <div
+                    class="absolute -right-2 top-1/2 -translate-y-1/2 translate-x-full flex items-center gap-2"
+                  >
+                    <div class="w-8 h-px bg-spark-gold"></div>
+                    <span class="text-spark-gold text-xs font-medium whitespace-nowrap"
+                      >Character Card</span
+                    >
+                  </div>
+                </div>
+
+                <div class="bg-bg-panel rounded-lg p-3">
+                  <div class="flex items-center gap-3">
+                    <div
+                      class="w-10 h-10 rounded-full bg-spark-gold/20 flex items-center justify-center"
+                    >
+                      <MapPin class="w-5 h-5 text-spark-gold" />
+                    </div>
+                    <div>
+                      <span class="text-text-primary font-medium">Marcus</span>
+                      <p class="text-text-secondary text-xs">Mentor</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Toolbar buttons -->
+              <div class="mt-4 pt-4 border-t border-bg-panel space-y-2">
+                <!-- Collapse All button -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-7 h-7 rounded bg-bg-panel flex items-center justify-center flex-shrink-0"
+                  >
+                    <ListChevronsDownUp class="w-4 h-4 text-text-secondary" />
+                  </div>
+                  <span class="text-text-secondary text-sm"
+                    ><strong class="text-text-primary">Collapse All</strong> — close all expanded cards</span
+                  >
+                </div>
+
+                <!-- Sort A-Z button -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-7 h-7 rounded bg-bg-panel flex items-center justify-center flex-shrink-0"
+                  >
+                    <ArrowDownAZ class="w-4 h-4 text-text-secondary" />
+                  </div>
+                  <span class="text-text-secondary text-sm"
+                    ><strong class="text-text-primary">Sort A-Z</strong> — alphabetize the list</span
+                  >
+                </div>
+
+                <!-- Hide Panel button -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-7 h-7 rounded bg-bg-panel flex items-center justify-center flex-shrink-0"
+                  >
+                    <ChevronsRight class="w-4 h-4 text-text-secondary" />
+                  </div>
+                  <span class="text-text-secondary text-sm"
+                    ><strong class="text-text-primary">Hide Panel</strong> — collapse to focus on writing</span
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div class="bg-bg-card/50 rounded-lg p-4 mb-6">
+              <ul class="text-text-secondary text-sm space-y-2">
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Characters tab</strong> shows who appears in the
+                    current scene</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Locations tab</strong> shows where the scene takes
+                    place</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Collapse All</strong> closes all expanded character/location
+                    cards</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Sort A-Z</strong> alphabetizes the list</span
+                  >
+                </li>
+                <li class="flex items-start gap-2">
+                  <span class="text-accent mt-0.5">•</span>
+                  <span
+                    ><strong class="text-text-primary">Hide Panel</strong> collapses the sidebar to focus
+                    on writing</span
+                  >
+                </li>
+              </ul>
+            </div>
+
+            <div class="flex justify-between items-center pt-4 border-t border-bg-card">
+              <button
+                onclick={() => ui.previousStep()}
+                class="text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
+              >
+                <ChevronLeft class="w-4 h-4" />
+                Back
+              </button>
+              <button
+                onclick={() => ui.nextStep()}
+                class="py-2 px-4 bg-accent hover:bg-flame-orange text-white font-medium rounded-lg transition-colors flex items-center gap-1"
+              >
+                Start Importing
+                <ChevronRight class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        {:else if ui.onboardingStep === "import"}
+          <!-- STEP 5: Import (Final Step) -->
+          <div>
+            <div class="text-center mb-6">
+              <div
+                class="w-16 h-16 rounded-full bg-success/20 flex items-center justify-center mx-auto mb-4"
+              >
+                <Check class="w-8 h-8 text-success" />
+              </div>
+              <h2 class="text-2xl font-heading font-semibold text-text-primary mb-2">
+                Ready to Import
+              </h2>
+              <p class="text-text-secondary">Choose your outline format to get started.</p>
+            </div>
+
+            <div class="grid grid-cols-3 gap-4 mb-6">
+              <button
+                onclick={importPlottr}
+                class="flex flex-col items-center p-5 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer border border-transparent hover:border-accent/30"
+              >
+                <Kanban class="w-12 h-12 text-accent mb-3" />
+                <span class="text-text-primary font-medium">Plottr</span>
+                <span class="text-text-secondary text-sm">.pltr</span>
+              </button>
+
+              <button
+                onclick={importScrivener}
+                class="flex flex-col items-center p-5 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer border border-transparent hover:border-accent/30"
+              >
+                <BookOpen class="w-12 h-12 text-accent mb-3" />
+                <span class="text-text-primary font-medium">Scrivener</span>
+                <span class="text-text-secondary text-sm">.scriv</span>
+              </button>
+
+              <button
+                onclick={importMarkdown}
+                class="flex flex-col items-center p-5 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer border border-transparent hover:border-accent/30"
+              >
+                <FileText class="w-12 h-12 text-accent mb-3" />
+                <span class="text-text-primary font-medium">Markdown</span>
+                <span class="text-text-secondary text-sm">.md</span>
+              </button>
+            </div>
+
+            <div class="flex justify-between items-center pt-4 border-t border-bg-card">
+              <button
+                onclick={() => ui.previousStep()}
+                class="text-text-secondary hover:text-text-primary transition-colors flex items-center gap-1"
+              >
+                <ChevronLeft class="w-4 h-4" />
+                Back to tour
+              </button>
+              <button
+                onclick={skipOnboarding}
+                class="text-text-secondary hover:text-text-primary text-sm transition-colors"
+              >
+                I'll import later
+              </button>
+            </div>
+          </div>
+        {/if}
+      </div>
+
+      <!-- Skip button (always visible except on import step) -->
+      {#if ui.onboardingStep !== "import"}
+        <div class="text-center mt-4">
+          <button
+            onclick={skipOnboarding}
+            class="text-text-secondary hover:text-text-primary text-sm transition-colors"
+          >
+            Skip onboarding
+          </button>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Import Progress Modal -->
+    {#if ui.isImporting}
+      <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-[60]">
+        <div class="bg-bg-panel rounded-lg p-6 max-w-md w-full mx-4">
+          <h3 class="text-lg font-heading font-medium text-text-primary mb-4">Importing...</h3>
+          <div class="w-full bg-bg-card rounded-full h-2 mb-2">
+            <div
+              class="bg-accent h-2 rounded-full transition-all"
+              style="width: {ui.importProgress}%"
+            ></div>
+          </div>
+          <p class="text-text-secondary text-sm">{ui.importStatus}</p>
+        </div>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/ReferencesPanel.svelte
+++ b/src/lib/components/ReferencesPanel.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { SvelteSet } from "svelte/reactivity";
+  import {
+    ArrowDownAZ,
+    ChevronDown,
+    ChevronsLeft,
+    ChevronsRight,
+    GripVertical,
+    ListChevronsDownUp,
+    MapPin,
+    User,
+  } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
   import type { Character, Location } from "../types";
@@ -247,40 +257,16 @@
           aria-label="Collapse all"
           title="Collapse all"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M5 15l7-7 7 7"
-            />
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M5 9l7-7 7 7"
-            />
-          </svg>
+          <ListChevronsDownUp class="w-4 h-4" />
         </button>
         <!-- Sort Alphabetically button -->
         <button
           onclick={sortAlphabetically}
-          class="text-text-secondary hover:text-text-primary p-1 text-xs font-bold"
+          class="text-text-secondary hover:text-text-primary p-1"
           aria-label="Sort alphabetically"
           title="Sort A-Z"
         >
-          <span class="flex items-center gap-0.5">
-            A
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 14l-7 7-7-7"
-              />
-            </svg>
-            Z
-          </span>
+          <ArrowDownAZ class="w-4 h-4" />
         </button>
         <!-- Close panel button -->
         <button
@@ -288,14 +274,7 @@
           class="text-text-secondary hover:text-text-primary p-1"
           aria-label="Collapse references panel"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M13 5l7 7-7 7M5 5l7 7-7 7"
-            />
-          </svg>
+          <ChevronsRight class="w-4 h-4" />
         </button>
       </div>
     </div>
@@ -361,14 +340,7 @@
                   tabindex="-1"
                   aria-label="Drag to reorder"
                 >
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  </svg>
+                  <GripVertical class="w-4 h-4" />
                 </div>
                 <!-- Clickable area for expand/collapse -->
                 <button
@@ -379,19 +351,7 @@
                   <div
                     class="w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center flex-shrink-0"
                   >
-                    <svg
-                      class="w-4 h-4 text-accent"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                      />
-                    </svg>
+                    <User class="w-4 h-4 text-accent" />
                   </div>
                   <div class="flex-1 min-w-0">
                     <p class="text-text-primary font-medium text-sm truncate">{character.name}</p>
@@ -399,20 +359,11 @@
                       <p class="text-text-secondary text-xs truncate">{character.description}</p>
                     {/if}
                   </div>
-                  <svg
-                    class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0"
-                    class:rotate-180={isExpanded}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  <ChevronDown
+                    class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0 {isExpanded
+                      ? 'rotate-180'
+                      : ''}"
+                  />
                 </button>
               </div>
 
@@ -472,14 +423,7 @@
                   tabindex="-1"
                   aria-label="Drag to reorder"
                 >
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  </svg>
+                  <GripVertical class="w-4 h-4" />
                 </div>
                 <!-- Clickable area for expand/collapse -->
                 <button
@@ -490,25 +434,7 @@
                   <div
                     class="w-8 h-8 rounded-full bg-spark-gold/20 flex items-center justify-center flex-shrink-0"
                   >
-                    <svg
-                      class="w-4 h-4 text-spark-gold"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                      />
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                      />
-                    </svg>
+                    <MapPin class="w-4 h-4 text-spark-gold" />
                   </div>
                   <div class="flex-1 min-w-0">
                     <p class="text-text-primary font-medium text-sm truncate">{location.name}</p>
@@ -516,20 +442,11 @@
                       <p class="text-text-secondary text-xs truncate">{location.description}</p>
                     {/if}
                   </div>
-                  <svg
-                    class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0"
-                    class:rotate-180={isExpanded}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  <ChevronDown
+                    class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0 {isExpanded
+                      ? 'rotate-180'
+                      : ''}"
+                  />
                 </button>
               </div>
 
@@ -570,13 +487,6 @@
     class="fixed right-0 top-1/2 -translate-y-1/2 bg-bg-panel p-2 rounded-l-lg text-text-secondary hover:text-text-primary z-10"
     aria-label="Expand references panel"
   >
-    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
-      />
-    </svg>
+    <ChevronsLeft class="w-5 h-5" />
   </button>
 {/if}

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { FileText } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
 </script>
 
@@ -90,14 +91,7 @@
   {:else}
     <!-- Empty State -->
     <div class="flex-1 flex flex-col items-center justify-center text-text-secondary">
-      <svg class="w-16 h-16 mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
-          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-        />
-      </svg>
+      <FileText class="w-16 h-16 mb-4 opacity-50" strokeWidth={1.5} />
       <p class="text-lg">Select a scene to start writing</p>
       <p class="text-sm mt-1">Choose a scene from the sidebar to view its content</p>
     </div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { SvelteSet } from "svelte/reactivity";
+  import { ChevronRight, ChevronsLeft, ChevronsRight, FileText, Folder, Home } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
   import type { Chapter, Scene } from "../types";
@@ -146,14 +147,7 @@
         class="text-text-secondary hover:text-text-primary p-1"
         aria-label="Collapse sidebar"
       >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
-          />
-        </svg>
+        <ChevronsLeft class="w-5 h-5" />
       </button>
     </div>
     {#if currentProject.value}
@@ -165,14 +159,7 @@
         class="w-full mt-3 flex items-center justify-center gap-2 px-3 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary bg-bg-card hover:bg-beat-header rounded-lg transition-colors"
         aria-label="Close project"
       >
-        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-          />
-        </svg>
+        <Home class="w-3.5 h-3.5" />
         All Projects
       </button>
     {/if}
@@ -202,34 +189,13 @@
               aria-expanded={isExpanded}
             >
               <!-- Expand/collapse chevron -->
-              <svg
-                class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0"
-                class:rotate-90={isExpanded}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
+              <ChevronRight
+                class="w-4 h-4 text-text-secondary transition-transform flex-shrink-0 {isExpanded
+                  ? 'rotate-90'
+                  : ''}"
+              />
               <!-- Chapter icon -->
-              <svg
-                class="w-4 h-4 text-text-secondary flex-shrink-0"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-                />
-              </svg>
+              <Folder class="w-4 h-4 text-text-secondary flex-shrink-0" />
               <span class="text-text-primary font-medium text-sm truncate">{chapter.title}</span>
             </button>
 
@@ -248,21 +214,11 @@
                     class:hover:text-text-primary={!isSelected}
                   >
                     <!-- Scene icon -->
-                    <svg
-                      class="w-3.5 h-3.5 flex-shrink-0"
-                      class:text-white={isSelected}
-                      class:text-text-secondary={!isSelected}
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                      />
-                    </svg>
+                    <FileText
+                      class="w-3.5 h-3.5 flex-shrink-0 {isSelected
+                        ? 'text-white'
+                        : 'text-text-secondary'}"
+                    />
                     <span class="truncate">{scene.title}</span>
                   </button>
                 {/each}
@@ -285,13 +241,6 @@
     class="fixed left-0 top-1/2 -translate-y-1/2 bg-bg-panel p-2 rounded-r-lg text-text-secondary hover:text-text-primary z-10"
     aria-label="Expand sidebar"
   >
-    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M13 5l7 7-7 7M5 5l7 7-7 7"
-      />
-    </svg>
+    <ChevronsRight class="w-5 h-5" />
   </button>
 {/if}

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-dialog";
+  import { BookOpen, FileText, Kanban } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
   import type { Project } from "../types";
@@ -140,19 +141,7 @@
           onclick={importPlottr}
           class="flex flex-col items-center p-4 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer"
         >
-          <svg
-            class="w-10 h-10 text-accent mb-2"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
-            />
-          </svg>
+          <Kanban class="w-10 h-10 text-accent mb-2" />
           <span class="text-text-primary font-medium">Plottr</span>
           <span class="text-text-secondary text-sm">.pltr</span>
         </button>
@@ -161,19 +150,7 @@
           onclick={importScrivener}
           class="flex flex-col items-center p-4 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer"
         >
-          <svg
-            class="w-10 h-10 text-accent mb-2"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-            />
-          </svg>
+          <BookOpen class="w-10 h-10 text-accent mb-2" />
           <span class="text-text-primary font-medium">Scrivener</span>
           <span class="text-text-secondary text-sm">.scriv</span>
         </button>
@@ -182,19 +159,7 @@
           onclick={importMarkdown}
           class="flex flex-col items-center p-4 bg-bg-card rounded-lg hover:bg-beat-header transition-colors cursor-pointer"
         >
-          <svg
-            class="w-10 h-10 text-accent mb-2"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
-          </svg>
+          <FileText class="w-10 h-10 text-accent mb-2" />
           <span class="text-text-primary font-medium">Markdown</span>
           <span class="text-text-secondary text-sm">.md</span>
         </button>


### PR DESCRIPTION
## Summary

- Add multi-step onboarding modal for first-time users
- Integrate lucide-svelte icon library, replacing all inline SVGs across the app
- Add onboarding state management with localStorage persistence

## Changes

### Onboarding Flow
5-step guided tour:
1. **Welcome** - Introduction to Kindling
2. **Sidebar Tour** - Explains chapters & scenes navigation
3. **Editor Tour** - Covers synopsis and beats
4. **References Tour** - Characters/locations panel with toolbar buttons
5. **Import** - File import options (Plottr, Scrivener, Markdown)

### Icon System
Migrated from inline SVGs to Lucide icons:
- `ArrowDownAZ` for alphabetical sorting
- `ListChevronsDownUp` for collapse all
- `FileText`, `BookOpen`, `Kanban` for import types
- Navigation chevrons, user/location icons, etc.

### Files Changed
- New: `src/lib/components/Onboarding.svelte`
- Modified: `ui.svelte.ts` (onboarding state management)
- Modified: All component files (Lucide icon integration)
- Added: `lucide-svelte` dependency

## Test plan

- [ ] Launch app fresh (clear localStorage) - onboarding should appear
- [ ] Navigate through all 5 steps
- [ ] Skip onboarding - should not reappear
- [ ] Complete onboarding - should not reappear on reload
- [ ] Verify icons render correctly in all components
- [ ] Test import buttons still function

Closes #18