### PR TITLE
feat(menu): add quit, about dialog, and fix auto-updater ACL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kindling",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Spark your draft - Bridge the gap between outline and prose",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kindling"
-version = "1.1.1"
+version = "1.1.2"
 description = "Spark your draft - Bridge the gap between outline and prose"
 authors = ["Josh Smith"]
 edition = "2021"
@@ -17,6 +17,7 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-updater = "2.9"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.38", features = ["bundled"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:app:default",
     "opener:default",
     "dialog:default",
-    "updater:default"
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             // Get the app data directory
             let app_data_dir = app

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -29,6 +29,8 @@ pub mod menu_ids {
     pub const TOGGLE_REFERENCES: &str = "toggle_references";
     pub const SYNC: &str = "sync";
     pub const COMMAND_PALETTE: &str = "command_palette";
+    pub const ABOUT: &str = "about";
+    pub const QUIT: &str = "quit";
 }
 
 /// Create the application menu
@@ -89,6 +91,11 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .accelerator("CmdOrCtrl+N")
         .build(app)?;
 
+    let quit = MenuItemBuilder::new("Quit Kindling")
+        .id(menu_ids::QUIT)
+        .accelerator("CmdOrCtrl+Q")
+        .build(app)?;
+
     // Build File submenu
     let file_submenu = SubmenuBuilder::new(app, "File")
         .item(&new_project)
@@ -100,6 +107,8 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .separator()
         .item(&project_settings)
         .item(&kindling_settings)
+        .separator()
+        .item(&quit)
         .build()?;
 
     // Build Edit submenu with standard items
@@ -144,6 +153,10 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .build()?;
 
     // Help submenu
+    let about = MenuItemBuilder::new("About Kindling...")
+        .id(menu_ids::ABOUT)
+        .build(app)?;
+
     let command_palette = MenuItemBuilder::new("Command Palette...")
         .id(menu_ids::COMMAND_PALETTE)
         .accelerator("CmdOrCtrl+K")
@@ -155,6 +168,8 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .build(app)?;
 
     let help_submenu = SubmenuBuilder::new(app, "Help")
+        .item(&about)
+        .separator()
         .item(&command_palette)
         .item(&quick_start)
         .build()?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kindling",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.kindlingwriter.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
+  import { exit } from "@tauri-apps/plugin-process";
   import { onMount } from "svelte";
   import { runImport, type ImportType } from "./lib/utils/import";
+  import AboutDialog from "./lib/components/AboutDialog.svelte";
   import Onboarding from "./lib/components/Onboarding.svelte";
   import ReferencesPanel from "./lib/components/ReferencesPanel.svelte";
   import ScenePanel from "./lib/components/ScenePanel.svelte";
@@ -39,6 +41,7 @@
   let showQuickStart = $state(false);
   let showCommandPalette = $state(false);
   let showNewProjectDialog = $state(false);
+  let showAboutDialog = $state(false);
 
   async function loadRecentProjects() {
     try {
@@ -171,6 +174,12 @@
         case "sync":
           window.dispatchEvent(new CustomEvent("kindling:sync"));
           break;
+        case "about":
+          showAboutDialog = true;
+          break;
+        case "quit":
+          exit(0);
+          break;
       }
     });
 
@@ -231,6 +240,12 @@
         break;
       case "kindling_settings":
         showKindlingSettings = true;
+        break;
+      case "about":
+        showAboutDialog = true;
+        break;
+      case "quit":
+        exit(0);
         break;
     }
   }
@@ -375,4 +390,9 @@
 <!-- Export Success Dialog -->
 {#if exportResult}
   <ExportSuccessDialog result={exportResult} onClose={() => (exportResult = null)} />
+{/if}
+
+<!-- About Dialog -->
+{#if showAboutDialog}
+  <AboutDialog onClose={() => (showAboutDialog = false)} />
 {/if}

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -7,8 +7,8 @@ describe("COMMAND_DEFS", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("has unique shortcuts", () => {
-    const shortcuts = COMMAND_DEFS.map((c) => c.shortcut);
+  it("has unique shortcuts among commands that have one", () => {
+    const shortcuts = COMMAND_DEFS.map((c) => c.shortcut).filter((s) => s !== "");
     expect(new Set(shortcuts).size).toBe(shortcuts.length);
   });
 
@@ -31,6 +31,8 @@ describe("COMMAND_DEFS", () => {
     expect(ids).toContain("toggle_sidebar");
     expect(ids).toContain("quick_start");
     expect(ids).toContain("sync");
+    expect(ids).toContain("quit");
+    expect(ids).toContain("about");
   });
 });
 

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -36,8 +36,16 @@ export const COMMAND_DEFS: CommandDef[] = [
     label: "Close project",
     shortcut: "⌘W",
     category: "File",
-    keywords: ["close", "exit"],
+    keywords: ["close"],
     requiresProject: true,
+  },
+  {
+    id: "quit",
+    label: "Quit Kindling",
+    shortcut: "⌘Q",
+    category: "File",
+    keywords: ["quit", "exit"],
+    requiresProject: false,
   },
   {
     id: "import_plottr",
@@ -115,6 +123,14 @@ export const COMMAND_DEFS: CommandDef[] = [
     requiresProject: true,
   },
   // Help
+  {
+    id: "about",
+    label: "About Kindling",
+    shortcut: "",
+    category: "Help",
+    keywords: ["about", "version", "info"],
+    requiresProject: false,
+  },
   {
     id: "quick_start",
     label: "Quick start guide",

--- a/src/lib/components/AboutDialog.svelte
+++ b/src/lib/components/AboutDialog.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { getVersion } from "@tauri-apps/api/app";
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import { X, ExternalLink, Flame } from "lucide-svelte";
+  import { onMount } from "svelte";
+
+  let { onClose }: { onClose: () => void } = $props();
+
+  let version = $state("...");
+
+  onMount(async () => {
+    try {
+      version = await getVersion();
+    } catch {
+      version = "unknown";
+    }
+  });
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      onClose();
+    }
+  }
+
+  async function openLink(url: string) {
+    await openUrl(url);
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+  class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="about-title"
+  tabindex="-1"
+>
+  <div
+    class="bg-bg-panel rounded-xl shadow-xl max-w-sm w-full flex flex-col"
+    data-testid="about-dialog"
+  >
+    <div class="flex items-center justify-between p-5 border-b border-bg-card shrink-0">
+      <h2 id="about-title" class="text-lg font-heading font-semibold text-text-primary">
+        About Kindling
+      </h2>
+      <button
+        onclick={onClose}
+        class="p-1 rounded hover:bg-bg-card text-text-secondary transition-colors"
+        aria-label="Close"
+      >
+        <X class="w-5 h-5" />
+      </button>
+    </div>
+
+    <div class="p-5 flex flex-col items-center text-center gap-4">
+      <div class="w-14 h-14 rounded-2xl bg-accent/15 flex items-center justify-center">
+        <Flame class="w-8 h-8 text-accent" />
+      </div>
+
+      <div>
+        <h3 class="text-lg font-heading font-semibold text-text-primary">Kindling</h3>
+        <p class="text-sm text-text-secondary mt-0.5">Version {version}</p>
+      </div>
+
+      <p class="text-sm text-text-secondary leading-relaxed">
+        Spark your draft &mdash; Bridge the gap between outline and prose.
+      </p>
+
+      <div class="w-full border-t border-bg-card pt-4 flex flex-col gap-2">
+        <button
+          onclick={() => openLink("https://github.com/smith-and-web/kindling")}
+          class="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-card rounded-lg transition-colors"
+        >
+          <ExternalLink class="w-4 h-4 shrink-0" />
+          GitHub Repository
+        </button>
+        <button
+          onclick={() => openLink("https://github.com/smith-and-web/kindling/issues/new")}
+          class="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-card rounded-lg transition-colors"
+        >
+          <ExternalLink class="w-4 h-4 shrink-0" />
+          Report an Issue
+        </button>
+        <button
+          onclick={() => openLink("https://github.com/smith-and-web/kindling/releases")}
+          class="flex items-center gap-2 w-full px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-card rounded-lg transition-colors"
+        >
+          <ExternalLink class="w-4 h-4 shrink-0" />
+          Release Notes
+        </button>
+      </div>
+    </div>
+
+    <div class="px-5 py-3 border-t border-bg-card text-center text-xs text-text-secondary shrink-0">
+      &copy; 2026 Josh Smith
+    </div>
+  </div>
+</div>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,3 +12,23 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
   save: vi.fn(),
 }));
+
+// Mock @tauri-apps/plugin-process
+vi.mock("@tauri-apps/plugin-process", () => ({
+  exit: vi.fn(),
+  relaunch: vi.fn(),
+}));
+
+// Mock @tauri-apps/api/app
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("1.0.0"),
+  getName: vi.fn().mockResolvedValue("Kindling"),
+  getTauriVersion: vi.fn().mockResolvedValue("2.0.0"),
+}));
+
+// Mock @tauri-apps/plugin-opener
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+  openPath: vi.fn(),
+  revealItemInDir: vi.fn(),
+}));


### PR DESCRIPTION
## Summary

- **Fix auto-updater ACL error**: Register `tauri-plugin-process` backend crate, add it to the Tauri builder chain, and grant `process:default` permission so `relaunch()` no longer fails with "Command plugin:process|restart not allowed by ACL"
- **Add "Quit Kindling"**: Added to File menu (`CmdOrCtrl+Q`) and command palette — calls `exit(0)` via `@tauri-apps/plugin-process`
- **Add "About Kindling" dialog**: Accessible from Help menu and command palette — displays version (from `getVersion()`), tagline, copyright, and links to GitHub repo, issue tracker, and release notes
- **Version bump to v1.1.2** across `package.json`, `tauri.conf.json`, and `Cargo.toml`

## Files changed

| File | Change |
|------|--------|
| `src-tauri/Cargo.toml` | Add `tauri-plugin-process`, bump version |
| `src-tauri/src/lib.rs` | Register process plugin |
| `src-tauri/capabilities/default.json` | Add `process:default` permission |
| `src-tauri/src/menu.rs` | Add Quit to File menu, About to Help menu |
| `src/lib/commands.ts` | Add `quit` and `about` commands |
| `src/lib/components/AboutDialog.svelte` | New About dialog component |
| `src/App.svelte` | Handle `quit`/`about` events, render dialog |
| `src/lib/commands.test.ts` | Update expected commands |
| `src/test/setup.ts` | Add mocks for process, app, opener plugins |

## Test plan

- [ ] Auto-updater: verify `relaunch()` works without ACL error
- [ ] File menu: "Quit Kindling" exits the app
- [ ] Help menu: "About Kindling..." opens the dialog
- [ ] About dialog shows correct version, links open in browser
- [ ] Command palette: `quit` and `about` commands appear and work
- [ ] Cross-platform: menus render correctly on macOS, Windows, Linux