### PR TITLE
feat(export): add docx export backend command

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ walkdir = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 flate2 = "1"
+docx-rs = "0.4"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-dialog = "2.6"

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -4,7 +4,8 @@
 
 use crate::commands::AppState;
 use crate::db;
-use crate::models::{Beat, Scene, SnapshotTrigger};
+use crate::models::{Beat, Chapter, Scene, SnapshotTrigger};
+use docx_rs::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -54,6 +55,29 @@ pub struct ExportResult {
     pub chapters_exported: usize,
     /// Total scenes exported
     pub scenes_exported: usize,
+}
+
+/// Export options for DOCX export
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocxExportOptions {
+    /// What to export (project, chapter, or scene)
+    pub scope: ExportScope,
+    /// Include beat markers as Heading 3 in output
+    pub include_beat_markers: bool,
+    /// Include scene synopsis as italicized paragraph
+    pub include_synopsis: bool,
+    /// Output file path (full path including filename)
+    pub output_path: String,
+    /// Create a snapshot before exporting
+    #[serde(default)]
+    pub create_snapshot: bool,
+    /// Add page breaks between chapters
+    #[serde(default = "default_page_breaks")]
+    pub page_breaks_between_chapters: bool,
+}
+
+fn default_page_breaks() -> bool {
+    true
 }
 
 /// Sanitize a filename by removing invalid characters
@@ -437,6 +461,312 @@ pub async fn export_to_markdown(
     })
 }
 
+/// Create heading styles for the DOCX document
+fn create_docx_styles() -> Docx {
+    Docx::new()
+        // Heading 1 style (for chapters)
+        .add_style(
+            Style::new("Heading1", StyleType::Paragraph)
+                .name("Heading 1")
+                .size(48) // 24pt (size is in half-points)
+                .bold()
+                .color("2E5090")
+                .next("Normal"),
+        )
+        // Heading 2 style (for scenes)
+        .add_style(
+            Style::new("Heading2", StyleType::Paragraph)
+                .name("Heading 2")
+                .size(36) // 18pt
+                .bold()
+                .color("404040")
+                .next("Normal"),
+        )
+        // Heading 3 style (for beats)
+        .add_style(
+            Style::new("Heading3", StyleType::Paragraph)
+                .name("Heading 3")
+                .size(28) // 14pt
+                .bold()
+                .italic()
+                .color("666666")
+                .next("Normal"),
+        )
+        // Synopsis style (italicized, gray)
+        .add_style(
+            Style::new("Synopsis", StyleType::Paragraph)
+                .name("Synopsis")
+                .size(22) // 11pt
+                .italic()
+                .color("666666")
+                .next("Normal"),
+        )
+}
+
+/// Add a chapter to the document
+fn add_chapter_to_docx(
+    docx: Docx,
+    chapter: &Chapter,
+    scenes: &[Scene],
+    beats_by_scene: &std::collections::HashMap<Uuid, Vec<Beat>>,
+    options: &DocxExportOptions,
+    is_first_chapter: bool,
+) -> Docx {
+    let mut docx = docx;
+
+    // Add page break before chapter (except first)
+    if !is_first_chapter && options.page_breaks_between_chapters {
+        docx = docx.add_paragraph(Paragraph::new().page_break_before(true));
+    }
+
+    // Chapter title as Heading 1
+    docx = docx.add_paragraph(
+        Paragraph::new()
+            .add_run(Run::new().add_text(&chapter.title))
+            .style("Heading1"),
+    );
+
+    // Add scenes
+    for scene in scenes.iter().filter(|s| !s.archived) {
+        docx = add_scene_to_docx(
+            docx,
+            scene,
+            beats_by_scene
+                .get(&scene.id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]),
+            options,
+        );
+    }
+
+    docx
+}
+
+/// Add a scene to the document
+fn add_scene_to_docx(
+    docx: Docx,
+    scene: &Scene,
+    beats: &[Beat],
+    options: &DocxExportOptions,
+) -> Docx {
+    let mut docx = docx;
+
+    // Scene title as Heading 2
+    docx = docx.add_paragraph(
+        Paragraph::new()
+            .add_run(Run::new().add_text(&scene.title))
+            .style("Heading2"),
+    );
+
+    // Synopsis if requested and present
+    if options.include_synopsis {
+        if let Some(ref synopsis) = scene.synopsis {
+            if !synopsis.trim().is_empty() {
+                docx = docx.add_paragraph(
+                    Paragraph::new()
+                        .add_run(Run::new().add_text(synopsis))
+                        .style("Synopsis"),
+                );
+            }
+        }
+    }
+
+    // Add beats
+    for beat in beats {
+        docx = add_beat_to_docx(docx, beat, options);
+    }
+
+    docx
+}
+
+/// Add a beat to the document
+fn add_beat_to_docx(docx: Docx, beat: &Beat, options: &DocxExportOptions) -> Docx {
+    let mut docx = docx;
+
+    // Beat marker as Heading 3 if requested
+    if options.include_beat_markers {
+        docx = docx.add_paragraph(
+            Paragraph::new()
+                .add_run(Run::new().add_text(&beat.content))
+                .style("Heading3"),
+        );
+    }
+
+    // Beat prose
+    if let Some(ref prose) = beat.prose {
+        let clean_prose = strip_html(prose);
+        if !clean_prose.is_empty() {
+            // Split by double newlines to create separate paragraphs
+            for para_text in clean_prose.split("\n\n") {
+                let trimmed = para_text.trim();
+                if !trimmed.is_empty() {
+                    docx =
+                        docx.add_paragraph(Paragraph::new().add_run(Run::new().add_text(trimmed)));
+                }
+            }
+        }
+    }
+
+    docx
+}
+
+/// Export project to DOCX file
+///
+/// Creates a single .docx file with chapters as H1, scenes as H2, beats as H3
+#[tauri::command]
+pub async fn export_to_docx(
+    project_id: String,
+    options: DocxExportOptions,
+    app_handle: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ExportResult, String> {
+    let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+
+    // Create snapshot if requested (before taking the connection lock)
+    if options.create_snapshot {
+        let snapshot_options = super::CreateSnapshotOptions {
+            name: "Pre-export snapshot".to_string(),
+            description: Some("Automatic snapshot created before DOCX export".to_string()),
+            trigger_type: SnapshotTrigger::Export,
+        };
+
+        super::create_snapshot(
+            project_id.clone(),
+            snapshot_options,
+            app_handle,
+            state.clone(),
+        )
+        .await?;
+    }
+
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+
+    // Get project info
+    let project = db::queries::get_project(&conn, &project_uuid)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Project not found: {}", project_id))?;
+
+    let mut chapters_exported = 0;
+    let mut scenes_exported = 0;
+
+    // Initialize document with styles
+    let mut docx = create_docx_styles();
+
+    // Add title page with project name
+    docx = docx.add_paragraph(
+        Paragraph::new()
+            .add_run(Run::new().add_text(&project.name).size(72).bold())
+            .align(AlignmentType::Center),
+    );
+    docx = docx.add_paragraph(Paragraph::new().page_break_before(true));
+
+    match &options.scope {
+        ExportScope::Project => {
+            // Get all chapters
+            let chapters =
+                db::queries::get_chapters(&conn, &project_uuid).map_err(|e| e.to_string())?;
+
+            // Pre-fetch all scenes and beats for efficiency
+            let mut beats_by_scene: std::collections::HashMap<Uuid, Vec<Beat>> =
+                std::collections::HashMap::new();
+
+            let mut is_first_chapter = true;
+            for chapter in chapters.iter().filter(|c| !c.archived) {
+                let scenes =
+                    db::queries::get_scenes(&conn, &chapter.id).map_err(|e| e.to_string())?;
+                let active_scenes: Vec<Scene> =
+                    scenes.into_iter().filter(|s| !s.archived).collect();
+
+                // Fetch beats for each scene
+                for scene in &active_scenes {
+                    let beats =
+                        db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+                    beats_by_scene.insert(scene.id, beats);
+                }
+
+                scenes_exported += active_scenes.len();
+
+                docx = add_chapter_to_docx(
+                    docx,
+                    chapter,
+                    &active_scenes,
+                    &beats_by_scene,
+                    &options,
+                    is_first_chapter,
+                );
+
+                chapters_exported += 1;
+                is_first_chapter = false;
+            }
+        }
+        ExportScope::Chapter(chapter_id) => {
+            let chapter_uuid = Uuid::parse_str(chapter_id).map_err(|e| e.to_string())?;
+            let chapter = db::queries::get_chapter_by_id(&conn, &chapter_uuid)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("Chapter not found: {}", chapter_id))?;
+
+            let scenes = db::queries::get_scenes(&conn, &chapter.id).map_err(|e| e.to_string())?;
+            let active_scenes: Vec<Scene> = scenes.into_iter().filter(|s| !s.archived).collect();
+
+            let mut beats_by_scene: std::collections::HashMap<Uuid, Vec<Beat>> =
+                std::collections::HashMap::new();
+
+            for scene in &active_scenes {
+                let beats = db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+                beats_by_scene.insert(scene.id, beats);
+            }
+
+            scenes_exported = active_scenes.len();
+
+            docx = add_chapter_to_docx(
+                docx,
+                &chapter,
+                &active_scenes,
+                &beats_by_scene,
+                &options,
+                true,
+            );
+
+            chapters_exported = 1;
+        }
+        ExportScope::Scene(scene_id) => {
+            let scene_uuid = Uuid::parse_str(scene_id).map_err(|e| e.to_string())?;
+            let scene = db::queries::get_scene_by_id(&conn, &scene_uuid)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("Scene not found: {}", scene_id))?;
+
+            let beats = db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+
+            docx = add_scene_to_docx(docx, &scene, &beats, &options);
+
+            scenes_exported = 1;
+        }
+    }
+
+    // Build and write the document
+    let output_path = PathBuf::from(&options.output_path);
+
+    // Ensure parent directory exists
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create output directory: {}", e))?;
+    }
+
+    let file = fs::File::create(&output_path)
+        .map_err(|e| format!("Failed to create output file: {}", e))?;
+
+    docx.build()
+        .pack(file)
+        .map_err(|e| format!("Failed to write DOCX file: {}", e))?;
+
+    Ok(ExportResult {
+        output_path: output_path.to_string_lossy().to_string(),
+        files_created: 1,
+        chapters_exported,
+        scenes_exported,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -480,5 +810,129 @@ mod tests {
     #[test]
     fn test_strip_html_plain_text() {
         assert_eq!(strip_html("Plain text"), "Plain text");
+    }
+
+    #[test]
+    fn test_create_docx_styles() {
+        // Test that the styles are created without panicking
+        let docx = create_docx_styles();
+        // Build should succeed
+        let built = docx.build();
+        // Pack to a buffer should succeed
+        let mut buffer = Vec::new();
+        built.pack(&mut std::io::Cursor::new(&mut buffer)).unwrap();
+        // Should produce a non-empty zip file
+        assert!(!buffer.is_empty());
+    }
+
+    #[test]
+    fn test_add_beat_to_docx_with_prose() {
+        use crate::models::Beat;
+        use uuid::Uuid;
+
+        let beat = Beat {
+            id: Uuid::new_v4(),
+            scene_id: Uuid::new_v4(),
+            content: "Test Beat".to_string(),
+            position: 0,
+            prose: Some("<p>Test prose content</p>".to_string()),
+            source_id: None,
+        };
+
+        let options = DocxExportOptions {
+            scope: ExportScope::Project,
+            include_beat_markers: true,
+            include_synopsis: true,
+            output_path: "/tmp/test.docx".to_string(),
+            create_snapshot: false,
+            page_breaks_between_chapters: true,
+        };
+
+        let docx = Docx::new();
+        let docx = add_beat_to_docx(docx, &beat, &options);
+
+        // Build should succeed
+        let built = docx.build();
+        let mut buffer = Vec::new();
+        built.pack(&mut std::io::Cursor::new(&mut buffer)).unwrap();
+        assert!(!buffer.is_empty());
+    }
+
+    #[test]
+    fn test_add_beat_to_docx_without_markers() {
+        use crate::models::Beat;
+        use uuid::Uuid;
+
+        let beat = Beat {
+            id: Uuid::new_v4(),
+            scene_id: Uuid::new_v4(),
+            content: "Test Beat".to_string(),
+            position: 0,
+            prose: Some("Plain text prose".to_string()),
+            source_id: None,
+        };
+
+        let options = DocxExportOptions {
+            scope: ExportScope::Project,
+            include_beat_markers: false,
+            include_synopsis: false,
+            output_path: "/tmp/test.docx".to_string(),
+            create_snapshot: false,
+            page_breaks_between_chapters: false,
+        };
+
+        let docx = Docx::new();
+        let docx = add_beat_to_docx(docx, &beat, &options);
+
+        // Build should succeed
+        let built = docx.build();
+        let mut buffer = Vec::new();
+        built.pack(&mut std::io::Cursor::new(&mut buffer)).unwrap();
+        assert!(!buffer.is_empty());
+    }
+
+    #[test]
+    fn test_add_scene_to_docx() {
+        use crate::models::{Beat, Scene};
+        use uuid::Uuid;
+
+        let scene = Scene {
+            id: Uuid::new_v4(),
+            chapter_id: Uuid::new_v4(),
+            title: "Test Scene".to_string(),
+            position: 0,
+            synopsis: Some("This is a synopsis".to_string()),
+            prose: None,
+            locked: false,
+            archived: false,
+            source_id: None,
+        };
+
+        let beats = vec![Beat {
+            id: Uuid::new_v4(),
+            scene_id: scene.id,
+            content: "Beat 1".to_string(),
+            position: 0,
+            prose: Some("Beat prose".to_string()),
+            source_id: None,
+        }];
+
+        let options = DocxExportOptions {
+            scope: ExportScope::Project,
+            include_beat_markers: true,
+            include_synopsis: true,
+            output_path: "/tmp/test.docx".to_string(),
+            create_snapshot: false,
+            page_breaks_between_chapters: true,
+        };
+
+        let docx = Docx::new();
+        let docx = add_scene_to_docx(docx, &scene, &beats, &options);
+
+        // Build should succeed
+        let built = docx.build();
+        let mut buffer = Vec::new();
+        built.pack(&mut std::io::Cursor::new(&mut buffer)).unwrap();
+        assert!(!buffer.is_empty());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             commands::unlock_scene,
             // Export commands
             commands::export_to_markdown,
+            commands::export_to_docx,
             // Snapshot commands
             commands::create_snapshot,
             commands::list_snapshots,


### PR DESCRIPTION
## Summary

Adds backend support for exporting projects to Microsoft Word (.docx) format. This closes the backend portion of #48.

## Changes

- Add `docx-rs` crate dependency for Word document generation
- Implement `export_to_docx` Tauri command with configurable options
- Create proper Word heading styles (H1 for chapters, H2 for scenes, H3 for beats)
- Add title page with centered project name
- Support all export scopes: entire project, single chapter, single scene

## Export Options

| Option | Description | Default |
|--------|-------------|---------|
| `include_beat_markers` | Show beats as Heading 3 | - |
| `include_synopsis` | Include scene synopses (italicized) | - |
| `page_breaks_between_chapters` | Add page breaks between chapters | `true` |
| `create_snapshot` | Create snapshot before export | `false` |

## Document Structure

```
[Title Page - Project Name (centered, 36pt)]
---page break---
Chapter 1                    <- Heading 1 (24pt, bold, blue)
  Scene 1                    <- Heading 2 (18pt, bold, gray)
    [Synopsis if enabled]    <- Italic, gray
    Beat 1                   <- Heading 3 (14pt, bold italic) - optional
    Prose paragraph...       <- Normal text
---page break (if enabled)---
Chapter 2
  ...
```

## Test plan

- [x] Unit tests for DOCX style creation
- [x] Unit tests for beat-to-docx conversion (with/without markers)
- [x] Unit tests for scene-to-docx conversion
- [x] All 106 Rust tests pass
- [x] Clippy passes with no warnings
- [ ] Manual testing with frontend (requires #49)

## Next Steps

After this PR merges, the frontend Export Dialog (#49) needs to be updated to call `export_to_docx` and allow users to select DOCX format.

Closes #48 (backend portion)