### PR TITLE
feat: add release workflow and installation documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Release
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS Apple Silicon (M1/M2/M3)
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+            args: "--target aarch64-apple-darwin"
+          # macOS Intel
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+            args: "--target x86_64-apple-darwin"
+          # Linux x64
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            args: ""
+          # Windows x64
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+          key: ${{ matrix.target }}
+
+      - name: Install system dependencies (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build and Release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "Kindling ${{ github.ref_name }}"
+          releaseBody: |
+            ## Installation
+
+            Download the appropriate installer for your platform:
+            - **macOS (Apple Silicon)**: `Kindling_*_aarch64.dmg`
+            - **macOS (Intel)**: `Kindling_*_x64.dmg`
+            - **Windows**: `Kindling_*_x64-setup.msi`
+            - **Linux**: `Kindling_*_amd64.AppImage` or `.deb`
+
+            ### First-Time Installation Notes
+
+            **macOS**: This app is not code-signed. See the [Installation Guide](https://github.com/smith-and-web/kindling/wiki/Installation) for instructions on opening unsigned apps.
+
+            **Windows**: You may see a SmartScreen warning. Click "More info" then "Run anyway".
+
+            **Linux**: Make the AppImage executable with `chmod +x` before running.
+
+            ---
+
+            See the full changelog below.
+          releaseDraft: true
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          generateReleaseNotes: true
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,18 @@ Kindling keeps your outline visible and actionable as you write. Each scene disp
 
 ## Installation
 
-> **Note**: Kindling is in early development. Pre-built releases are coming soon.
+### Download
+
+Download the latest release for your platform from the [Releases page](https://github.com/smith-and-web/kindling/releases):
+
+| Platform | Download |
+|----------|----------|
+| macOS (Apple Silicon) | `Kindling_*_aarch64.dmg` |
+| macOS (Intel) | `Kindling_*_x64.dmg` |
+| Windows | `Kindling_*_x64-setup.msi` |
+| Linux | `Kindling_*_amd64.AppImage` or `.deb` |
+
+> **Note**: Kindling is not code-signed. You may see security warnings on first launch. See the [Installation Guide](https://github.com/smith-and-web/kindling/wiki/Installation) for instructions on bypassing these warnings.
 
 ### From Source
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -8,6 +8,7 @@
 
 ### Getting Started
 
+- [Installation](Installation) - Download and install Kindling
 - [Importing Projects](Importing-Projects) - How to import from Plottr, Scrivener, and Markdown
 
 ### Reference

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,186 @@
+# Installation
+
+Download and install Kindling on your platform.
+
+## Download
+
+Get the latest release from the [GitHub Releases page](https://github.com/smith-and-web/kindling/releases).
+
+### Available Downloads
+
+| Platform | File | Description |
+|----------|------|-------------|
+| macOS (Apple Silicon) | `Kindling_*_aarch64.dmg` | For M1, M2, M3 Macs |
+| macOS (Intel) | `Kindling_*_x64.dmg` | For Intel-based Macs |
+| Windows | `Kindling_*_x64-setup.msi` | Windows installer |
+| Linux | `Kindling_*_amd64.AppImage` | Portable, works on most distros |
+| Linux (Debian/Ubuntu) | `kindling_*_amd64.deb` | Native package for apt-based systems |
+
+---
+
+## macOS Installation
+
+Kindling is not code-signed with an Apple Developer certificate. When you first open the app, macOS will show a security warning.
+
+### macOS Sequoia (15.0) and Later
+
+1. Double-click the `.dmg` file to mount it
+2. Drag **Kindling** to your **Applications** folder
+3. Try to open Kindling — you'll see a message saying it "cannot be opened because the developer cannot be verified"
+4. Open **System Settings** → **Privacy & Security**
+5. Scroll down to the **Security** section
+6. You'll see a message about Kindling being blocked — click **Open Anyway**
+7. Enter your password if prompted
+8. Click **Open** in the confirmation dialog
+
+After this one-time setup, Kindling will open normally.
+
+### macOS Sonoma (14.0) and Earlier
+
+1. Double-click the `.dmg` file to mount it
+2. Drag **Kindling** to your **Applications** folder
+3. **Right-click** (or Control-click) on Kindling in your Applications folder
+4. Select **Open** from the context menu
+5. Click **Open** in the dialog that appears
+
+After this one-time setup, Kindling will open normally.
+
+### Alternative: Terminal Method
+
+If the above methods don't work, you can remove the quarantine attribute:
+
+```bash
+xattr -cr /Applications/Kindling.app
+```
+
+Then open Kindling normally.
+
+---
+
+## Windows Installation
+
+Kindling is not signed with a Windows code signing certificate. Windows SmartScreen may show a warning when you first run the installer.
+
+### Bypassing SmartScreen
+
+1. Download the `.msi` installer
+2. Double-click to run the installer
+3. If you see **"Windows protected your PC"**:
+   - Click **More info**
+   - Click **Run anyway**
+4. Follow the installation wizard
+5. Launch Kindling from the Start menu
+
+After installation, Kindling will run without warnings.
+
+### Why This Warning Appears
+
+SmartScreen warns about apps that don't have an established reputation with Microsoft. As more users download and run Kindling, this warning will eventually disappear. Code signing certificates are expensive ($200-500/year), so we've opted to ship unsigned for now.
+
+---
+
+## Linux Installation
+
+### AppImage (Recommended)
+
+AppImage is a portable format that works on most Linux distributions without installation.
+
+```bash
+# Download the AppImage
+# Make it executable
+chmod +x Kindling_*.AppImage
+
+# Run it
+./Kindling_*.AppImage
+```
+
+#### Optional: Desktop Integration
+
+To add Kindling to your application menu:
+
+```bash
+# Install AppImageLauncher (recommended)
+# Or manually create a .desktop file
+
+# Move AppImage to a permanent location
+mkdir -p ~/Applications
+mv Kindling_*.AppImage ~/Applications/
+
+# Create desktop entry
+cat > ~/.local/share/applications/kindling.desktop << EOF
+[Desktop Entry]
+Name=Kindling
+Exec=$HOME/Applications/Kindling_*.AppImage
+Icon=kindling
+Type=Application
+Categories=Office;Writing;
+EOF
+```
+
+### Debian/Ubuntu (.deb)
+
+For Debian-based distributions (Ubuntu, Linux Mint, Pop!_OS, etc.):
+
+```bash
+# Install the package
+sudo dpkg -i kindling_*.deb
+
+# If there are dependency issues
+sudo apt-get install -f
+```
+
+Launch Kindling from your application menu or run `kindling` in the terminal.
+
+#### Uninstalling
+
+```bash
+sudo apt remove kindling
+```
+
+---
+
+## Troubleshooting
+
+### macOS: "App is damaged and can't be opened"
+
+This usually means the quarantine attribute is corrupted. Remove it with:
+
+```bash
+xattr -cr /Applications/Kindling.app
+```
+
+### macOS: App crashes immediately
+
+Ensure you downloaded the correct version:
+- **Apple Silicon** (M1/M2/M3): `aarch64.dmg`
+- **Intel**: `x64.dmg`
+
+Check your Mac's chip: Apple menu → About This Mac → Chip/Processor.
+
+### Windows: Installer fails silently
+
+Try running the installer as Administrator:
+1. Right-click the `.msi` file
+2. Select **Run as administrator**
+
+### Linux: AppImage won't start
+
+Ensure FUSE is installed:
+
+```bash
+# Ubuntu/Debian
+sudo apt install libfuse2
+
+# Fedora
+sudo dnf install fuse
+```
+
+### Linux: No application icon
+
+AppImages don't always integrate with desktop environments automatically. Use AppImageLauncher or create a `.desktop` file manually (see above).
+
+---
+
+## Building from Source
+
+If you prefer to build Kindling yourself, see the [README](https://github.com/smith-and-web/kindling#from-source) for instructions.


### PR DESCRIPTION
## Summary

Implements GitHub Actions workflow to build and release Kindling binaries for all platforms, along with comprehensive documentation for installing unsigned applications.

## Changes

- **New**: `.github/workflows/release.yml` - Release workflow triggered on tag push (`v*`)
- **New**: `docs/installation.md` - Comprehensive installation guide with unsigned app instructions
- **Updated**: `docs/Home.md` - Added installation link to wiki home
- **Updated**: `README.md` - Added download section with platform table

## Release Workflow Features

- Builds for 4 platform targets:
  - macOS Apple Silicon (`aarch64-apple-darwin`)
  - macOS Intel (`x86_64-apple-darwin`)
  - Windows (`x86_64-pc-windows-msvc`)
  - Linux (`x86_64-unknown-linux-gnu`)
- Creates draft releases for manual review before publishing
- Auto-detects pre-releases from tag names (alpha/beta/rc)
- Auto-generates changelogs from merged PRs
- Uses official `tauri-apps/tauri-action@v0`

## Installation Documentation

Detailed instructions for bypassing unsigned app warnings:
- **macOS**: System Settings method for Sequoia+, right-click method for earlier versions
- **Windows**: SmartScreen bypass instructions
- **Linux**: AppImage permissions and desktop integration

## Test Plan

- [ ] Merge this PR
- [ ] Create and push a test tag: `git tag v0.1.0-alpha && git push origin v0.1.0-alpha`
- [ ] Verify all 4 platform builds succeed
- [ ] Review draft release on GitHub
- [ ] Test download and installation on each platform

Closes #41