### PR TITLE
ci(audit): move dependency auditing out of the required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,11 @@ jobs:
       - name: Type check
         run: npm run check
 
-      - name: Security audit
-        run: npm audit --audit-level=high
-
+      # Dependency auditing deliberately lives in security.yml, not here.
+      # This job is a required status check on main, so a fresh advisory in a
+      # transitive dev dependency would otherwise block every merge and every
+      # release — and, because the audit ran before the tests, silently skip
+      # the test suite while doing it. See security.yml for the audit.
       - name: Test with coverage
         run: npm test -- --coverage
 
@@ -116,12 +118,6 @@ jobs:
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-registry-
 
-      - name: Cache cargo-audit
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cargo-audit
-          key: ${{ runner.os }}-cargo-audit-0.18
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -133,11 +129,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Security audit
-        run: |
-          command -v cargo-audit || cargo install cargo-audit --quiet
-          cargo audit
-
+      # See the note in the Frontend job: auditing lives in security.yml.
       - name: Test
         run: cargo test --all-features
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,18 @@
 name: Security
+#
+# Dependency auditing lives here, and only here — deliberately.
+#
+# This workflow is NOT a required status check on main (main requires only
+# "Frontend" and "Rust" from ci.yml). That is the point: a newly published
+# advisory in a transitive dependency should raise a signal, not block every
+# merge and hold up a release behind unrelated dependency work. Triage happens
+# in a dedicated dependency PR.
+#
+# So a red run here is informational and expected to happen from time to time.
+# Read it, don't route around it — and please don't "fix" it by copying the
+# audit steps back into ci.yml, which is where they used to be. There they ran
+# *before* the test steps, so any advisory both blocked all merges and silently
+# skipped the entire test suite on the way.
 
 on:
   # Run weekly on Monday at 9am UTC


### PR DESCRIPTION
## Summary

`main` has been failing CI since at least 2026-08-16 — every scheduled run, same head SHA `1b83cb2` — and the only failing steps are `Security audit` in the Frontend and Rust jobs. Branch protection requires exactly those two checks, so **nothing has been mergeable to `main` without an admin bypass**, on nothing but newly published advisories.

The second-order effect is the worse one. Both jobs ran the audit *before* their test steps:

```
Frontend:  Lint -> Format check -> Type check -> Security audit -> Test with coverage -> Upload coverage
Rust:      Format check -> Clippy -> Security audit -> Test
```

A failing audit therefore skipped `npm test -- --coverage`, the coverage upload, and `cargo test --all-features`. **CI has not run a test in roughly three weeks while presenting itself as a test gate.** The green "JUnit Test Report" check comes from the E2E workflow, which made it look covered. The suite is green locally (156 frontend, 365 Rust), so nothing was masked — but a genuine regression would have merged clean.

These audit steps were also pure duplication: `security.yml` already runs `npm audit` and `cargo audit` weekly, on any PR touching `package.json`/`package-lock.json`/`Cargo.toml`/`Cargo.lock`, and on `workflow_dispatch`.

## Changes

- Remove the `Security audit` step from the Frontend and Rust jobs in `ci.yml`, leaving tests as the final step in each.
- Remove the now-orphaned `Cache cargo-audit` step from the Rust job.
- Comment both files with the reasoning, so the steps don't get copied back into `ci.yml`.

Auditing itself is **unchanged** — same commands, same thresholds, still on every dependency PR. It has simply moved out of the required-check path, so advisories surface as a signal rather than blocking merges and holding releases behind unrelated dependency work.

## Related Issues

None.

## Type of Change

- [x] CI/Build changes

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works — n/a, CI configuration only
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [ ] I have added relevant labels to this PR

## Testing Instructions

1. Both workflow files parse (`js-yaml`) and pass `prettier --check`.
2. The `Frontend` and `Rust` checks on this PR should now go green, and — the actual point — their logs should show `Test with coverage` and `Test` executing, with a `frontend-coverage` artifact attached. That's the thing to verify in review.
3. `security.yml` is untouched in behaviour; it still fails on the current advisories, which is now informational.

## Additional Notes

**This does mean no audit blocks a merge.** Deliberate, and worth stating plainly: the compensating controls are the weekly `Security` run, the `Security` job on dependency PRs, and CodeQL's SARIF upload to the Security tab. If a critical advisory ever needs to hard-block, the honest way is to add `Security` to the required checks explicitly, not to smuggle a duplicate audit into the test job.

I did **not** silence `security.yml` with `continue-on-error`. It blocks nothing as it stands, and a red run there is a truthful signal; making it always-green would have lost the signal as well as the gate. Happy to reconsider if you'd rather it read green.

**Outstanding advisories, unaffected by this PR and each wanting its own:**

| Advisory | Where | Fix |
| --- | --- | --- |
| RUSTSEC-2026-0194/0195 (quick-xml DoS) | **direct dep**, `Cargo.toml:28` — used by `parsers/ywriter.rs`, `parsers/scrivener.rs`, `commands/export.rs` | 0.39 -> 0.41, breaking 0.x bump; surface is 3 files and 4 APIs (`Reader`, `events::Event`, `escape::unescape`, `Error`) |
| RUSTSEC-2026-0204 (crossbeam-epoch) | transitive via `crossbeam-deque` | `cargo update -p crossbeam-epoch` to >=0.9.20 |
| linkify-it (quadratic `mailto:` DoS) | transitive via TipTap | production dep; `--omit=dev` audit reports only this plus one moderate in `@tiptap/core` |
| 17 remaining npm highs | WebdriverIO dev chain (`@wdio/*`, `webdriver`, `undici`, `@puppeteer/browsers`) | devDependency-only, never ships in the bundle |
| 7 unmaintained-crate warnings | transitive via `gtk3-macros`, `selectors` | upstream; nothing actionable |

The quick-xml one is the only advisory with real product relevance — those parsers consume user-supplied `.scrivx` and `.yw7` files — though for an offline desktop app the impact ceiling is a hang or OOM on a file the user chose to import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)