### PR TITLE
fix(blacksmith): exempt automation from the repo's human git hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -2,6 +2,14 @@
 # Commit message linting hook
 # Enforces Conventional Commits format
 
+# Automation bypass: blacksmith authors its own intermediate commit messages
+# ("blacksmith: WU-..") and commits WITHOUT --no-verify, then squashes/cherry-picks them
+# into a single PR. Skip Conventional-Commits enforcement for those (and when a tool sets
+# SKIP_COMMIT_LINT). Human commits never use this prefix, so they are unaffected.
+if [ -n "$SKIP_COMMIT_LINT" ] || head -n1 "$1" | grep -qE '^blacksmith[:/]'; then
+  exit 0
+fi
+
 # Run commitlint on the commit message
 npx --no -- commitlint --edit "$1"
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,29 @@
 # Kindling pre-push hook
 # Runs linting, formatting, type checking, and tests before pushing
 
+# Automation bypass: blacksmith has its own test gate and CI re-runs every check on the
+# PR, and it pushes `blacksmith/*` branches WITHOUT --no-verify. Skip this heavy local
+# suite when every ref being pushed is a blacksmith branch (or SKIP_PREPUSH is set).
+# Human pushes to normal branches still run the full suite below.
+if [ -n "$SKIP_PREPUSH" ]; then
+  echo "pre-push: skipped (SKIP_PREPUSH set)"
+  exit 0
+fi
+_bs_skip=1
+_bs_saw=0
+while read -r _local_ref _rest; do
+  [ -z "$_local_ref" ] && continue
+  _bs_saw=1
+  case "$_local_ref" in
+    refs/heads/blacksmith/*) : ;;
+    *) _bs_skip=0 ;;
+  esac
+done
+if [ "$_bs_saw" = 1 ] && [ "$_bs_skip" = 1 ]; then
+  echo "pre-push: skipping checks for blacksmith automation branch"
+  exit 0
+fi
+
 echo "Running pre-push checks..."
 
 # Store the current directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,12 @@ npm run check:all        # everything CI checks (types, format, lint, rust fmt+c
 
 ## Conventions
 
-- **Commits:** Conventional Commits, enforced by commitlint via `.githooks`
-  (e.g. `feat(export): ...`, `fix(scrivener): ...`, `docs(readme): ...`).
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/), enforced by
+  commitlint (`commitlint.config.js`) via the `.githooks/commit-msg` hook **and** the CI
+  "Commit Messages" check. Format is `type(scope): subject` with a lowercase subject;
+  valid types are `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+  `ci`, `chore`, `revert` (e.g. `feat(export): ...`, `fix(scrivener): ...`). A bare
+  `<word>: ...` (no valid type) is rejected.
 - **Formatting:** Prettier (frontend) and `cargo fmt` (Rust) — run before committing.
 - **Linting:** ESLint (frontend) and `clippy -D warnings` (Rust) must be clean.
 - **Svelte 5:** use runes (`$state`, `$derived`, `$props`, etc.); stores live in


### PR DESCRIPTION
## Why

Run `feedback20260626d` halted on **WU-03** (\$7.50 total) — not on the agent's code, but on **blacksmith's own commit message**. Blacksmith commits as `blacksmith: WU-03 <title>` (`implement.py`) **without `--no-verify`**, so the repo's `commit-msg` hook ran commitlint and rejected it:

```
✖ type must be one of [feat, fix, docs, …] [type-enum]
input: blacksmith: WU-03 FeedbackDialog.svelte form with validation and submit states
```

WU-01/WU-02 passed because they're the `rust` layer (no `npm ci`, so `prepare` never set `core.hooksPath .githooks`). WU-03 (`frontend`) ran `npm ci`, which activated the hooks.

Blacksmith also pushes (`pr.py`) without `--no-verify`, so the **`pre-push`** hook (full lint/format/test suite) is the *next* halt waiting at PR-creation time — and it re-enforces formatting that the gate no longer checks.

## Fix (repo-side, safe for humans)

- **`.githooks/commit-msg`** — skip commitlint for `blacksmith:`-prefixed messages (and `SKIP_COMMIT_LINT`). Human commits never use that prefix and are still linted (verified: a bad human message still fails).
- **`.githooks/pre-push`** — skip the local suite when every pushed ref is `blacksmith/*` (and `SKIP_PREPUSH`). Normal branches still run the full suite (this PR's push did).
- **`CLAUDE.md`** — spell out the valid Conventional Commits types.

## Strategy

A run passes three enforcement layers: **blacksmith gate** → **git hooks** → **CI**. Only the first two can *halt a run* (expensive); CI just yields a red PR check (cheap). This change exempts blacksmith from the human hooks so commit→gate→push→PR no longer halts on commit-message or formatting rules — those become CI checks on the PR instead. (Full mapping in a local sweep doc; upstream fix — blacksmith using `--no-verify` — proposed to the blacksmith repo.)

## Note

Hooks + docs only — no product code. Must merge before the next run (blacksmith worktrees from HEAD). After merge, WU-03 should commit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)