### PR TITLE
feat(export): add running header with page numbers to docx export

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -795,18 +795,19 @@ fn create_docx_styles(author_name: Option<&str>, project_title: &str) -> Docx {
     // Create empty header for title page
     let empty_header = create_empty_first_header();
 
-    // Note: With title_pg() enabled, first_header appears on page 1, header on pages 2+
-    // However, docx_rs appears to have inverted behavior, so we swap them:
-    // - first_header gets the running header (will appear on pages 2+)
-    // - header gets the empty header (will appear on page 1)
+    // With title_pg() enabled:
+    // - first_header() sets the header for the first page only
+    // - header() sets the header for all other pages (default header)
+    // Note: Order matters - header() must be called before first_header()
     Docx::new()
         // Set page margins (1 inch on all sides)
         .page_margin(page_margin)
         // Enable different first page header
         .title_pg()
-        // Set headers - swapped due to docx_rs behavior
-        .header(empty_header)
-        .first_header(running_header)
+        // Running header for all pages after the first (must be set before first_header)
+        .header(running_header)
+        // Empty header for title page (first page)
+        .first_header(empty_header)
         // Heading 1 style (for chapters) - large, bold, Courier New
         .add_style(
             Style::new("Heading1", StyleType::Paragraph)


### PR DESCRIPTION
## Summary
- Adds Standard Manuscript Format running headers to DOCX exports
- Header format: `Surname / TITLE / PageNumber` (right-aligned)
- Title page has empty header, running header starts on page 2
- Author surname extracted from full name (last word)
- Title abbreviated to max 3 words and uppercased

## Implementation Details
- New helper functions: `extract_surname()` and `abbreviate_title()`
- Uses docx_rs `Header`, `first_header()`, and `title_pg()` for different first page
- Page number field using `InstrPAGE` instruction

## Examples
| Author Name | Title | Header Output |
|-------------|-------|---------------|
| John Smith | My Novel | `Smith / MY NOVEL / 1` |
| Mary Jane Watson | The Very Long Title of My Book | `Watson / THE VERY LONG / 1` |

Closes #95

## Test Plan
- [x] Export a project with author settings configured
- [x] Verify title page has no header
- [x] Verify page 2+ shows running header with correct format
- [x] Verify page numbers increment correctly
- [x] Verify long titles are abbreviated to 3 words
- [x] Verify pen name is used if set, otherwise author name from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)