### PR TITLE
ci(build): pass build-check config as a file, and verify it on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,52 @@ jobs:
       - name: Test
         run: cargo test --all-features
 
+  # Does this PR touch the build plumbing itself?
+  #
+  # The Build job below is expensive (three platforms), so it normally only runs
+  # on pushes to main and on the weekly schedule. That left one blind spot: a
+  # change to the build command or the Tauri config could not be verified before
+  # merging, and a Windows-only quoting bug shipped through exactly that gap.
+  # When a PR edits this workflow or the Tauri config, build it properly.
+  plumbing:
+    name: Detect build-plumbing changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "changed files:"
+          echo "$files"
+          if echo "$files" | grep -qE '^(\.github/workflows/|src-tauri/tauri\..*\.json|src-tauri/Cargo\.(toml|lock)|package(-lock)?\.json)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "-> build plumbing touched; the Build job will run"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "-> no build plumbing touched; the Build job will be skipped"
+          fi
+
   # Build check (ensures the full app can build)
-  # Only runs on push to main or scheduled runs, not on PRs
+  # Runs on pushes to main, on the schedule, and on PRs that touch the build
+  # plumbing (see the plumbing job above).
   build:
     name: Build
-    needs: [frontend, rust]
-    if: github.event_name != 'pull_request'
+    needs: [frontend, rust, plumbing]
+    if: |
+      always()
+      && needs.frontend.result == 'success'
+      && needs.rust.result == 'success'
+      && (github.event_name != 'pull_request'
+          || needs.plumbing.outputs.changed == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -189,8 +229,13 @@ jobs:
 
       # Build-verification only; updater signing happens in release.yml.
       # Disable updater artifacts so the build doesn't require a signing key.
+      # The updater artifacts are skipped here because signing them needs
+      # TAURI_SIGNING_PRIVATE_KEY, which this job has no business holding — the
+      # release workflow does that. Passed as a config *file* rather than inline
+      # JSON on purpose: the inline form lost its quotes to pwsh on the Windows
+      # runner and failed with "key must be a string".
       - name: Build
-        run: npm run tauri build -- --target ${{ matrix.target }} --config '{"bundle":{"createUpdaterArtifacts":false}}'
+        run: npm run tauri build -- --target ${{ matrix.target }} --config src-tauri/tauri.build-check.conf.json
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/src-tauri/tauri.build-check.conf.json
+++ b/src-tauri/tauri.build-check.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
## Summary

The `Build` job has failed on `windows-latest` on **every push to `main` since 8c2a22b** (PR #260). The step was:

```
npm run tauri build -- --target ${{ matrix.target }} --config '{"bundle":{"createUpdaterArtifacts":false}}'
```

Windows runs steps under `pwsh`, which strips the inner double quotes, so Tauri received `{bundle:{createUpdaterArtifacts:false}}` and failed with `key must be a string at line 1 column 2`. Linux and macOS passed because bash preserves them.

Two reasons this went unnoticed for three weeks: `Build` carries `if: github.event_name != 'pull_request'`, so it never ran on the PR that introduced it; and `main` was already red from the dependency audit (fixed in #264), so one more red job changed nothing.

**The release path was never affected.** `release.yml` builds via `tauri-action` with an `args` string, not inline JSON. This was a build-check regression, not a shipping one.

## Changes

1. **The fix.** Move the override into `src-tauri/tauri.build-check.conf.json` and pass it by path. No shell quoting is involved on any platform, which matters because the escaping fix is the kind that can't be proven correct by reading it.
2. **The gap that let it through.** A new `plumbing` job diffs the PR's changed files and, when they touch `.github/workflows/**`, `src-tauri/tauri.*.json`, the Cargo manifests or the npm manifests, allows `Build` to run on the PR. Ordinary feature PRs still skip the three-platform build, so CI cost is unchanged for day-to-day work.

Comments in both files explain why the config is a file and why the updater is disabled here (signing belongs to the release workflow, which holds `TAURI_SIGNING_PRIVATE_KEY`; this job has no business holding it).

## Related Issues

Regression from #260. Complements #264, which took the dependency audit out of the required checks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/Build changes

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix/feature works — n/a, CI configuration; verified by execution, see below
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [ ] I have added relevant labels to this PR

## Testing Instructions

**This PR exercises the new path on itself** — it touches `.github/workflows/ci.yml`, so `plumbing` should report `changed=true` and all three `Build` matrix legs should run here, Windows included. That is the check to read in review: Windows green on a PR, which has never happened before.

Verified locally before pushing:

1. `--config <path>` is accepted and resolves from the repo root — the CLI parsed it and got as far as validating the `--target`.
2. The merge does what it claims: `npm run tauri build -- --config src-tauri/tauri.build-check.conf.json` finished with **two** bundles (`.app`, `.dmg`) and no updater step. Without it, the same command emits a third `.app.tar.gz` updater artifact and then fails with `A public key has been found, but no private key`, which is precisely the CI symptom #260 was working around.
3. Both `ci.yml` and the new config pass `prettier --check`, and `ci.yml` parses under `js-yaml`.
4. The detection regex was checked against this branch's own changed-file list.

## Additional Notes

The `plumbing` job id is deliberately hyphen-free. `needs.<job>.outputs.<x>` dot-dereferences the job id in an expression, and a hyphenated id there is the sort of thing that works until it doesn't; `plumbing` avoids the question entirely.

`Build` now gates on `always() && needs.frontend.result == 'success' && needs.rust.result == 'success' && (...)`. The `always()` is required because `plumbing` is skipped on `push` events, and a skipped dependency would otherwise skip `Build` too — while the two explicit `result == 'success'` checks keep the original behaviour of not building when the fast checks have already failed.

Worth noting for later: this only changed *when* `Build` runs, not what protects `main`. `Build` still isn't a required status check, so a broken build on a plumbing PR will be visible but won't block a merge. Adding it to branch protection is a reasonable follow-up, but it's a policy change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)