### PR TITLE
chore: credential pre-commit scan, gitleaks config, and commit/IPC conventions docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Scan staged changes for committed credentials.
+#
+# Kindling is a public repository and ships no secrets — the app is offline-only
+# by design. This hook is here so that stays true by construction rather than by
+# habit.
+#
+# Optional by design: if gitleaks isn't installed the hook exits 0 silently, so
+# contributors are never blocked by tooling they didn't ask for. Install it with
+#   brew install gitleaks        (or see https://github.com/gitleaks/gitleaks)
+#
+# Bypass in a genuine emergency with:  git commit --no-verify
+#
+# Enabled via core.hooksPath=.githooks — see CONTRIBUTING.md / npm run prepare.
+
+set -uo pipefail
+
+command -v gitleaks >/dev/null 2>&1 || exit 0
+
+# Nothing staged (e.g. `git commit --amend --no-edit` with no changes).
+git diff --cached --quiet && exit 0
+
+if ! out=$(gitleaks git --pre-commit --staged --no-banner --redact 2>&1); then
+  printf '%s\n' "$out" | grep -vE '^\s*$' | sed 's/^/    /'
+  cat <<'MSG'
+
+✗ Commit blocked — possible credential in staged changes.
+
+  If it is a real secret:
+    git restore --staged <file>
+
+  Kindling has no server, accounts or API keys, so a credential here is almost
+  certainly a mistake — a test fixture, a pasted token, or a local config file
+  that should be gitignored.
+
+  If it is a false positive, add an allowlist entry to .gitleaks.toml rather
+  than bypassing the hook.
+
+  Last resort: git commit --no-verify
+MSG
+  exit 1
+fi
+
+exit 0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# gitleaks configuration for Kindling.
+#
+# Kindling is offline-only and ships no secrets, so this file exists to give the
+# .githooks/pre-commit hook a documented home for false positives rather than
+# having contributors reach for `git commit --no-verify`.
+#
+# Start from the upstream ruleset, then narrow.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Paths that are never committed, plus fixture-shaped false positives"
+paths = [
+  # Local-only files. Already gitignored; listed so a scan of the working tree
+  # (`gitleaks dir .`) is quiet too, not just the staged-changes hook.
+  '''^\.env(\..*)?$''',
+  '''^src-tauri/target/''',
+  '''^node_modules/''',
+  '''^e2e/node_modules/''',
+  # Import-parser fixtures: Plottr/yWriter/Scrivener sample projects contain
+  # high-entropy ids that trip the generic-api-key rule.
+  '''^test-data/''',
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,35 @@ npm run check:all        # everything CI checks (types, format, lint, rust fmt+c
   behavior change.
 - **DOCX export** follows Standard Manuscript Format — don't change those rules casually.
 
+## The IPC boundary (Rust ↔ TypeScript)
+
+Rust and TypeScript are maintained independently and **nothing checks their
+agreement at build time**. Currently 123 `#[tauri::command]` functions, 123
+registered, and 65 `invoke()` call sites in the frontend. Three things must line
+up for every command:
+
+1. The function is annotated `#[tauri::command]` (in `src-tauri/src/commands/`).
+2. It is listed in `tauri::generate_handler![...]` in `src-tauri/src/lib.rs`.
+   **A command that exists but isn't registered compiles fine and fails only at
+   runtime** — check the count matches after adding or renaming one.
+3. The frontend `invoke("name", { args })` matches the command name and its
+   argument names exactly.
+
+Two conversions that hide mismatches:
+
+- **Tauri maps Rust `snake_case` parameters to `camelCase` on the JS side.** A
+  mismatch here arrives as a missing or `null` argument, not an error.
+- **A Rust `Err` becomes a rejected promise.** With no `catch` at the call site
+  the failure is silent and the UI simply does nothing. Every `invoke` needs
+  error handling; a missing one is a real defect, not a style nit.
+
+Also: a Tauri plugin or filesystem/shell capability the frontend calls must be
+permitted in `src-tauri/capabilities/default.json`, or it fails at runtime with a
+misleading message.
+
+`npm run dev` runs Vite **without** the Rust backend, so every `invoke` fails
+there. Verify anything touching the boundary with `npm run tauri dev`.
+
 ## Sensitive areas (touch only with explicit intent)
 
 - `src-tauri/src/db/schema.rs` — the SQLite schema. Changes affect existing user files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,42 @@ npm run check:all        # everything CI checks (types, format, lint, rust fmt+c
   behavior change.
 - **DOCX export** follows Standard Manuscript Format — don't change those rules casually.
 
+### Commit type and scope feed the release notes
+
+Release notes are generated from commit messages —
+`npm run changelog` runs `conventional-changelog -p conventionalcommits -i
+CHANGELOG.md -s`. The commit message _is_ the release note, so two things are
+worth getting right at commit time because they are tedious to fix afterwards.
+
+**Type decides whether users see it.** In practice this preset renders only
+`feat` (Features) and `fix` (Bug Fixes) sections; `chore`, `docs`, `style`,
+`refactor`, `test`, `ci` and `build` are hidden. So pick the type by asking
+whether a _writer using Kindling_ would care. Work on the toolchain, CI, git
+hooks or the blacksmith orchestrator is `chore` or `ci` even when it fixes
+something — `fix(blacksmith): ...` puts an automation detail in front of end
+users, and the 1.1.0 notes already carry `fix(dev)` and `fix(mock)` entries
+that mean nothing to a novelist.
+
+**Scope should name a product area, not a work item.** Good: `export`,
+`scrivener`, `plottr`, `editor`, `import`, `db`, `ui`. Not a PRD id, work-unit
+id, branch name or ticket number — `feat(wu-01): ...` renders as a headline
+feature scoped to a label no reader can interpret. If a work unit spans one
+product area, use that area; if it spans several, split the commit.
+
+Neither rule is machine-enforced. Commitlint checks the type is in its
+`type-enum` and that the scope is kebab-case — `wu-01` passes both, and scope
+is optional. The CI "Commit Messages" check will not catch a mis-typed `fix` or
+a meaningless scope.
+
+**Two gotchas when actually cutting the notes.** `npm run changelog` emits only
+the _unreleased_ section and takes the version from `package.json`, so while
+`package.json` still matches the latest tag it outputs nothing — bump the
+version first, then generate. And CHANGELOG.md is currently stale: its newest
+entry is `0.2.0-alpha`, so 1.0.0-beta through 1.2.0 were never appended.
+`npm run changelog:all` (`-r 0`) regenerates the whole file from history and
+will overwrite any hand-edited prose in it — check the diff rather than
+trusting it.
+
 ## The IPC boundary (Rust ↔ TypeScript)
 
 Rust and TypeScript are maintained independently and **nothing checks their


### PR DESCRIPTION
## Summary

Four repo-hygiene commits. The first two were stranded on `fix/ci-updater-signing-key` after PR #260 merged — that branch's actual purpose (disabling updater artifacts in the build-check job) is already on `main`, and these follow-ups landed on it afterwards, unrelated to CI signing. Moved to a branch that describes them, then extended.

- `docs(claude): document the rust/ts ipc boundary` — the three things that must line up for every Tauri command (annotated, registered in `generate_handler!`, invoked under the matching name), plus the two silent-failure modes: Rust `snake_case` params arriving as `camelCase`, and a Rust `Err` becoming an uncaught rejected promise that makes the UI simply do nothing.
- `chore(hooks): scan staged changes for credentials` — optional gitleaks pre-commit hook. Exits 0 silently when gitleaks isn't installed, so contributors are never blocked by tooling they didn't ask for. Bypassable with `--no-verify`.
- `chore(hooks): add gitleaks config for documented allowlisting` — the hook told contributors to add allowlist entries to `.gitleaks.toml`, but that file didn't exist. It does now.
- `docs(claude): document how commit type and scope drive release notes` — see below.

Kindling is offline-only and ships no secrets, so the hook is about keeping that true by construction rather than by habit.

## Related Issues

None.

## Type of Change

- [x] Documentation update
- [x] Other (please describe): developer tooling — an optional git hook and a scanner config. No product code touched.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works — n/a, no product code changes (docs, a git hook, a scanner config)
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [ ] I have added relevant labels to this PR

## Testing Instructions

1. `npm run check:all` — 0 errors. The 6 svelte-check a11y warnings are pre-existing and in files this branch doesn't touch.
2. `npm test` (156 pass) and `cd src-tauri && cargo test --all-features` (365 pass).
3. With gitleaks installed, stage a file containing a fake key and commit — the hook blocks and points at `.gitleaks.toml`. Without gitleaks on `PATH`, commits proceed silently.
4. `gitleaks dir src scripts` — clean.

## Additional Notes

**On the scan results.** A working-tree scan on one machine reported five findings, all outside tracked source: two in a local `.env` (gitignored, `.gitignore:22`) and three in `src-tauri/target/**/*.rmeta` build artifacts (gitignored via `src-tauri/.gitignore:3`). Tracked source is clean, and the hook only inspects *staged* changes, so none of them were ever reachable by it. No real leak — but it's why the allowlist covers those paths, so a full-tree `gitleaks dir .` is quiet too and not just the hook. Side benefit: excluding `node_modules` took a working-tree scan from ~1.1 GB / 2m52s to 7.5 MB / 2.6s.

**On the commit conventions commit.** Written after checking the behaviour rather than from assumption, and two initial claims turned out wrong and were corrected before commit:

- The `conventionalcommits` preset renders only `feat` and `fix` sections in practice — `build(deps)` does *not* reach the user-facing changelog, contrary to what I first wrote.
- Commitlint enforces `scope-case: kebab-case`, which `wu-01` satisfies, so nothing mechanical will ever reject a work-unit-id scope.

Two gotchas surfaced while verifying, both now recorded in CLAUDE.md:

- `npm run changelog` emits only the *unreleased* section and reads the version from `package.json`, so it currently outputs nothing — `package.json` is 1.2.0 and so is the latest tag. Bump first, then generate.
- CHANGELOG.md is stale: newest entry is `0.2.0-alpha`, so 1.0.0-beta through 1.2.0 were never appended. `changelog:all` (`-r 0`) would regenerate the whole file and overwrite hand-edited prose, so that needs a reviewed diff rather than a blind run. Not fixed here — flagging it, not bundling it.

**Verification of the branch move.** At the time of the move, `git diff origin/fix/ci-updater-signing-key..HEAD` was empty, so the cherry-picked content was identical to what was on the old branch. `fix/ci-updater-signing-key` is left in place and can be deleted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)