### PR TITLE
test(end-to-end): dockerize local e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,8 +86,8 @@ jobs:
         working-directory: e2e
         run: npm ci
 
-      - name: Build Tauri app (release)
-        run: npm run tauri build
+      - name: Build Tauri app (release, no bundle)
+        run: npm run tauri build -- --no-bundle
         env:
           TAURI_SIGNING_PRIVATE_KEY: ""
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_HOME=/root/.cargo \
+    RUSTUP_HOME=/root/.rustup \
+    PATH=/root/.cargo/bin:${PATH}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    libgtk-3-dev \
+    libwebkit2gtk-4.1-dev \
+    libappindicator3-dev \
+    librsvg2-dev \
+    xdg-utils \
+    patchelf \
+    webkit2gtk-driver \
+    xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --profile minimal
+
+RUN cargo install tauri-driver
+
+WORKDIR /app

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,15 +8,28 @@ End-to-end tests for Kindling using [WebdriverIO](https://webdriver.io/) and [Ta
 |----------|--------|-------|
 | Linux | ✅ Supported | Uses `WebKitWebDriver` |
 | Windows | ✅ Supported | Uses `msedgedriver` |
-| macOS | ❌ Not supported | No WKWebView WebDriver |
+| macOS | ⚠️ Docker only | Use Docker to run Linux tests |
+| Docker | ✅ Supported | Linux container matching CI |
 
-**Note:** macOS does not have a WebDriver for WKWebView, so E2E tests cannot run locally on macOS. Tests run in CI on Linux instead.
+**Note:** macOS does not have a WebDriver for WKWebView, so E2E tests cannot run locally on macOS. Use Docker (below) or CI on Linux instead.
 
 ## Running Tests
 
 ### In CI (Recommended)
 
 E2E tests run automatically in GitHub Actions on Linux runners. See `.github/workflows/e2e.yml`.
+
+### In Docker (Recommended on macOS/Windows)
+
+```bash
+# From project root
+npm run test:e2e:docker
+```
+
+This builds a Linux container with the same dependencies as CI, builds the Tauri app,
+and runs the E2E tests with Xvfb.
+
+The E2E fixtures live in `test-data/` (for example `test-data/simple-story.pltr`).
 
 ### Locally on Linux
 
@@ -114,7 +127,7 @@ For tests to work, add these `data-testid` attributes to components:
 - `title-input` - Inline title input for creating items
 - `drag-handle` - Drag grip icon
 - `delete-button` - Trash icon button
-- `reimport-button` - Refresh/reimport button
+- `sync-button` - Refresh/reimport button
 
 ### Scene Panel
 - `scene-panel` - Main scene content area
@@ -173,6 +186,10 @@ cargo install tauri-driver
 cargo install tauri-driver
 ```
 
+### Docker
+
+Install Docker Desktop (macOS/Windows) or Docker Engine (Linux) with Compose support.
+
 ## Troubleshooting
 
 ### "Could not find Tauri binary"
@@ -218,7 +235,7 @@ Make sure `~/.cargo/bin` is in your PATH.
 This is expected. macOS lacks a WebDriver for WKWebView. Run E2E tests:
 - In CI (automatically runs on Linux)
 - On a Linux machine or VM
-- Using Docker (experimental)
+- Using Docker
 
 ### Test flakiness
 
@@ -249,4 +266,7 @@ npm run test:e2e
 
 # For CI/headless mode
 npm run test:e2e:ci
+
+# Docker (Linux container, recommended for macOS/Windows)
+npm run test:e2e:docker
 ```

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  e2e:
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile
+    working_dir: /app
+    volumes:
+      - ..:/app
+      - node-modules:/app/node_modules
+      - e2e-node-modules:/app/e2e/node_modules
+      - cargo-registry:/root/.cargo/registry
+      - cargo-git:/root/.cargo/git
+      - npm-cache:/root/.npm
+      - tauri-target:/app/src-tauri/target
+    environment:
+      DISPLAY: ":99"
+      TAURI_SIGNING_PRIVATE_KEY: ""
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+      APPIMAGE_EXTRACT_AND_RUN: "1"
+      TAURI_BUNDLER_DISABLE_APPIMAGE: "1"
+    command: >
+      sh -c "npm ci &&
+             npm run tauri build -- --no-bundle &&
+             npm ci --prefix e2e --include=dev &&
+             (Xvfb :99 -screen 0 1920x1080x24 &) &&
+             sleep 2 &&
+             npm run test:ci --prefix e2e"
+
+volumes:
+  node-modules:
+  e2e-node-modules:
+  cargo-registry:
+  cargo-git:
+  npm-cache:
+  tauri-target:

--- a/e2e/specs/reimport.spec.js
+++ b/e2e/specs/reimport.spec.js
@@ -78,7 +78,7 @@ async function closeAllDialogs() {
 async function waitForSyncButtonClickable() {
   await browser.waitUntil(
     async () => {
-      const syncButton = await $('[data-testid="reimport-button"]');
+      const syncButton = await $('[data-testid="sync-button"]');
       if (!(await syncButton.isExisting())) return false;
       if (!(await syncButton.isDisplayed())) return false;
       return await syncButton.isClickable();
@@ -93,7 +93,7 @@ async function waitForSyncButtonClickable() {
 async function clickSyncButton() {
   await closeAllDialogs();
   await waitForSyncButtonClickable();
-  const syncButton = await $('[data-testid="reimport-button"]');
+  const syncButton = await $('[data-testid="sync-button"]');
   await syncButton.click();
 }
 
@@ -116,7 +116,7 @@ describe("Re-import to Update Project (#40)", () => {
   describe("Sync Button Visibility", () => {
     it("should show sync button for imported projects", async () => {
       // Assumes we're on an imported project (has source_path)
-      const syncButton = await $('[data-testid="reimport-button"]');
+      const syncButton = await $('[data-testid="sync-button"]');
       expect(await syncButton.isExisting()).toBe(true);
     });
 
@@ -289,7 +289,7 @@ describe("Re-import to Update Project (#40)", () => {
 
       // For now, verify the sync button is accessible
       await waitForSyncButtonClickable();
-      const syncButton = await $('[data-testid="reimport-button"]');
+      const syncButton = await $('[data-testid="sync-button"]');
       expect(await syncButton.isExisting()).toBe(true);
     });
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:rust": "cd src-tauri && cargo test --all-features",
     "test:e2e": "npm test --prefix e2e",
     "test:e2e:ci": "npm run test:ci --prefix e2e",
+    "test:e2e:docker": "docker compose -f e2e/docker-compose.yml up --build --abort-on-container-exit --exit-code-from e2e",
     "test:all": "npm run test && npm run test:rust",
     "check:all": "npm run check && npm run format:check && npm run lint && npm run format:rust:check && npm run lint:rust",
     "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",

--- a/test-data/simple-story.pltr
+++ b/test-data/simple-story.pltr
@@ -1,0 +1,75 @@
+{
+  "series": {
+    "name": "Simple Story"
+  },
+  "beats": [
+    { "id": 1, "title": "Act 1", "position": 0 },
+    { "id": 2, "title": "Act 2", "position": 1 },
+    { "id": 3, "title": "Act 3", "position": 2 }
+  ],
+  "lines": [
+    { "id": 1, "title": "Scenes", "position": 0 }
+  ],
+  "cards": [
+    {
+      "id": 101,
+      "lineId": 1,
+      "beatId": 1,
+      "title": "The Beginning",
+      "description": [
+        { "type": "paragraph", "children": [{ "text": "Opening scene." }] },
+        { "type": "paragraph", "children": [{ "text": "Second beat text." }] }
+      ],
+      "position": 0,
+      "positionWithinLine": 0
+    },
+    {
+      "id": 102,
+      "lineId": 1,
+      "beatId": 1,
+      "title": "Discovery",
+      "description": [
+        { "type": "paragraph", "children": [{ "text": "A discovery happens." }] }
+      ],
+      "position": 1,
+      "positionWithinLine": 0
+    },
+    {
+      "id": 201,
+      "lineId": 1,
+      "beatId": 2,
+      "title": "Turning Point",
+      "description": [
+        { "type": "paragraph", "children": [{ "text": "Things change." }] }
+      ],
+      "position": 0,
+      "positionWithinLine": 0
+    },
+    {
+      "id": 202,
+      "lineId": 1,
+      "beatId": 2,
+      "title": "Aftermath",
+      "description": [
+        { "type": "paragraph", "children": [{ "text": "Consequences follow." }] }
+      ],
+      "position": 1,
+      "positionWithinLine": 0
+    },
+    {
+      "id": 301,
+      "lineId": 1,
+      "beatId": 3,
+      "title": "Finale",
+      "description": [
+        { "type": "paragraph", "children": [{ "text": "Resolution." }] }
+      ],
+      "position": 0,
+      "positionWithinLine": 0
+    }
+  ],
+  "characters": [],
+  "places": [],
+  "tags": [],
+  "notes": []
+}


### PR DESCRIPTION
## Summary
- add Docker-based E2E runner with cached dependencies to mirror CI
- include a Plottr fixture in `test-data/` for local imports
- align CI build with the Docker path (no-bundle) and fix sync testid usage

## Test plan
- [x] npm run test:e2e:docker
- [x] pre-push checks (prettier, eslint, svelte-check, cargo fmt, clippy, vitest)