### PR TITLE
feat(markdown): improve outline parsing

### DIFF
--- a/src-tauri/tests/fixtures/frontmatter.md
+++ b/src-tauri/tests/fixtures/frontmatter.md
@@ -1,0 +1,12 @@
+---
+title: Frontmatter Project
+author: Jane Doe
+description: An example description.
+word_target: 42000
+---
+
+# Chapter One
+
+## Scene One
+
+- Beat one


### PR DESCRIPTION
## Summary
- parse markdown frontmatter into project metadata and ignore it during outline parsing
- support scene-only outlines and orphan beats by creating default chapter/scene
- capture scene synopsis when a blockquote follows a scene heading

## Test plan
- [x] `npm run check:all`
- [x] `npm run test:coverage`
- [x] pre-push checks (format, lint, svelte-check, clippy, vitest)