### PR TITLE
Make start screen projects scrollable

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -163,11 +163,7 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<main
-  class="flex h-screen w-screen bg-bg-primary overflow-x-hidden"
-  class:overflow-hidden={currentProject.value}
-  class:overflow-y-auto={!currentProject.value}
->
+<main class="flex h-screen w-screen overflow-hidden bg-bg-primary">
   {#if currentProject.value}
     <Sidebar />
     <ScenePanel />

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -122,7 +122,7 @@
   }
 </script>
 
-<div class="flex-1 flex flex-col items-center justify-center p-8 relative">
+<div class="flex-1 flex flex-col items-center justify-start p-8 relative overflow-hidden">
   <!-- Settings button in corner -->
   <div class="absolute top-4 right-4">
     <Tooltip text="Kindling Settings" position="left">
@@ -136,7 +136,7 @@
     </Tooltip>
   </div>
 
-  <div class="max-w-2xl w-full">
+  <div class="max-w-2xl w-full flex flex-col flex-1 min-h-0">
     <!-- Logo & Tagline -->
     <div class="text-center mb-12">
       <div class="flex justify-center mb-4">
@@ -218,7 +218,7 @@
     {#if recentProjects.length > 0}
       <div
         data-testid="recent-projects"
-        class="bg-bg-panel rounded-lg p-6 flex flex-col max-h-[50vh] min-h-0"
+        class="bg-bg-panel rounded-lg p-6 flex flex-col flex-1 min-h-0"
       >
         <h2 class="text-xl font-heading font-medium text-text-primary mb-4">Recent Projects</h2>
         <div class="space-y-2 overflow-y-auto pr-1 flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- make the Start Screen layout fill height and avoid double-scroll
- ensure the Recent Projects list itself is scrollable

Closes #158

## Test plan
- [x] npm run format
- [x] npm run lint
- [x] npm run check
- [x] npm test