### PR TITLE
Add scene workflow metadata

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -3090,7 +3090,7 @@ mod tests {
 
     #[test]
     fn test_add_scene_to_docx() {
-        use crate::models::{Beat, Scene};
+        use crate::models::{Beat, Scene, SceneStatus, SceneType};
         use uuid::Uuid;
 
         let scene = Scene {
@@ -3103,6 +3103,8 @@ mod tests {
             locked: false,
             archived: false,
             source_id: None,
+            scene_type: SceneType::Normal,
+            scene_status: SceneStatus::Draft,
         };
 
         let beats = vec![Beat {
@@ -3372,7 +3374,7 @@ mod tests {
 
     #[test]
     fn test_add_chapter_to_docx() {
-        use crate::models::{Beat, Chapter, Scene};
+        use crate::models::{Beat, Chapter, Scene, SceneStatus, SceneType};
         use std::collections::HashMap;
         use uuid::Uuid;
 
@@ -3397,6 +3399,8 @@ mod tests {
             locked: false,
             archived: false,
             source_id: None,
+            scene_type: SceneType::Normal,
+            scene_status: SceneStatus::Draft,
         };
 
         let beat = Beat {
@@ -3433,7 +3437,7 @@ mod tests {
 
     #[test]
     fn test_add_chapter_with_multiple_scenes() {
-        use crate::models::{Beat, Chapter, Scene};
+        use crate::models::{Beat, Chapter, Scene, SceneStatus, SceneType};
         use std::collections::HashMap;
         use uuid::Uuid;
 
@@ -3458,6 +3462,8 @@ mod tests {
             locked: false,
             archived: false,
             source_id: None,
+            scene_type: SceneType::Normal,
+            scene_status: SceneStatus::Draft,
         };
 
         let scene2 = Scene {
@@ -3470,6 +3476,8 @@ mod tests {
             locked: false,
             archived: false,
             source_id: None,
+            scene_type: SceneType::Normal,
+            scene_status: SceneStatus::Draft,
         };
 
         let beat1 = Beat {

--- a/src-tauri/src/commands/snapshot.rs
+++ b/src-tauri/src/commands/snapshot.rs
@@ -418,6 +418,8 @@ fn restore_create_new(
             source_id: scene.source_id.clone(),
             archived: scene.archived,
             locked: scene.locked,
+            scene_type: scene.scene_type,
+            scene_status: scene.scene_status,
         };
         if let Err(e) = db::insert_scene(conn, &new_scene) {
             conn.execute("ROLLBACK", []).ok();

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -207,6 +207,8 @@ pub async fn reimport_project(
                     &new_scene.title,
                     new_scene.synopsis.as_deref(),
                     new_scene.position,
+                    &new_scene.scene_type,
+                    &new_scene.scene_status,
                 )
                 .map_err(|e| {
                     let _ = conn.execute("ROLLBACK", []);
@@ -228,6 +230,8 @@ pub async fn reimport_project(
                     source_id: new_scene.source_id.clone(),
                     archived: false,
                     locked: false,
+                    scene_type: new_scene.scene_type,
+                    scene_status: new_scene.scene_status,
                 };
                 db::insert_scene(&conn, &scene_to_insert).map_err(|e| {
                     let _ = conn.execute("ROLLBACK", []);
@@ -751,6 +755,8 @@ pub async fn apply_sync(
                         &new_title,
                         new_synopsis.as_deref(),
                         new_scene.position,
+                        &new_scene.scene_type,
+                        &new_scene.scene_status,
                     )
                     .map_err(|e| {
                         let _ = conn.execute("ROLLBACK", []);
@@ -775,6 +781,8 @@ pub async fn apply_sync(
                         source_id: new_scene.source_id.clone(),
                         archived: false,
                         locked: false,
+                        scene_type: new_scene.scene_type,
+                        scene_status: new_scene.scene_status,
                     };
                     db::insert_scene(&conn, &scene_to_insert).map_err(|e| {
                         let _ = conn.execute("ROLLBACK", []);

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -34,7 +34,9 @@ pub fn initialize_schema(conn: &Connection) -> Result<()> {
             synopsis TEXT,
             prose TEXT,
             position INTEGER NOT NULL,
-            source_id TEXT
+            source_id TEXT,
+            scene_type TEXT NOT NULL DEFAULT 'normal',
+            scene_status TEXT NOT NULL DEFAULT 'draft'
         );
 
         CREATE TABLE IF NOT EXISTS beats (
@@ -225,6 +227,18 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if !columns.contains(&"locked".to_string()) {
         conn.execute(
             "ALTER TABLE scenes ADD COLUMN locked INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
+    if !columns.contains(&"scene_type".to_string()) {
+        conn.execute(
+            "ALTER TABLE scenes ADD COLUMN scene_type TEXT NOT NULL DEFAULT 'normal'",
+            [],
+        )?;
+    }
+    if !columns.contains(&"scene_status".to_string()) {
+        conn.execute(
+            "ALTER TABLE scenes ADD COLUMN scene_status TEXT NOT NULL DEFAULT 'draft'",
             [],
         )?;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ pub fn run() {
             commands::delete_reference,
             commands::save_beat_prose,
             commands::save_scene_synopsis,
+            commands::update_scene_metadata,
             commands::save_scene_prose,
             commands::reorder_chapters,
             commands::reorder_scenes,

--- a/src-tauri/src/models/scene.rs
+++ b/src-tauri/src/models/scene.rs
@@ -1,6 +1,63 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SceneType {
+    #[default]
+    Normal,
+    Notes,
+    Todo,
+    Unused,
+}
+
+impl SceneType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SceneType::Normal => "normal",
+            SceneType::Notes => "notes",
+            SceneType::Todo => "todo",
+            SceneType::Unused => "unused",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_lowercase().as_str() {
+            "notes" => SceneType::Notes,
+            "todo" => SceneType::Todo,
+            "unused" => SceneType::Unused,
+            _ => SceneType::Normal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SceneStatus {
+    #[default]
+    Draft,
+    Revised,
+    Final,
+}
+
+impl SceneStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SceneStatus::Draft => "draft",
+            SceneStatus::Revised => "revised",
+            SceneStatus::Final => "final",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_lowercase().as_str() {
+            "revised" => SceneStatus::Revised,
+            "final" => SceneStatus::Final,
+            _ => SceneStatus::Draft,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Scene {
     pub id: Uuid,
@@ -15,6 +72,10 @@ pub struct Scene {
     pub archived: bool,
     #[serde(default)]
     pub locked: bool,
+    #[serde(default)]
+    pub scene_type: SceneType,
+    #[serde(default)]
+    pub scene_status: SceneStatus,
 }
 
 impl Scene {
@@ -29,6 +90,8 @@ impl Scene {
             source_id: None,
             archived: false,
             locked: false,
+            scene_type: SceneType::Normal,
+            scene_status: SceneStatus::Draft,
         }
     }
 

--- a/src/lib/stores/project.svelte.test.ts
+++ b/src/lib/stores/project.svelte.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { currentProject } from "./project.svelte";
-import type { Project, ReferenceTypeId } from "../types";
+import type { Project, ReferenceTypeId, Scene } from "../types";
+
+const defaultSceneMeta: Pick<Scene, "scene_type" | "scene_status"> = {
+  scene_type: "normal",
+  scene_status: "draft",
+};
 
 describe("currentProject store", () => {
   beforeEach(() => {
@@ -61,6 +66,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
       },
     ]);
     currentProject.setBeats([
@@ -223,6 +229,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
     ];
@@ -241,6 +248,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     const scene2 = {
@@ -252,6 +260,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
 
@@ -287,6 +296,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -309,6 +319,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
 
@@ -411,6 +422,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
       {
@@ -422,6 +434,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
       {
@@ -433,6 +446,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
     ];
@@ -497,6 +511,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     const beat = { id: "b-1", scene_id: "sc-1", content: "Beat", position: 0, prose: null };
@@ -555,6 +570,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
       {
@@ -566,6 +582,7 @@ describe("currentProject store", () => {
         prose: null,
         archived: false,
         locked: false,
+        ...defaultSceneMeta,
         is_part: false,
       },
     ];
@@ -587,6 +604,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     const beat = { id: "b-1", scene_id: "sc-1", content: "Beat", position: 0, prose: null };
@@ -703,6 +721,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -722,6 +741,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -743,6 +763,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -828,6 +849,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -849,6 +871,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);
@@ -870,6 +893,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     const scene2 = {
@@ -881,6 +905,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene1, scene2]);
@@ -902,6 +927,7 @@ describe("currentProject store", () => {
       prose: null,
       archived: false,
       locked: false,
+      ...defaultSceneMeta,
       is_part: false,
     };
     currentProject.setScenes([scene]);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,7 +78,13 @@ export interface Scene {
   source_id?: string | null;
   archived: boolean;
   locked: boolean;
+  scene_type: SceneType;
+  scene_status: SceneStatus;
 }
+
+export type SceneType = "normal" | "notes" | "todo" | "unused";
+
+export type SceneStatus = "draft" | "revised" | "final";
 
 /** Container for archived (soft-deleted) items */
 export interface ArchivedItems {


### PR DESCRIPTION
## Summary
- persist scene type/status in models, schema, and queries
- add scene metadata editing plus sidebar filters and icon indicators
- map yWriter scene status/type into Kindling metadata

## Test plan
- [x] npm run check:all
- [x] npm run test
- [x] cargo test --all-features