### PR TITLE
feat(export): add standard manuscript format title page

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Manager};
 use crate::models::AppSettings;
 
 /// Get the path to the settings file
-fn get_settings_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
+pub fn get_settings_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
@@ -23,10 +23,9 @@ fn get_settings_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
     Ok(app_data_dir.join("settings.json"))
 }
 
-/// Get app settings
-#[tauri::command]
-pub async fn get_app_settings(app_handle: AppHandle) -> Result<AppSettings, String> {
-    let settings_path = get_settings_path(&app_handle)?;
+/// Load app settings from the settings file (internal helper)
+pub fn load_app_settings(app_handle: &AppHandle) -> Result<AppSettings, String> {
+    let settings_path = get_settings_path(app_handle)?;
 
     if settings_path.exists() {
         let contents = fs::read_to_string(&settings_path).map_err(|e| e.to_string())?;
@@ -36,6 +35,12 @@ pub async fn get_app_settings(app_handle: AppHandle) -> Result<AppSettings, Stri
         // Return default settings if file doesn't exist
         Ok(AppSettings::default())
     }
+}
+
+/// Get app settings
+#[tauri::command]
+pub async fn get_app_settings(app_handle: AppHandle) -> Result<AppSettings, String> {
+    load_app_settings(&app_handle)
 }
 
 /// Update app settings

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -41,6 +41,7 @@
   let includeBeatMarkers = $state(true);
   let includeSynopsis = $state(true);
   let pageBreaksBetweenChapters = $state(true);
+  let includeTitlePage = $state(true);
   let deleteExisting = $state(false);
   let createSnapshot = $state(false);
   let outputPath = $state("");
@@ -146,6 +147,7 @@
           output_path: docxFilePath,
           create_snapshot: createSnapshot,
           page_breaks_between_chapters: pageBreaksBetweenChapters,
+          include_title_page: includeTitlePage,
         };
 
         result = await invoke<ExportResult>("export_to_docx", {
@@ -248,6 +250,14 @@
             <span class="text-text-primary">Include beat markers as headings</span>
           </label>
           {#if exportFormat === "docx"}
+            <label class="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                bind:checked={includeTitlePage}
+                class="w-4 h-4 text-accent bg-bg-card border-bg-card rounded focus:ring-accent"
+              />
+              <span class="text-text-primary">Include title page</span>
+            </label>
             <label class="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -205,6 +205,8 @@ export interface DocxExportOptions {
   create_snapshot?: boolean;
   /** Add page breaks between chapters */
   page_breaks_between_chapters?: boolean;
+  /** Include a Standard Manuscript Format title page */
+  include_title_page?: boolean;
 }
 
 /** Result of an export operation */


### PR DESCRIPTION
## Summary
- Adds SMF-compliant title page generation to DOCX exports (Issue #96)
- Contact info (author name, address, phone, email from Kindling Settings)
- Word count (calculated from prose, rounded to nearest thousand)
- Title in uppercase, centered
- Author byline (pen name from project settings, or author name from app settings)
- Genre (from project settings, optional)

## Changes
- Added `include_title_page` option to DOCX export (defaults to true)
- Created `add_title_page()` function with proper SMF layout
- Added `calculate_project_word_count()` to count words across all beats
- Added `round_word_count()` to format count per SMF conventions
- Made `load_app_settings()` public for reuse in export command
- Added comprehensive unit tests for new functions

## Test plan
- [x] All 110 Rust tests pass
- [x] Frontend and backend compile without errors
- [x] Clippy passes without warnings
- [x] Export dialog shows "Include title page" checkbox for DOCX format

🤖 Generated with [Claude Code](https://claude.com/claude-code)