### PR TITLE
Import yWriter item metadata into references

### DIFF
--- a/src-tauri/src/parsers/ywriter.rs
+++ b/src-tauri/src/parsers/ywriter.rs
@@ -1681,9 +1681,18 @@ mod tests {
         assert_eq!(item.name, "The Key");
         let desc = item.description.as_ref().unwrap();
         assert!(desc.contains("<em>rusty</em>"));
-        assert_eq!(item.attributes.get("aliases").map(String::as_str), Some("The Rust Key"));
-        assert_eq!(item.attributes.get("tags").map(String::as_str), Some("metal;locker"));
-        assert_eq!(item.attributes.get("image").map(String::as_str), Some("items/key.png"));
+        assert_eq!(
+            item.attributes.get("aliases").map(String::as_str),
+            Some("The Rust Key")
+        );
+        assert_eq!(
+            item.attributes.get("tags").map(String::as_str),
+            Some("metal;locker")
+        );
+        assert_eq!(
+            item.attributes.get("image").map(String::as_str),
+            Some("items/key.png")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- capture yWriter item aliases/tags/images into reference attributes
- normalize item descriptions with yWriter markup conversion
- add unit coverage for item field mapping

## Test plan
- [x] npm run format:check
- [x] npm run lint
- [x] npm run check
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] npm run test