### PR TITLE
feat(settings): add author metadata and file menu

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,12 +11,14 @@
 //! - [`lock`]: Lock/unlock commands
 //! - [`export`]: Export commands for Markdown, DOCX
 //! - [`snapshot`]: Snapshot/versioning commands
+//! - [`settings`]: App-wide settings
 
 mod archive;
 mod crud;
 mod export;
 mod import;
 mod lock;
+mod settings;
 mod snapshot;
 mod state;
 mod sync;
@@ -27,6 +29,7 @@ pub use crud::*;
 pub use export::*;
 pub use import::*;
 pub use lock::*;
+pub use settings::*;
 pub use snapshot::*;
 pub use state::*;
 pub use sync::*;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,53 @@
+//! App Settings Commands
+//!
+//! Handles reading and writing app-wide settings (stored in JSON file).
+
+use std::fs;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+use crate::models::AppSettings;
+
+/// Get the path to the settings file
+fn get_settings_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?;
+
+    // Ensure the directory exists
+    if !app_data_dir.exists() {
+        fs::create_dir_all(&app_data_dir).map_err(|e| e.to_string())?;
+    }
+
+    Ok(app_data_dir.join("settings.json"))
+}
+
+/// Get app settings
+#[tauri::command]
+pub async fn get_app_settings(app_handle: AppHandle) -> Result<AppSettings, String> {
+    let settings_path = get_settings_path(&app_handle)?;
+
+    if settings_path.exists() {
+        let contents = fs::read_to_string(&settings_path).map_err(|e| e.to_string())?;
+        let settings: AppSettings = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+        Ok(settings)
+    } else {
+        // Return default settings if file doesn't exist
+        Ok(AppSettings::default())
+    }
+}
+
+/// Update app settings
+#[tauri::command]
+pub async fn update_app_settings(
+    app_handle: AppHandle,
+    settings: AppSettings,
+) -> Result<AppSettings, String> {
+    let settings_path = get_settings_path(&app_handle)?;
+
+    let contents = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
+    fs::write(&settings_path, contents).map_err(|e| e.to_string())?;
+
+    Ok(settings)
+}

--- a/src-tauri/src/commands/snapshot.rs
+++ b/src-tauri/src/commands/snapshot.rs
@@ -360,6 +360,9 @@ fn restore_create_new(
         source_path: data.project.source_path,
         created_at: now.clone(),
         modified_at: now,
+        // Copy project-specific metadata from snapshot
+        author_pen_name: data.project.author_pen_name,
+        genre: data.project.genre,
     };
 
     if let Err(e) = db::insert_project(conn, &new_project) {

--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -13,8 +13,8 @@ use crate::models::{
 
 pub fn insert_project(conn: &Connection, project: &Project) -> Result<()> {
     conn.execute(
-        "INSERT INTO projects (id, name, source_type, source_path, created_at, modified_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        "INSERT INTO projects (id, name, source_type, source_path, created_at, modified_at, author_pen_name, genre)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             project.id.to_string(),
             project.name,
@@ -22,6 +22,8 @@ pub fn insert_project(conn: &Connection, project: &Project) -> Result<()> {
             project.source_path,
             project.created_at,
             project.modified_at,
+            project.author_pen_name,
+            project.genre,
         ],
     )?;
     Ok(())
@@ -29,7 +31,7 @@ pub fn insert_project(conn: &Connection, project: &Project) -> Result<()> {
 
 pub fn get_project(conn: &Connection, id: &Uuid) -> Result<Option<Project>> {
     let mut stmt = conn.prepare(
-        "SELECT id, name, source_type, source_path, created_at, modified_at
+        "SELECT id, name, source_type, source_path, created_at, modified_at, author_pen_name, genre
          FROM projects WHERE id = ?1",
     )?;
 
@@ -44,6 +46,8 @@ pub fn get_project(conn: &Connection, id: &Uuid) -> Result<Option<Project>> {
             source_path: row.get(3)?,
             created_at: row.get(4)?,
             modified_at: row.get(5)?,
+            author_pen_name: row.get(6)?,
+            genre: row.get(7)?,
         }))
     } else {
         Ok(None)
@@ -52,7 +56,7 @@ pub fn get_project(conn: &Connection, id: &Uuid) -> Result<Option<Project>> {
 
 pub fn get_recent_projects(conn: &Connection, limit: usize) -> Result<Vec<Project>> {
     let mut stmt = conn.prepare(
-        "SELECT id, name, source_type, source_path, created_at, modified_at
+        "SELECT id, name, source_type, source_path, created_at, modified_at, author_pen_name, genre
          FROM projects ORDER BY modified_at DESC LIMIT ?1",
     )?;
 
@@ -66,6 +70,8 @@ pub fn get_recent_projects(conn: &Connection, limit: usize) -> Result<Vec<Projec
                 source_path: row.get(3)?,
                 created_at: row.get(4)?,
                 modified_at: row.get(5)?,
+                author_pen_name: row.get(6)?,
+                genre: row.get(7)?,
             })
         })?
         .filter_map(|r| r.ok())
@@ -1366,12 +1372,14 @@ pub fn delete_all_project_content(conn: &Connection, project_id: &Uuid) -> Resul
 /// Update project metadata
 pub fn update_project(conn: &Connection, project: &Project) -> Result<()> {
     conn.execute(
-        "UPDATE projects SET name = ?1, source_type = ?2, source_path = ?3, modified_at = ?4 WHERE id = ?5",
+        "UPDATE projects SET name = ?1, source_type = ?2, source_path = ?3, modified_at = ?4, author_pen_name = ?5, genre = ?6 WHERE id = ?7",
         params![
             project.name,
             project.source_type.as_str(),
             project.source_path,
             project.modified_at,
+            project.author_pen_name,
+            project.genre,
             project.id.to_string(),
         ],
     )?;

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -200,6 +200,20 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration: Add project-specific metadata columns
+    let columns: Vec<String> = conn
+        .prepare("PRAGMA table_info(projects)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if !columns.contains(&"author_pen_name".to_string()) {
+        conn.execute("ALTER TABLE projects ADD COLUMN author_pen_name TEXT", [])?;
+    }
+    if !columns.contains(&"genre".to_string()) {
+        conn.execute("ALTER TABLE projects ADD COLUMN genre TEXT", [])?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod commands;
 pub mod db;
+pub mod menu;
 pub mod models;
 pub mod parsers;
 
@@ -44,6 +45,11 @@ pub fn run() {
 
             app.manage(state);
 
+            // Set up application menu
+            let app_handle = app.handle();
+            menu::create_menu(app_handle).expect("Failed to create menu");
+            menu::setup_menu_events(app_handle);
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -52,6 +58,7 @@ pub fn run() {
             commands::import_markdown,
             commands::get_project,
             commands::get_recent_projects,
+            commands::update_project_settings,
             commands::delete_project,
             commands::get_chapters,
             commands::create_chapter,
@@ -100,6 +107,9 @@ pub fn run() {
             commands::delete_snapshot,
             commands::restore_snapshot,
             commands::preview_snapshot,
+            // App settings commands
+            commands::get_app_settings,
+            commands::update_app_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,0 +1,121 @@
+//! Application Menu Setup
+//!
+//! Creates the native application menu with File menu items for:
+//! - Import (Plottr, Scrivener, Markdown)
+//! - Export
+//! - Close Project
+//! - Project Settings
+//! - Kindling Settings
+
+use tauri::{
+    menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder},
+    AppHandle, Emitter, Manager, Wry,
+};
+
+/// Menu item IDs for event handling
+pub mod menu_ids {
+    pub const IMPORT_PLOTTR: &str = "import_plottr";
+    pub const IMPORT_SCRIVENER: &str = "import_scrivener";
+    pub const IMPORT_MARKDOWN: &str = "import_markdown";
+    pub const EXPORT: &str = "export";
+    pub const CLOSE_PROJECT: &str = "close_project";
+    pub const PROJECT_SETTINGS: &str = "project_settings";
+    pub const KINDLING_SETTINGS: &str = "kindling_settings";
+}
+
+/// Create the application menu
+pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error>> {
+    // Import submenu
+    let import_plottr = MenuItemBuilder::new("Plottr (.pltr)")
+        .id(menu_ids::IMPORT_PLOTTR)
+        .build(app)?;
+
+    let import_scrivener = MenuItemBuilder::new("Scrivener (.scriv)")
+        .id(menu_ids::IMPORT_SCRIVENER)
+        .build(app)?;
+
+    let import_markdown = MenuItemBuilder::new("Markdown (.md)")
+        .id(menu_ids::IMPORT_MARKDOWN)
+        .build(app)?;
+
+    let import_submenu = SubmenuBuilder::new(app, "Import")
+        .item(&import_plottr)
+        .item(&import_scrivener)
+        .item(&import_markdown)
+        .build()?;
+
+    // Export menu item
+    let export = MenuItemBuilder::new("Export...")
+        .id(menu_ids::EXPORT)
+        .accelerator("CmdOrCtrl+E")
+        .build(app)?;
+
+    // Close Project menu item
+    let close_project = MenuItemBuilder::new("Close Project")
+        .id(menu_ids::CLOSE_PROJECT)
+        .accelerator("CmdOrCtrl+W")
+        .build(app)?;
+
+    // Settings menu items
+    let project_settings = MenuItemBuilder::new("Project Settings...")
+        .id(menu_ids::PROJECT_SETTINGS)
+        .build(app)?;
+
+    let kindling_settings = MenuItemBuilder::new("Kindling Settings...")
+        .id(menu_ids::KINDLING_SETTINGS)
+        .accelerator("CmdOrCtrl+,")
+        .build(app)?;
+
+    // Build File submenu
+    let file_submenu = SubmenuBuilder::new(app, "File")
+        .items(&[&import_submenu])
+        .item(&export)
+        .separator()
+        .item(&close_project)
+        .separator()
+        .item(&project_settings)
+        .item(&kindling_settings)
+        .build()?;
+
+    // Build Edit submenu with standard items
+    let edit_submenu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    // Build Window submenu with standard items
+    let window_submenu = SubmenuBuilder::new(app, "Window")
+        .minimize()
+        .maximize()
+        .separator()
+        .close_window()
+        .build()?;
+
+    // Build the full menu
+    let menu = MenuBuilder::new(app)
+        .items(&[&file_submenu, &edit_submenu, &window_submenu])
+        .build()?;
+
+    app.set_menu(menu)?;
+
+    Ok(())
+}
+
+/// Set up menu event handling
+pub fn setup_menu_events(app: &AppHandle<Wry>) {
+    let app_handle = app.clone();
+
+    app.on_menu_event(move |_app, event| {
+        let id = event.id().0.as_str();
+
+        // Emit event to frontend for handling
+        if let Some(window) = app_handle.get_webview_window("main") {
+            let _ = window.emit("menu-event", id);
+        }
+    });
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod character;
 pub mod location;
 pub mod project;
 pub mod scene;
+pub mod settings;
 pub mod snapshot;
 
 pub use beat::*;
@@ -12,4 +13,5 @@ pub use character::*;
 pub use location::*;
 pub use project::*;
 pub use scene::*;
+pub use settings::*;
 pub use snapshot::*;

--- a/src-tauri/src/models/project.rs
+++ b/src-tauri/src/models/project.rs
@@ -35,6 +35,11 @@ pub struct Project {
     pub source_path: Option<String>,
     pub created_at: String,
     pub modified_at: String,
+    // Project-specific metadata for export title page
+    /// Pen name for this project (overrides app-level author name if set)
+    pub author_pen_name: Option<String>,
+    /// Genre of this work
+    pub genre: Option<String>,
 }
 
 impl Project {
@@ -47,6 +52,8 @@ impl Project {
             source_path,
             created_at: now.clone(),
             modified_at: now,
+            author_pen_name: None,
+            genre: None,
         }
     }
 }

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -1,0 +1,37 @@
+//! App-wide settings model
+//!
+//! These settings apply to all projects and are stored in a JSON file
+//! in the app data directory.
+
+use serde::{Deserialize, Serialize};
+
+/// App-wide settings stored outside of the database
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AppSettings {
+    /// Author's legal name (used in contact info on title pages)
+    #[serde(default)]
+    pub author_name: Option<String>,
+
+    /// First line of contact address (e.g., street address)
+    #[serde(default)]
+    pub contact_address_line1: Option<String>,
+
+    /// Second line of contact address (e.g., city, country, postal code)
+    #[serde(default)]
+    pub contact_address_line2: Option<String>,
+
+    /// Phone number
+    #[serde(default)]
+    pub contact_phone: Option<String>,
+
+    /// Email address
+    #[serde(default)]
+    pub contact_email: Option<String>,
+}
+
+impl AppSettings {
+    /// Create new default settings
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,13 +1,28 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
+  import { open } from "@tauri-apps/plugin-dialog";
+  import { onMount } from "svelte";
   import Onboarding from "./lib/components/Onboarding.svelte";
   import ReferencesPanel from "./lib/components/ReferencesPanel.svelte";
   import ScenePanel from "./lib/components/ScenePanel.svelte";
   import Sidebar from "./lib/components/Sidebar.svelte";
   import StartScreen from "./lib/components/StartScreen.svelte";
+  import KindlingSettingsDialog from "./lib/components/KindlingSettingsDialog.svelte";
+  import ProjectSettingsDialog from "./lib/components/ProjectSettingsDialog.svelte";
+  import ExportDialog from "./lib/components/ExportDialog.svelte";
+  import ExportSuccessDialog from "./lib/components/ExportSuccessDialog.svelte";
   import { currentProject } from "./lib/stores/project.svelte";
+  import { ui } from "./lib/stores/ui.svelte";
+  import type { Project, ExportResult } from "./lib/types";
 
   let recentProjects = $state<any[]>([]);
+
+  // Dialog states triggered by menu
+  let showKindlingSettings = $state(false);
+  let showProjectSettings = $state(false);
+  let showExportDialog = $state(false);
+  let exportResult = $state<ExportResult | null>(null);
 
   async function loadRecentProjects() {
     try {
@@ -25,6 +40,113 @@
       loadRecentProjects();
     }
   });
+
+  // Import functions (same as StartScreen)
+  async function importPlottr() {
+    const path = await open({
+      multiple: false,
+      filters: [{ name: "Plottr", extensions: ["pltr"] }],
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_plottr", { path });
+        currentProject.setProject(project);
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Plottr file:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  async function importScrivener() {
+    const path = await open({
+      multiple: false,
+      directory: true,
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_scrivener", { path });
+        currentProject.setProject(project);
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Scrivener project:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  async function importMarkdown() {
+    const path = await open({
+      multiple: false,
+      filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
+    });
+
+    if (path) {
+      ui.startImport();
+      try {
+        const project = await invoke<Project>("import_markdown", { path });
+        currentProject.setProject(project);
+        ui.setView("editor");
+      } catch (e) {
+        console.error("Failed to import Markdown file:", e);
+        alert(`Import failed: ${e}`);
+      } finally {
+        ui.finishImport();
+      }
+    }
+  }
+
+  function closeProject() {
+    currentProject.setProject(null);
+  }
+
+  // Handle menu events from Tauri
+  onMount(() => {
+    const unlisten = listen<string>("menu-event", (event) => {
+      const menuId = event.payload;
+
+      switch (menuId) {
+        case "import_plottr":
+          importPlottr();
+          break;
+        case "import_scrivener":
+          importScrivener();
+          break;
+        case "import_markdown":
+          importMarkdown();
+          break;
+        case "export":
+          if (currentProject.value) {
+            showExportDialog = true;
+          }
+          break;
+        case "close_project":
+          closeProject();
+          break;
+        case "project_settings":
+          if (currentProject.value) {
+            showProjectSettings = true;
+          }
+          break;
+        case "kindling_settings":
+          showKindlingSettings = true;
+          break;
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  });
 </script>
 
 <main class="flex h-screen w-screen overflow-hidden bg-bg-primary">
@@ -39,3 +161,41 @@
 
 <!-- Onboarding overlay (shown on first launch) -->
 <Onboarding />
+
+<!-- Kindling Settings Dialog (triggered by menu) -->
+{#if showKindlingSettings}
+  <KindlingSettingsDialog
+    onClose={() => (showKindlingSettings = false)}
+    onSave={() => (showKindlingSettings = false)}
+  />
+{/if}
+
+<!-- Project Settings Dialog (triggered by menu) -->
+{#if showProjectSettings && currentProject.value}
+  <ProjectSettingsDialog
+    onClose={() => (showProjectSettings = false)}
+    onSave={(project) => {
+      currentProject.setProject(project);
+      showProjectSettings = false;
+    }}
+  />
+{/if}
+
+<!-- Export Dialog (triggered by menu) -->
+{#if showExportDialog && currentProject.value}
+  <ExportDialog
+    scope="project"
+    scopeId={null}
+    scopeTitle={currentProject.value.name}
+    onClose={() => (showExportDialog = false)}
+    onSuccess={(result) => {
+      showExportDialog = false;
+      exportResult = result;
+    }}
+  />
+{/if}
+
+<!-- Export Success Dialog -->
+{#if exportResult}
+  <ExportSuccessDialog result={exportResult} onClose={() => (exportResult = null)} />
+{/if}

--- a/src/lib/components/KindlingSettingsDialog.svelte
+++ b/src/lib/components/KindlingSettingsDialog.svelte
@@ -1,0 +1,271 @@
+<!--
+  KindlingSettingsDialog.svelte - App-wide settings dialog
+
+  Allows users to configure their author information and contact details
+  that apply across all projects:
+  - Author name
+  - Contact address (two lines for international flexibility)
+  - Phone and email
+-->
+<script lang="ts">
+  /* eslint-disable no-undef */
+  import { invoke } from "@tauri-apps/api/core";
+  import { X, Loader2, Settings, User } from "lucide-svelte";
+  import type { AppSettings } from "../types";
+  import Tooltip from "./Tooltip.svelte";
+
+  let {
+    onClose,
+    onSave,
+  }: {
+    onClose: () => void;
+    onSave: (settings: AppSettings) => void;
+  } = $props();
+
+  // Form state
+  let authorName = $state("");
+  let addressLine1 = $state("");
+  let addressLine2 = $state("");
+  let phone = $state("");
+  let email = $state("");
+
+  let loading = $state(true);
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  // Load existing settings on mount
+  $effect(() => {
+    loadSettings();
+  });
+
+  async function loadSettings() {
+    loading = true;
+    error = null;
+
+    try {
+      const settings = await invoke<AppSettings>("get_app_settings");
+      authorName = settings.author_name ?? "";
+      addressLine1 = settings.contact_address_line1 ?? "";
+      addressLine2 = settings.contact_address_line2 ?? "";
+      phone = settings.contact_phone ?? "";
+      email = settings.contact_email ?? "";
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleSave() {
+    saving = true;
+    error = null;
+
+    try {
+      // Convert empty strings to null for optional fields
+      const settings: AppSettings = {
+        author_name: authorName.trim() || null,
+        contact_address_line1: addressLine1.trim() || null,
+        contact_address_line2: addressLine2.trim() || null,
+        contact_phone: phone.trim() || null,
+        contact_email: email.trim() || null,
+      };
+
+      const updatedSettings = await invoke<AppSettings>("update_app_settings", {
+        settings,
+      });
+
+      onSave(updatedSettings);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      onClose();
+    } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey) && !saving && !loading) {
+      handleSave();
+    }
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- Backdrop -->
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+  onclick={handleBackdropClick}
+  onkeydown={(e) => e.key === "Enter" && handleBackdropClick}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="settings-dialog-title"
+  tabindex="-1"
+>
+  <!-- Dialog -->
+  <div
+    class="bg-bg-panel rounded-lg shadow-xl w-full max-w-lg mx-4 overflow-hidden max-h-[90vh] flex flex-col"
+  >
+    <!-- Header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b border-bg-card flex-shrink-0">
+      <div class="flex items-center gap-2">
+        <Settings class="w-5 h-5 text-accent" />
+        <h2 id="settings-dialog-title" class="text-lg font-medium text-text-primary">
+          Kindling Settings
+        </h2>
+      </div>
+      <Tooltip text="Close" position="left">
+        <button
+          type="button"
+          onclick={onClose}
+          class="p-1 text-text-secondary hover:text-text-primary transition-colors rounded"
+          aria-label="Close"
+        >
+          <X class="w-5 h-5" />
+        </button>
+      </Tooltip>
+    </div>
+
+    <!-- Content -->
+    <div class="p-4 space-y-4 overflow-y-auto flex-1">
+      {#if loading}
+        <div class="flex items-center justify-center py-12">
+          <Loader2 class="w-8 h-8 animate-spin text-accent" />
+        </div>
+      {:else}
+        <p class="text-sm text-text-secondary">
+          These settings apply to all your projects. Your contact information will appear on
+          manuscript title pages when exporting.
+        </p>
+
+        <!-- Section: Author Information -->
+        <fieldset>
+          <legend class="flex items-center gap-2 text-sm font-medium text-accent mb-3">
+            <User class="w-4 h-4" />
+            Author Information
+          </legend>
+          <div class="space-y-3">
+            <div>
+              <label for="author-name" class="block text-sm text-text-secondary mb-1">
+                Author Name
+              </label>
+              <input
+                id="author-name"
+                type="text"
+                bind:value={authorName}
+                placeholder="Your legal name"
+                disabled={saving}
+                class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+              />
+              <p class="text-xs text-text-secondary mt-1">
+                Used in contact info on title pages. Projects can override this with a pen name.
+              </p>
+            </div>
+          </div>
+        </fieldset>
+
+        <!-- Section: Contact Information -->
+        <fieldset>
+          <legend class="block text-sm font-medium text-accent mb-3">Contact Information</legend>
+          <p class="text-xs text-text-secondary mb-3">
+            Optional details for manuscript title pages. Use any format that works for your country.
+          </p>
+          <div class="space-y-3">
+            <div>
+              <label for="address-line1" class="block text-sm text-text-secondary mb-1">
+                Address Line 1
+              </label>
+              <input
+                id="address-line1"
+                type="text"
+                bind:value={addressLine1}
+                placeholder="Street address or PO Box"
+                disabled={saving}
+                class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+              />
+            </div>
+
+            <div>
+              <label for="address-line2" class="block text-sm text-text-secondary mb-1">
+                Address Line 2
+              </label>
+              <input
+                id="address-line2"
+                type="text"
+                bind:value={addressLine2}
+                placeholder="City, State/Province, Postal Code, Country"
+                disabled={saving}
+                class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+              />
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+              <div>
+                <label for="phone" class="block text-sm text-text-secondary mb-1"> Phone </label>
+                <input
+                  id="phone"
+                  type="tel"
+                  bind:value={phone}
+                  placeholder="+1 (555) 123-4567"
+                  disabled={saving}
+                  class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+                />
+              </div>
+
+              <div>
+                <label for="email" class="block text-sm text-text-secondary mb-1"> Email </label>
+                <input
+                  id="email"
+                  type="email"
+                  bind:value={email}
+                  placeholder="author@email.com"
+                  disabled={saving}
+                  class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+                />
+              </div>
+            </div>
+          </div>
+        </fieldset>
+
+        <!-- Error Message -->
+        {#if error}
+          <p class="text-sm text-red-400">{error}</p>
+        {/if}
+      {/if}
+    </div>
+
+    <!-- Footer -->
+    <div
+      class="flex items-center justify-end gap-2 px-4 py-3 border-t border-bg-card flex-shrink-0"
+    >
+      <button
+        type="button"
+        onclick={onClose}
+        class="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        disabled={saving}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        onclick={handleSave}
+        class="px-4 py-2 text-sm bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 flex items-center gap-2"
+        disabled={saving || loading}
+      >
+        {#if saving}
+          <Loader2 class="w-4 h-4 animate-spin" />
+          Saving...
+        {:else}
+          Save Settings
+        {/if}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/ProjectSettingsDialog.svelte
+++ b/src/lib/components/ProjectSettingsDialog.svelte
@@ -1,0 +1,181 @@
+<!--
+  ProjectSettingsDialog.svelte - Project-specific settings dialog
+
+  Allows users to configure project-specific metadata:
+  - Pen name (overrides app-level author name for this project)
+  - Genre
+-->
+<script lang="ts">
+  /* eslint-disable no-undef */
+  import { invoke } from "@tauri-apps/api/core";
+  import { X, Loader2, BookOpen } from "lucide-svelte";
+  import { currentProject } from "../stores/project.svelte";
+  import type { Project } from "../types";
+  import Tooltip from "./Tooltip.svelte";
+
+  let {
+    onClose,
+    onSave,
+  }: {
+    onClose: () => void;
+    onSave: (project: Project) => void;
+  } = $props();
+
+  // Form fields initialized from current project
+  let authorPenName = $state(currentProject.value?.author_pen_name ?? "");
+  let genre = $state(currentProject.value?.genre ?? "");
+
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+
+  async function handleSave() {
+    if (!currentProject.value) return;
+
+    saving = true;
+    error = null;
+
+    try {
+      // Convert empty strings to null for optional fields
+      const settings = {
+        author_pen_name: authorPenName.trim() || null,
+        genre: genre.trim() || null,
+      };
+
+      const updatedProject = await invoke<Project>("update_project_settings", {
+        projectId: currentProject.value.id,
+        settings,
+      });
+
+      onSave(updatedProject);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      onClose();
+    } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey) && !saving) {
+      handleSave();
+    }
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- Backdrop -->
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+  onclick={handleBackdropClick}
+  onkeydown={(e) => e.key === "Enter" && handleBackdropClick}
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="settings-dialog-title"
+  tabindex="-1"
+>
+  <!-- Dialog -->
+  <div class="bg-bg-panel rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b border-bg-card">
+      <div class="flex items-center gap-2">
+        <BookOpen class="w-5 h-5 text-accent" />
+        <h2 id="settings-dialog-title" class="text-lg font-medium text-text-primary">
+          Project Settings
+        </h2>
+      </div>
+      <Tooltip text="Close" position="left">
+        <button
+          type="button"
+          onclick={onClose}
+          class="p-1 text-text-secondary hover:text-text-primary transition-colors rounded"
+          aria-label="Close"
+        >
+          <X class="w-5 h-5" />
+        </button>
+      </Tooltip>
+    </div>
+
+    <!-- Content -->
+    <div class="p-4 space-y-4">
+      <p class="text-sm text-text-secondary">
+        These settings are specific to <strong class="text-text-primary"
+          >{currentProject.value?.name}</strong
+        >.
+      </p>
+
+      <!-- Pen Name -->
+      <div>
+        <label for="author-pen-name" class="block text-sm text-text-secondary mb-1">
+          Pen Name <span class="text-text-secondary/60">(optional)</span>
+        </label>
+        <input
+          id="author-pen-name"
+          type="text"
+          bind:value={authorPenName}
+          placeholder="Leave blank to use your author name"
+          disabled={saving}
+          class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+        />
+        <p class="text-xs text-text-secondary mt-1">
+          If provided, this will be used as the byline on title pages instead of your author name.
+        </p>
+      </div>
+
+      <!-- Genre -->
+      <div>
+        <label for="genre" class="block text-sm text-text-secondary mb-1">
+          Genre <span class="text-text-secondary/60">(optional)</span>
+        </label>
+        <input
+          id="genre"
+          type="text"
+          bind:value={genre}
+          placeholder="e.g., Literary Fiction, Science Fiction, Mystery"
+          disabled={saving}
+          class="w-full bg-bg-card text-text-primary border border-bg-card rounded-lg px-3 py-2 focus:outline-none focus:border-accent disabled:opacity-50"
+        />
+        <p class="text-xs text-text-secondary mt-1">
+          Genre will be displayed on manuscript title pages.
+        </p>
+      </div>
+
+      <!-- Error Message -->
+      {#if error}
+        <p class="text-sm text-red-400">{error}</p>
+      {/if}
+    </div>
+
+    <!-- Footer -->
+    <div class="flex items-center justify-end gap-2 px-4 py-3 border-t border-bg-card">
+      <button
+        type="button"
+        onclick={onClose}
+        class="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+        disabled={saving}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        onclick={handleSave}
+        class="px-4 py-2 text-sm bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 flex items-center gap-2"
+        disabled={saving}
+      >
+        {#if saving}
+          <Loader2 class="w-4 h-4 animate-spin" />
+          Saving...
+        {:else}
+          Save
+        {/if}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -29,11 +29,20 @@
     Lock,
     Unlock,
     Download,
+    Settings,
   } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
-  import type { Chapter, Scene, SyncPreview, ReimportSummary, ExportResult } from "../types";
+  import type {
+    Chapter,
+    Scene,
+    SyncPreview,
+    ReimportSummary,
+    ExportResult,
+    Project,
+  } from "../types";
   import ArchivePanel from "./ArchivePanel.svelte";
+  import ProjectSettingsDialog from "./ProjectSettingsDialog.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import RenameDialog from "./RenameDialog.svelte";
@@ -110,6 +119,9 @@
 
   // Snapshots panel state
   let showSnapshotsPanel = $state(false);
+
+  // Project settings dialog state
+  let showSettingsDialog = $state(false);
 
   // Export dialog state
   let exportDialog: {
@@ -719,6 +731,16 @@
         </p>
         <!-- Action icons -->
         <div class="flex items-center gap-0.5 flex-shrink-0">
+          <Tooltip text="Project settings" position="bottom">
+            <button
+              data-testid="settings-button"
+              onclick={() => (showSettingsDialog = true)}
+              class="p-1.5 text-text-secondary hover:text-text-primary hover:bg-bg-card rounded transition-colors"
+              aria-label="Project settings"
+            >
+              <Settings class="w-4 h-4" />
+            </button>
+          </Tooltip>
           <Tooltip text="Export project" position="bottom">
             <button
               data-testid="export-button"
@@ -1089,4 +1111,15 @@
 <!-- Export Success Dialog -->
 {#if exportResult}
   <ExportSuccessDialog result={exportResult} onClose={() => (exportResult = null)} />
+{/if}
+
+<!-- Project Settings Dialog -->
+{#if showSettingsDialog}
+  <ProjectSettingsDialog
+    onClose={() => (showSettingsDialog = false)}
+    onSave={(updatedProject: Project) => {
+      currentProject.setProject(updatedProject);
+      showSettingsDialog = false;
+    }}
+  />
 {/if}

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-dialog";
-  import { BookOpen, FileText, Kanban, Trash2, Loader2 } from "lucide-svelte";
+  import { BookOpen, FileText, Kanban, Trash2, Loader2, Settings } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
   import type { Project } from "../types";
   import Tooltip from "./Tooltip.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
+  import KindlingSettingsDialog from "./KindlingSettingsDialog.svelte";
 
   interface Props {
     recentProjects: Project[];
@@ -17,6 +18,7 @@
   let deletingProjectId = $state<string | null>(null);
   let hoveredProjectId = $state<string | null>(null);
   let projectToDelete = $state<Project | null>(null);
+  let showSettingsDialog = $state(false);
 
   async function importPlottr() {
     const path = await open({
@@ -120,7 +122,20 @@
   }
 </script>
 
-<div class="flex-1 flex flex-col items-center justify-center p-8">
+<div class="flex-1 flex flex-col items-center justify-center p-8 relative">
+  <!-- Settings button in corner -->
+  <div class="absolute top-4 right-4">
+    <Tooltip text="Kindling Settings" position="left">
+      <button
+        onclick={() => (showSettingsDialog = true)}
+        class="p-2 text-text-secondary hover:text-text-primary hover:bg-bg-card rounded-lg transition-colors"
+        aria-label="Kindling Settings"
+      >
+        <Settings class="w-5 h-5" />
+      </button>
+    </Tooltip>
+  </div>
+
   <div class="max-w-2xl w-full">
     <!-- Logo & Tagline -->
     <div class="text-center mb-12">
@@ -279,5 +294,13 @@
     confirmLabel="Delete Project"
     onConfirm={confirmDeleteProject}
     onCancel={cancelDeleteProject}
+  />
+{/if}
+
+<!-- Kindling Settings Dialog -->
+{#if showSettingsDialog}
+  <KindlingSettingsDialog
+    onClose={() => (showSettingsDialog = false)}
+    onSave={() => (showSettingsDialog = false)}
   />
 {/if}

--- a/src/lib/stores/project.svelte.test.ts
+++ b/src/lib/stores/project.svelte.test.ts
@@ -26,6 +26,8 @@ describe("currentProject store", () => {
       source_path: "/path/to/file.pltr",
       created_at: new Date().toISOString(),
       modified_at: new Date().toISOString(),
+      author_pen_name: null,
+      genre: null,
     };
 
     currentProject.setProject(mockProject);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,25 @@ export interface Project {
   source_path: string | null;
   created_at: string;
   modified_at: string;
+  // Project-specific metadata for export title page
+  /** Pen name for this project (overrides app-level author name if set) */
+  author_pen_name: string | null;
+  /** Genre of the work (displayed on title page) */
+  genre: string | null;
+}
+
+/** App-wide settings (stored in JSON file, not database) */
+export interface AppSettings {
+  /** Author's name (used in contact info on title pages) */
+  author_name: string | null;
+  /** First line of contact address (e.g., street address) */
+  contact_address_line1: string | null;
+  /** Second line of contact address (e.g., city, country, postal code) */
+  contact_address_line2: string | null;
+  /** Phone number */
+  contact_phone: string | null;
+  /** Email address */
+  contact_email: string | null;
 }
 
 /** A chapter groups related scenes together */


### PR DESCRIPTION
## Summary
- Adds two-tier settings architecture for manuscript export metadata (Issue #105)
- Implements native File menu with Import submenu, Export, Close Project, and Settings items
- App-wide "Kindling Settings" for author identity (name, contact info) stored in JSON
- Project-specific settings for pen name and genre stored in SQLite

## Test plan
- [x] Verified app compiles (Rust and TypeScript)
- [x] Tested Kindling Settings dialog opens from start screen and File menu
- [x] Tested Project Settings dialog opens from Sidebar and File menu
- [x] Tested settings save and persist across app restarts
- [x] Tested File menu items trigger appropriate actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)