### PR TITLE
feat(novelwriter): support export, import and prose sync

### DIFF
--- a/docs/importing-projects.md
+++ b/docs/importing-projects.md
@@ -1,11 +1,11 @@
 # Importing Projects into Kindling
 
-Kindling supports importing story outlines from multiple sources. This guide explains how to prepare your files for successful import and how reference data is handled.
+Kindling supports importing story outlines and drafts from multiple sources. This guide explains how to prepare your files for successful import and how reference data is handled.
 
 ## Importing a Project
 
 1. Choose **Import** from the start screen or project menu.
-2. Select a source file (Plottr, Markdown, yWriter) or a Longform/Obsidian vault folder.
+2. Select a source file (Plottr, Markdown, yWriter), a Longform/Obsidian index or vault, or a novelWriter project folder.
 3. Review the import summary and finish the import.
 
 ![Screenshot: Import dialog](https://raw.githubusercontent.com/smith-and-web/kindling/main/docs/assets/import-dialog.png)
@@ -18,6 +18,7 @@ Kindling supports importing story outlines from multiple sources. This guide exp
 | [Markdown](#markdown-md) | `.md` | Plain text markdown outlines |
 | [yWriter](#ywriter-yw7) | `.yw7` | yWriter 7 project files |
 | [Longform/Obsidian](#longform-obsidian-md) | `.md` index or vault folder | Longform index + scene files |
+| [novelWriter](#novelwriter-project-folder) | Folder containing `nwProject.nwx` | Manuscript, prose, beats and reference notes |
 
 ---
 
@@ -189,7 +190,7 @@ Kindling enhances the Obsidian workflow—it doesn't replace it. Keep research a
 - **Chapters and scenes** based on the `longform.scenes` list
 - **Scene status, synopsis, and prose**
 - **Reference types** via frontmatter, tags, folders, and wikilinks
-- **Reference notes** from character/location/item/objective/organization notes
+- **Reference notes** from character, location, item, objective, organization, timeline and custom notes
 
 ### Recommended Vault Structure
 
@@ -204,6 +205,8 @@ My Novel/
   items/
   objectives/
   organizations/
+  timelines/
+  notes/
   templates/
 ```
 
@@ -256,6 +259,8 @@ Supported fields:
 - `items` / `objects`
 - `objectives` / `goals`
 - `organizations` / `factions` / `groups` / `teams`
+- `timelines`
+- `custom` (or `notes`)
 
 You can also use Dataview-style fields (`characters::`, `setting::`) or `#status/final` tags.
 
@@ -263,12 +268,79 @@ You can also use Dataview-style fields (`characters::`, `setting::`) or `#status
 
 Kindling detects reference notes using both folder names and frontmatter:
 
-- Use folders like `characters/`, `locations/`, `items/`, `objectives/`, `organizations/`
+- Use folders like `characters/`, `locations/`, `items/`, `objectives/`, `organizations/`, `timelines/`, `notes/`
 - Add `type`, `category`, or `tags` in frontmatter (e.g., `type: character`)
 - Keep reference names consistent between notes and scene links
 - Use `[[;Name]]` for characters and `[[~Place]]` for locations when a name could be ambiguous
 - Keep a single Longform index file per vault to avoid import ambiguity
 - Let Longform manage the `longform.scenes` list so ordering stays in sync
+
+Timeline notes import into **Timelines**, and custom notes into **Notes**. You can
+also classify them with `type: timeline` or `type: custom` in frontmatter.
+Longform export and import preserve these categories, their descriptions and
+attributes, and scene links. Keep the exported **Description** and **Notes**
+sections to preserve their text separately.
+
+---
+
+## novelWriter (Project Folder)
+
+Import a novelWriter project to plan its chapters and scenes in Kindling while keeping your draft and reference notes together.
+
+### File Requirements
+
+1. Choose **Import → novelWriter** from the project menu, or **novelWriter** in the guided import.
+2. Select the project folder containing `nwProject.nwx` and its `content/` folder. Select the whole folder, not an individual scene file.
+3. Finish the import and review any reference classifications offered.
+
+Keep the project folder intact. Kindling reads current `.md` documents and legacy `.nwd` documents from project format versions 1.4–1.6.
+
+### What Gets Imported
+
+- **Project name and author**
+- **Parts, chapters and scenes** from the manuscript headings
+- **Prose** with bold, italic and strikethrough formatting
+- **Scene synopses** from `%Synopsis:` comments
+- **Beats** from `% Beat:` comments, with the prose following each comment
+- **Reference notes** with names, descriptions and attributes
+- **Scene links** to characters, locations and supported reference notes, resolved by their tags
+
+| novelWriter Note Root | Kindling Reference Type |
+|-----------------------|-------------------------|
+| Character | Characters |
+| World | Locations |
+| Object | Items |
+| Plot | Objectives |
+| Entity | Organizations |
+| Timeline | Timelines |
+| Custom | Notes |
+
+Blank lines separate paragraphs; a single newline stays within the same paragraph. Part documents that contain prose receive a normal chapter so their scenes remain accessible.
+
+A scene without beat comments opens in Page mode and also has a single beat titled **Scene Content**. Archive, Trash and Template roots are skipped; only the first Novel root is imported.
+
+### Moving Between Kindling and novelWriter
+
+To take a Kindling novel into novelWriter, choose **Export → novelWriter** and select an empty destination folder. Exported projects require **novelWriter 26.2 or newer**. Beat comments and reference notes are included by default; archived chapters and scenes are excluded. Screenplays cannot be exported to this format.
+
+Keep **Include beat comments** enabled to preserve beat boundaries for later sync. Page-mode scenes export as whole-scene prose because they have no stored beat boundaries. Exporting does not change the project's existing sync connection. Import the exported folder to create a Kindling project linked to that novelWriter source.
+
+### Reviewing Changes with Sync
+
+After editing the source project in novelWriter, open the linked Kindling project and choose **Sync**. Review the full current and incoming prose, select the changes you want, then choose **Apply Sync**. Prose changes are unselected by default, and locked chapters and scenes are skipped.
+
+- With beat comments, Beat-mode prose can be reviewed and accepted for individual beats.
+- Without beat comments, or in Page mode, prose is reviewed as one scene-level change.
+- Accepting a whole-scene replacement in Beat mode keeps the planning beats, puts the incoming text in the first beat and clears prose from the remaining beats. The editor mode stays the same.
+- Declining a change leaves your local prose untouched. Sync reads changes into Kindling; export to a new empty folder to take Kindling changes back to novelWriter.
+
+Beats created or split locally keep their own prose and are not assigned to incoming beat comments during Sync.
+
+Sync covers chapters, scenes, beats and prose. Changes to notes, reference links and project metadata are not synced. Keep beat comments in their original order when possible: inserting a beat between existing comments can change how subsequent beats are matched, so review those changes carefully.
+
+### Limitations
+
+Underline and Kindling-only planning data are not included in export. novelWriter shortcodes, footnotes, alignment and indent codes, ignored text and per-item importance are not preserved. H4 sections are flattened into scene prose; POV, focus, mention and story references are not restored as scene links.
 
 ---
 
@@ -283,19 +355,21 @@ Kindling detects reference notes using both folder names and frontmatter:
 - **Plottr**: Ensure the file is valid JSON (not corrupted)
 - **Markdown**: Check for encoding issues (should be UTF-8)
 - **Longform/Obsidian**: Ensure the index has `longform.format: scenes`
+- **novelWriter**: Select the folder containing a readable `nwProject.nwx` and its `content/` folder
 
 ### Missing Content After Import
 
 - **No chapters**: Make sure your file has the expected structure markers
 - **No scenes**: Scenes require a parent chapter to exist first
 - **No beats**: Beats require a parent scene to exist first
-- **No characters/locations**: These are only imported from Plottr, yWriter, or Longform/Obsidian
+- **No characters/locations**: These are imported from Plottr, yWriter, Longform/Obsidian and novelWriter
 
 ### Missing References or Notes
 
 - Confirm reference notes live in recognizable folders (e.g., `characters/`, `locations/`)
 - Add `type`, `category`, or `tags` frontmatter to classify notes
 - Use `[[;Name]]` and `[[~Place]]` prefixes for ambiguous names
+- For novelWriter, check that notes have unique `@tag:` values and scene references use those tags
 - Run the post-import reference classification dialog to adjust types
 
 ---
@@ -305,19 +379,20 @@ Kindling detects reference notes using both folder names and frontmatter:
 - Longform import supports `format: scenes` only (single-scene format is not supported yet).
 - Markdown imports outline structure only; it does not include reference types.
 - Sync/reimport updates outline structure but does not enrich references for Markdown sources.
+- novelWriter sync includes user-selected prose changes; notes, reference links and project metadata are not synced.
 
 ---
 
 ## Format Comparison
 
-| Feature | Plottr | Markdown | yWriter | Longform/Obsidian |
-|---------|--------|----------|---------|------------------|
-| Chapters | Yes | Yes (H1) | Yes | Yes |
-| Scenes | Yes | Yes (H2) | Yes | Yes |
-| Beats | Yes (scene descriptions) | Yes (lists/paragraphs) | Yes (Goal/Conflict/Outcome) | Yes (beats marker) |
-| Synopsis | Yes | No | Yes | Yes |
-| Prose | No | No | Yes | Yes |
-| Characters | Yes | No | Yes | Yes |
-| Locations | Yes | No | Yes | Yes |
-| Items/Objectives/Organizations | No | No | Items only | Yes |
-| Scene-reference links | Yes | No | Characters/locations | Yes |
+| Feature | Plottr | Markdown | yWriter | Longform/Obsidian | novelWriter |
+|---------|--------|----------|---------|------------------|-------------|
+| Chapters | Yes | Yes (H1) | Yes | Yes | Yes, including parts |
+| Scenes | Yes | Yes (H2) | Yes | Yes | Yes |
+| Beats | Yes (scene descriptions) | Yes (lists/paragraphs) | Yes (Goal/Conflict/Outcome) | Yes (beats marker) | Yes (beat comments; otherwise one content beat) |
+| Synopsis | Yes | No | Yes | Yes | Yes |
+| Prose | No | No | Yes | Yes | Yes, including reviewed sync changes |
+| Characters | Yes | No | Yes | Yes | Yes |
+| Locations | Yes | No | Yes | Yes | Yes |
+| Items/Objectives/Organizations | No | No | Items only | Yes | Yes, plus timelines and notes |
+| Scene-reference links | Yes | No | Characters/locations | Yes | Characters, locations and supported tagged notes |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -146,6 +146,17 @@ For tests to work, add these `data-testid` attributes to components:
 - `reimport-summary` - Summary text content
 - `reimport-spinner` - Loading spinner
 
+### novelWriter export and sync
+- `export-format-novelwriter` - novelWriter format radio
+- `novelwriter-beat-comments` - Include beat comments checkbox
+- `novelwriter-notes` - Include characters, locations and notes checkbox
+- `export-confirm` - Export confirmation button
+- `sync-prose-diff` - Full before/after prose block
+- `sync-change-checkbox` - Individual change selection (`data-change-id` identifies the change)
+- `sync-preview-dialog` - Sync preview dialog
+- `sync-confirm` - Apply selected changes
+- `sync-summary-dialog` - Sync results dialog
+
 ## Debugging
 
 ### View test output

--- a/e2e/specs/helpers.js
+++ b/e2e/specs/helpers.js
@@ -95,27 +95,34 @@ export async function waitForEditor() {
  * This bypasses the native file dialog which can't be controlled in E2E tests
  */
 export async function importPlottrFile(filename) {
-  const filePath = resolve(testDataDir, filename);
+  return importProject(resolve(testDataDir, filename), "plottr");
+}
 
+export async function importProject(filePath, format = "plottr") {
+  await waitForAppReady();
   // Use the app's importProject helper which handles:
   // 1. Calling invoke("import_plottr")
   // 2. Updating currentProject store
   // 3. Setting ui view to "editor"
-  const result = await browser.executeAsync(async (path, done) => {
-    try {
-      // The app exposes importProject via __KINDLING_TEST__ for E2E testing
-      if (!window.__KINDLING_TEST__?.importProject) {
-        throw new Error("__KINDLING_TEST__.importProject not available");
+  const result = await browser.executeAsync(
+    async (path, format, done) => {
+      try {
+        // The app exposes importProject via __KINDLING_TEST__ for E2E testing
+        if (!window.__KINDLING_TEST__?.importProject) {
+          throw new Error("__KINDLING_TEST__.importProject not available");
+        }
+        const project = await window.__KINDLING_TEST__.importProject(path, format);
+        done({ success: true, project });
+      } catch (error) {
+        done({ success: false, error: error.message || String(error) });
       }
-      const project = await window.__KINDLING_TEST__.importProject(path);
-      done({ success: true, project });
-    } catch (error) {
-      done({ success: false, error: error.message || String(error) });
-    }
-  }, filePath);
+    },
+    filePath,
+    format
+  );
 
   if (!result.success) {
-    throw new Error(`Failed to import Plottr file: ${result.error}`);
+    throw new Error(`Failed to import project: ${result.error}`);
   }
 
   // Wait for UI to update after import

--- a/e2e/specs/novelwriter.spec.js
+++ b/e2e/specs/novelwriter.spec.js
@@ -1,0 +1,91 @@
+/** Human-gated native smoke: run on a supported tauri-driver platform. */
+import { mkdtempSync, readFileSync, writeFileSync, readdirSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  waitForAppReady,
+  importProject,
+  skipOnboardingIfPresent,
+  selectChapter,
+  selectScene,
+  expandBeat,
+} from "./helpers.js";
+
+async function invoke(command, args = {}) {
+  const result = await browser.executeAsync(
+    async (command, args, done) => {
+      try {
+        done({ value: await window.__KINDLING_TEST__.invoke(command, args) });
+      } catch (e) {
+        done({ error: String(e) });
+      }
+    },
+    command,
+    args
+  );
+  if (result.error) throw new Error(result.error);
+  return result.value;
+}
+
+describe("novelWriter round trip and prose sync", () => {
+  let folder;
+  const createdProjects = [];
+  before(async () => {
+    await waitForAppReady();
+    await skipOnboardingIfPresent();
+  });
+  after(async () => {
+    for (const projectId of createdProjects) await invoke("delete_project", { projectId });
+    if (folder) rmSync(folder, { recursive: true, force: true });
+  });
+  it("exports a sample, imports it, and applies an on-disk prose edit in the editor", async () => {
+    folder = mkdtempSync(join(tmpdir(), "kindling-novelwriter-"));
+    const original = await invoke("create_sample_project");
+    createdProjects.push(original.id);
+    const originalChapters = await invoke("get_chapters", { projectId: original.id });
+    const originalScenes = (
+      await Promise.all(originalChapters.map((c) => invoke("get_scenes", { chapterId: c.id })))
+    ).flat();
+    await invoke("export_to_novelwriter", {
+      projectId: original.id,
+      outputPath: folder,
+      options: { include_beat_comments: true, include_notes: true, create_snapshot: false },
+    });
+    expect(existsSync(join(folder, "nwProject.nwx"))).toBe(true);
+    expect(readdirSync(join(folder, "content")).every((name) => name.endsWith(".md"))).toBe(true);
+    const imported = await importProject(folder, "novelwriter");
+    const projectId = imported.id;
+    createdProjects.push(projectId);
+    const chapters = await invoke("get_chapters", { projectId });
+    const scenes = (
+      await Promise.all(chapters.map((c) => invoke("get_scenes", { chapterId: c.id })))
+    ).flat();
+    expect(chapters.length).toBe(originalChapters.length);
+    expect(scenes.length).toBe(originalScenes.length);
+    expect((await invoke("get_sync_preview", { projectId })).changes).toHaveLength(0);
+    const scene = scenes[0];
+    const chapter = chapters.find((c) => c.id === scene.chapter_id);
+    const file = join(folder, "content", `${scene.source_id}.md`);
+    const sentence = "The visitor returned with an unexpected letter.";
+    writeFileSync(file, `${readFileSync(file, "utf8")}\n${sentence}\n`);
+    await $('[data-testid="sync-button"]').click();
+    const diff = await $('[data-testid="sync-prose-diff"]');
+    await diff.waitForDisplayed();
+    expect(await diff.getText()).toContain(sentence);
+    await diff.$("..").$("..").$('input[type="checkbox"]').click();
+    await $('[data-testid="sync-confirm"]').click();
+    await $('[data-testid="sync-summary-dialog"]').waitForDisplayed();
+    await $('[data-testid="dialog-close"]').click();
+    await selectChapter(chapter.title);
+    await selectScene(scene.title);
+    const beats = await invoke("get_beats", { sceneId: scene.id });
+    if (scene.editor_mode === "beat") await expandBeat(beats.length - 1);
+    await browser.waitUntil(
+      async () => (await $('[contenteditable="true"]').getText()).includes(sentence),
+      {
+        timeout: 5000,
+        timeoutMsg: "Accepted prose did not appear in editor",
+      }
+    );
+  });
+});

--- a/qa/visual/README.md
+++ b/qa/visual/README.md
@@ -24,6 +24,7 @@ qa/visual/
   history.mjs          builds results/index.md from every report.md
   baselines/           one reference JPEG per screenshot checkpoint (committed)
   data/                scratch app data dir used by `npm run tauri:qa` (gitignored)
+  fixtures/            small authored import fixtures (currently Longform)
   scenarios/           one file per e2e spec, then the areas e2e never covered
     00-app-launch.md
     01-create-content.md      ... 05-reimport.md   mirror the e2e specs
@@ -34,6 +35,8 @@ qa/visual/
     10-tools.md               export dialog, snapshots, command palette
     11-new-project.md         blank project, no sync button
     12-sync-updates.md        sync picks up a renamed chapter, new scene, new beat
+    13-import-formats.md      Markdown outline, yWriter parts, Longform references
+    14-novelwriter-round-trip.md  export options, selective prose sync, narrow/dark diff
     98-narrow-sweep.md        1100 x 700 overflow check
     99-dark-sweep.md          four dark screens
   results/             per-run output (gitignored)
@@ -46,12 +49,16 @@ qa/visual/
 
 ## Budget
 
-The machine has a mandatory screen lock. Targets for a full run of all
-scenarios plus both sweeps:
+The machine has a mandatory screen lock. Targets for the core run (00–12) plus both sweeps:
 
 | Tool calls | Screenshots | Wall clock  |
 | ---------- | ----------- | ----------- |
 | about 110  | about 40    | 8 to 10 min |
+
+Run the import extension separately: `/visual-qa 13` (3 screenshots, about
+3 minutes) and `/visual-qa 14` (5 screenshots, about 4–5 minutes). Scenario 14
+includes dark and narrow checks of the prose diff, a surface the standard
+sweeps do not show. A request for all scenarios needs multiple run groups.
 
 If a run is going to exceed this, run scenarios in groups (`/visual-qa 06 07 08`)
 and let each run write its own results folder. `history.mjs` merges them.
@@ -76,8 +83,8 @@ Run `npm run test:qa-harness` before using the harness. These regression tests
 exercise cleanup with an in-memory IPC mock, including pre-existing projects
 whose filenames or names match the fixtures, reload, and failed operations.
 
-Ask Claude: `/visual-qa` for everything, or `/visual-qa 03 04` for some. Each
-numbered item is one or two tool calls; do not add `wait_for`, state reads or
+Ask Claude: `/visual-qa` for everything in bounded groups, or `/visual-qa 03 04`
+for some. Each numbered item is one or two tool calls; do not add `wait_for`, state reads or
 renames beyond what is listed.
 
 1. **Preflight, one Bash call.**
@@ -203,9 +210,17 @@ renames beyond what is listed.
 - **Async settle times.** Deletes, duplicates and archive need about a second
   before the sidebar reflects them; use 900 to 1200 ms step delays.
 - **Import promise never settles.** Gate on `wait_for` text `Act 1`.
+  For additional formats use `q.importFixture(path, format)`, where format is
+  `plottr` (default), `markdown`, `ywriter`, `longform`, `scrivener` or
+  `novelwriter`. Wait for the fresh `#qa-done-fixture-created` marker, then the
+  expected chapter text. `q.fixtureProject()` returns the last owned fixture's
+  captured ID, including after reload. It never searches existing projects.
+  `q.invoke(command, args)` signals `#qa-done-invoke` on success **or failure**;
+  check `q.last.status` before continuing. These helpers bypass native file
+  pickers and reference classification; record that coverage boundary.
   `q.cleanupFixtures()` deletes only IDs returned by this harness's fixture
-  imports. `q.createBlankProject()` captures the ID from the scenario 11
-  creation click; `q.cleanupNamed(name)` can delete only those owned IDs.
+  imports, across all supported formats. `q.createBlankProject()` captures the
+  ID from the scenario 11 creation click; `q.cleanupNamed(name)` can delete only those owned IDs.
   Ownership survives page reload in sessionStorage. With no ownership record,
   cleanup deletes nothing. Never adopt existing projects by filename or name.
   Finish cleanup before starting a new run; closing the window loses the

--- a/qa/visual/fixtures/longform/characters/Mara.md
+++ b/qa/visual/fixtures/longform/characters/Mara.md
@@ -1,0 +1,5 @@
+---
+type: character
+---
+
+Mara has returned after ten years away.

--- a/qa/visual/fixtures/longform/index.md
+++ b/qa/visual/fixtures/longform/index.md
@@ -1,0 +1,9 @@
+---
+longform:
+  format: scenes
+  title: Harbor Story QA
+  sceneFolder: scenes
+  scenes:
+    - Harbor Chapter
+    - - Arrival
+---

--- a/qa/visual/fixtures/longform/locations/Old Harbor.md
+++ b/qa/visual/fixtures/longform/locations/Old Harbor.md
@@ -1,0 +1,5 @@
+---
+type: location
+---
+
+A fishing port with a bell above the pier.

--- a/qa/visual/fixtures/longform/scenes/Arrival.md
+++ b/qa/visual/fixtures/longform/scenes/Arrival.md
@@ -1,0 +1,15 @@
+---
+synopsis: Mara returns to the harbor after a long absence.
+status: revised
+characters:
+  - "[[;Mara]]"
+setting: "[[~Old Harbor]]"
+---
+
+The **harbor bell** rang as Mara stepped ashore.
+
+<!-- kindling: beats -->
+- Mara recognizes the harbor.
+  The boats were smaller than she remembered.
+- A stranger calls her name.
+  She turned toward the empty pier.

--- a/qa/visual/fixtures/longform/scenes/Harbor Chapter.md
+++ b/qa/visual/fixtures/longform/scenes/Harbor Chapter.md
@@ -1,0 +1,3 @@
+<!-- kindling: beats -->
+- Establish the harbor setting.
+  The bell above the pier had rung every morning for a hundred years.

--- a/qa/visual/harness.js
+++ b/qa/visual/harness.js
@@ -173,10 +173,15 @@
   // ------------------------------------------------------------ async ops
   // Only creation calls explicitly initiated by this harness confer ownership.
   // Persist across the reload scenario; never infer ownership from a filename/name.
+  const importCommands = new Map(Object.entries(window.__KINDLING_TEST__?.importCommands ?? {}));
+  const fixtureCommands = new Set(importCommands.values());
   const ownedKey = "__qa_created_projects";
   const owned = () => JSON.parse(sessionStorage.getItem(ownedKey) || "[]");
   qa.trackCreation = (command, action) => {
-    if (!["import_plottr", "create_blank_project", "create_screenplay_project"].includes(command))
+    if (
+      !fixtureCommands.has(command) &&
+      !["create_blank_project", "create_screenplay_project"].includes(command)
+    )
       throw new Error("Unsupported QA creation command");
     const ipc = window.__TAURI_INTERNALS__;
     if (!ipc?.invoke) throw new Error("Tauri IPC missing; cannot track QA project ownership");
@@ -188,9 +193,10 @@
         if (!project?.id) throw new Error("Creation returned no project ID");
         const projects = owned();
         if (!projects.some((p) => p.id === project.id)) {
-          projects.push({ id: project.id, name: project.name, fixture: cmd === "import_plottr" });
+          projects.push({ id: project.id, name: project.name, fixture: fixtureCommands.has(cmd) });
           sessionStorage.setItem(ownedKey, JSON.stringify(projects));
         }
+        if (fixtureCommands.has(cmd)) qa.done("fixture-created");
         return project;
       });
     };
@@ -203,26 +209,36 @@
   qa.createBlankProject = () =>
     qa.trackCreation("create_blank_project", () => qa.click("new-project-create"));
 
-  /** Import the fixture. Gate on wait_for text "Act 1"; the promise never settles reliably. */
-  qa.importFixture = (absolutePath) => {
+  /** Most recently created fixture, from captured IPC IDs only. Never adopts existing projects. */
+  qa.fixtureProject = () =>
+    owned()
+      .filter((p) => p.fixture)
+      .at(-1) ?? null;
+
+  /** Gate on the imported chapter text; the frontend promise may not settle reliably. */
+  qa.importFixture = (absolutePath, format = "plottr") => {
+    const command = importCommands.get(format);
+    if (!command) throw new Error(`Unsupported QA import format: ${format}`);
     const hook = window.__KINDLING_TEST__;
     if (!hook?.importProject)
       throw new Error("__KINDLING_TEST__.importProject missing (not a dev build?)");
     qa.last = { op: "import", status: "pending" };
     qa.clearMarkers();
     hook.disableGuidance();
-    qa.trackCreation("import_plottr", () => hook.importProject(absolutePath))
+    qa.trackCreation(command, () => hook.importProject(absolutePath, format))
       .then((p) => (qa.last = { op: "import", status: "ok", projectId: p.id }))
       .catch((e) => (qa.last = { op: "import", status: "error", error: String(e) }));
     return "started";
   };
-  /** Any Tauri command; result lands in __qa.last. */
+  /** Any Tauri command; wait for #qa-done-invoke, then check __qa.last.status. */
   qa.invoke = (cmd, args = {}) => {
+    document.getElementById("qa-done-invoke")?.remove();
     qa.last = { op: cmd, status: "pending" };
     window.__KINDLING_TEST__
       .invoke(cmd, args)
       .then((r) => (qa.last = { op: cmd, status: "ok", result: r }))
-      .catch((e) => (qa.last = { op: cmd, status: "error", error: String(e) }));
+      .catch((e) => (qa.last = { op: cmd, status: "error", error: String(e) }))
+      .finally(() => qa.done("invoke"));
     return "started";
   };
   /** Delete only IDs captured from successful QA creation calls. */
@@ -631,7 +647,7 @@
     }
     const measure = [];
     for (const ed of root.querySelectorAll(
-      ".novel-editor-content, .prose, [class*='max-w-measure']"
+      ".novel-editor-content, .prose, .prose-review, [class*='max-w-measure']"
     )) {
       const max = parseFloat(getComputedStyle(ed).maxWidth);
       const w = ed.getBoundingClientRect().width;

--- a/qa/visual/harness.test.mjs
+++ b/qa/visual/harness.test.mjs
@@ -10,9 +10,11 @@ function setup() {
   const dom = new JSDOM("<!doctype html>", { url: "http://localhost", runScripts: "outside-only" });
   const w = dom.window;
   const deleted = [];
+  const calls = [];
   let failDelete = false;
   w.__TAURI_INTERNALS__ = {
     invoke: async (command, args) => {
+      calls.push({ command, args });
       if (command === "get_recent_projects")
         return [
           { id: "existing-backup", source_path: "my-simple-story.pltr.backup" },
@@ -25,20 +27,33 @@ function setup() {
         return;
       }
       return {
-        id: command === "import_plottr" ? "created-fixture" : "created-blank",
+        id:
+          command === "import_plottr"
+            ? "created-fixture"
+            : command.startsWith("import_")
+              ? `created-${command}`
+              : "created-blank",
         name: "QA Blank Project",
       };
     },
   };
   w.__KINDLING_TEST__ = {
+    importCommands: Object.fromEntries(
+      ["plottr", "markdown", "ywriter", "longform", "scrivener", "novelwriter"].map((format) => [
+        format,
+        `import_${format}`,
+      ])
+    ),
     invoke: (...args) => w.__TAURI_INTERNALS__.invoke(...args),
     disableGuidance() {},
-    importProject: (path) => w.__TAURI_INTERNALS__.invoke("import_plottr", { path }),
+    importProject: (path, format = "plottr") =>
+      w.__TAURI_INTERNALS__.invoke(`import_${format}`, { path }),
   };
   w.eval(source);
   return {
     w,
     deleted,
+    calls,
     fail: (value) => {
       failDelete = value;
     },
@@ -108,6 +123,73 @@ test("failed deletes retain ownership for retry; failed creations grant no owner
     assert.equal(w.__qa.last.status, "error");
     assert.equal(w.__TAURI_INTERNALS__.invoke, reject);
     assert.equal(w.sessionStorage.getItem("__qa_created_projects"), "[]");
+  } finally {
+    close();
+  }
+});
+
+for (const format of ["markdown", "ywriter", "longform", "scrivener", "novelwriter"]) {
+  test(`${format} imports are tracked by returned ID and cleaned up after reload`, async () => {
+    const { w, calls, deleted, close } = setup();
+    try {
+      w.__qa.importFixture("/tmp/qa-import", format);
+      await settle();
+      assert.equal(calls[0].command, `import_${format}`);
+      assert.equal(calls[0].args.path, "/tmp/qa-import");
+      assert.equal(w.__qa.fixtureProject().id, `created-import_${format}`);
+      assert.ok(w.document.getElementById("qa-done-fixture-created"));
+      delete w.__qa;
+      w.eval(source);
+      w.__qa.cleanupFixtures();
+      await settle();
+      assert.deepEqual(deleted, [`created-import_${format}`]);
+      assert.equal(w.__qa.fixtureProject(), null);
+    } finally {
+      close();
+    }
+  });
+}
+
+test("unknown formats and failed imports never acquire ownership", async () => {
+  const { w, calls, deleted, close } = setup();
+  try {
+    assert.throws(
+      () => w.__qa.importFixture("/tmp/qa", "delete_project"),
+      /Unsupported QA import format/
+    );
+    assert.equal(calls.length, 0);
+    w.__TAURI_INTERNALS__.invoke = async () => {
+      throw new Error("Missing nwProject.nwx");
+    };
+    w.__qa.importFixture("/tmp/missing", "novelwriter");
+    await settle();
+    assert.equal(w.__qa.last.status, "error");
+    assert.equal(w.__qa.fixtureProject(), null);
+    assert.equal(w.document.getElementById("qa-done-fixture-created"), null);
+    w.__qa.cleanupFixtures();
+    await settle();
+    assert.deepEqual(deleted, []);
+  } finally {
+    close();
+  }
+});
+
+test("invoke completion markers distinguish fresh calls and surface errors", async () => {
+  const { w, close } = setup();
+  try {
+    w.__qa.invoke("get_recent_projects");
+    await settle();
+    assert.equal(w.__qa.last.status, "ok");
+    assert.ok(w.document.getElementById("qa-done-invoke"));
+    w.__TAURI_INTERNALS__.invoke = async () => {
+      throw new Error("export failed");
+    };
+    w.__qa.invoke("export_to_novelwriter");
+    assert.equal(w.document.getElementById("qa-done-invoke"), null);
+    await settle();
+    assert.equal(w.__qa.last.status, "error");
+    assert.match(w.__qa.last.error, /export failed/);
+    assert.ok(w.document.getElementById("qa-done-invoke"));
   } finally {
     close();
   }

--- a/qa/visual/scenarios/13-import-formats.md
+++ b/qa/visual/scenarios/13-import-formats.md
@@ -1,0 +1,123 @@
+# 13 Imported outlines, parts and references
+
+Adds visual coverage for Markdown, yWriter and Longform alongside the existing
+Plottr scenarios (00, 05 and 12). Run `/visual-qa 13` as its own group.
+Budget: 3 screenshots, about 20 tool calls, 3 minutes.
+
+Precondition: scratch database, harness installed, no dialogs open. Each import
+creates a new owned fixture; `q.cleanupFixtures()` removes only those captured
+IDs. The test bridge bypasses native pickers and reference classification, so
+this scenario checks the imported workspace, not the guided-import flow.
+
+Use `<repo>` for the absolute repository path. After **each** `q.importFixture`,
+wait for `#qa-done-fixture-created` attached, then the chapter text specified
+below. The marker is cleared for each import and prevents a stale chapter from
+satisfying the gate. On timeout inspect `q.last` and record the error; do not
+continue with the previously loaded project.
+
+## 13-01 Markdown outline
+
+```js
+const q = window.__qa;
+q.importFixture("<repo>/src-tauri/tests/fixtures/hamlet.md", "markdown");
+```
+
+Wait for the creation marker, then text `Act I`. Click `Act I` only if no scene
+rows are visible, wait for `Scene 1 - The Battlements`, then:
+
+```js
+const q = window.__qa;
+q.click("scene-title", "Scene 1 - The Battlements");
+```
+
+Wait for `[data-testid="beat-header"]`, then:
+
+```js
+const q = window.__qa;
+q.mark("13-01-outline", {
+  sync: !!q.find("sync-button"),
+  prompts: q.titles("beat-header"),
+});
+q.shot("13-01-markdown-outline");
+JSON.stringify(q.preflight());
+```
+
+Wait for `#qa-settled-13-01-markdown-outline`, then screenshot.
+
+**Assert**: five acts, four beats in the first scene, including `Francisco
+stands guard at Elsinore`; Sync is shown. **Expect**: a usable outline, clear
+chapter/scene hierarchy and readable prompts, without empty prose occupying
+most of the workspace.
+
+## 13-02 yWriter parts
+
+```js
+const q = window.__qa;
+q.importFixture("<repo>/src-tauri/tests/fixtures/parts_example.yw7", "ywriter");
+```
+
+Wait for the creation marker, then `[data-testid="part-item"]`. Part headings
+may be uppercased by CSS. If Chapter 1 is hidden, click Part 1 to expand it.
+Click `Chapter 1` only if its scenes are hidden; wait for `Scene 1`, then select
+it and wait for `[data-testid="scene-panel"]`.
+
+```js
+const q = window.__qa;
+q.mark("13-02-parts", { parts: q.titles("part-item"), sync: !!q.find("sync-button") });
+q.shot("13-02-ywriter-parts");
+JSON.stringify(q.preflight());
+```
+
+Wait for `#qa-settled-13-02-ywriter-parts`, then screenshot.
+
+**Assert**: two parts containing three chapters overall; Chapter 1 has Scene 1
+and Scene 2; Sync is shown. **Expect**: part headings visually distinct from
+chapters, scenes indented under their chapter, the selected scene's title and
+metadata readable. Do not treat the capitalized Part labels as missing text.
+
+## 13-03 Longform prose and references
+
+```js
+const q = window.__qa;
+q.importFixture("<repo>/qa/visual/fixtures/longform/index.md", "longform");
+```
+
+Wait for the creation marker, then `Harbor Chapter`. Expand it if needed, select
+`Arrival`, and wait for `[data-testid="beat-header"]`. Then:
+
+```js
+const q = window.__qa;
+q.clickNth("beat-header", 0);
+q.mark("13-03-longform", {
+  sync: !!q.find("sync-button"),
+  hasMara: document.body.textContent.includes("Mara"),
+  hasSynopsis: document.body.textContent.includes("Mara returns to the harbor"),
+});
+q.shot("13-03-longform-references");
+q.axe();
+JSON.stringify(q.preflight());
+```
+
+Wait for `#qa-settled-13-03-longform-references`, then screenshot. Wait for
+`#qa-axe-done` before reading `q.axeResult`.
+
+**Assert**: Harbor Chapter and Arrival appear as scene rows; Arrival has two
+beats and a synopsis, Mara appears in Characters and Old Harbor in
+Locations (switch the References tab to inspect it), and Sync shown.
+**Expect**: imported prose and prompts remain separate, reference names and
+counts fit their tabs, and synopsis/status controls remain readable alongside
+an open editor. Record `q.audit()` and the axe result.
+
+## Finish
+
+```js
+const q = window.__qa;
+q.key("Escape");
+q.done("13");
+JSON.stringify({ ...q.flush(), errors: q.takeErrors(), audit: q.audit(), axe: q.axeResult });
+```
+
+Before scenarios that expect Simple Story (including sweeps), restore that
+workspace: close the project and click its exact `project-card`, or import a
+fresh owned `test-data/simple-story.pltr` and wait for the new creation marker
+and `Act 1`. Final cleanup removes all owned imports. No fixture files change.

--- a/qa/visual/scenarios/14-novelwriter-round-trip.md
+++ b/qa/visual/scenarios/14-novelwriter-round-trip.md
@@ -1,0 +1,250 @@
+# 14 novelWriter round trip and prose review
+
+Mirrors `e2e/specs/novelwriter.spec.js`, with visual checks for export options,
+long before/after text, independent selection, dark theme and narrow width.
+Run `/visual-qa 14` separately. Budget: 5 screenshots, about 35 tool calls,
+4–5 minutes. Baselines are added only after a judged native run.
+
+Precondition: scratch database and harness installed. This uses a fresh owned
+Longform import as the seed, so it does not depend on scenario 13. It exports
+to a new temporary folder and edits only that export. The Kindling test bridge
+bypasses native pickers; opening the export in novelWriter itself remains a
+separate compatibility check.
+
+For every `q.invoke`, wait for `#qa-done-invoke` attached and check
+`q.last.status === "ok"` before using `q.last.result` or continuing. An error
+also sets the marker: completion is not evidence of success.
+
+## 1. Prepare an isolated round trip
+
+Bash:
+
+```bash
+mktemp -d /tmp/kindling-qa-novelwriter.XXXXXX
+```
+
+Record the printed absolute path as `<scratch folder>` for this scenario only.
+
+```js
+const q = window.__qa;
+q.importFixture("<repo>/qa/visual/fixtures/longform/index.md", "longform");
+```
+
+Wait for `#qa-done-fixture-created`, then `Harbor Chapter`. Expand the chapter
+if needed, select `Arrival`, and wait for `[data-testid="beat-header"]`.
+
+```js
+const q = window.__qa;
+window.__qaNW = {
+  folder: "<scratch folder>",
+  seedId: q.fixtureProject().id,
+  local:
+    "Mara watched the boats drift beneath the harbor bell. " +
+    "She remembered every window along the quay, but none of the faces. ".repeat(6),
+  retained: "She turned toward the empty pier.",
+};
+q.run([
+  ["14-seed-open-first", () => q.clickNth("beat-header", 0), 400],
+  ["14-seed-first", () => q.setProse(window.__qaNW.local), 2400],
+  ["14-seed-open-second", () => q.clickNth("beat-header", 1), 400],
+  ["14-seed-second", () => q.setProse(window.__qaNW.retained), 2400],
+  [
+    "14-seed-ready",
+    () => {
+      q.key("Escape");
+      q.done("14-seed");
+    },
+    0,
+  ],
+]);
+```
+
+Wait for `#qa-done-14-seed`; verify no save is pending before exporting.
+
+## 2. Export options (14-01)
+
+Open `more-actions-button`, then in the next call `export-button`. Wait for
+`#export-dialog-title`, then:
+
+```js
+const q = window.__qa;
+q.click("export-format-novelwriter");
+q.shot("14-01-novelwriter-export");
+```
+
+Wait for `#qa-settled-14-01-novelwriter-export`, then screenshot. In the next
+call inspect the controls after Svelte has updated:
+
+```js
+const q = window.__qa;
+q.mark("14-export-options", {
+  beats: q.find("novelwriter-beat-comments").checked,
+  notes: q.find("novelwriter-notes").checked,
+  disabled: q.find("export-confirm").disabled,
+  hasHelp: document.body.textContent.includes("disables beat-level sync"),
+});
+q.click("export-close");
+q.invoke("export_to_novelwriter", {
+  projectId: window.__qaNW.seedId,
+  outputPath: window.__qaNW.folder,
+  options: { include_beat_comments: true, include_notes: true, create_snapshot: false },
+});
+```
+
+**Assert**: all four options assertions are true. After the invoke gate, check
+`files_created > 1`. **Expect**: the selected novelWriter tile, both checked
+options, readable beat-sync help and an empty destination field, with a
+visibly disabled Export action. No clipped footer. The actual disk export
+uses IPC here; this does not claim coverage of the native folder picker.
+
+## 3. Re-import and establish a no-change baseline
+
+```js
+const q = window.__qa;
+q.importFixture(window.__qaNW.folder, "novelwriter");
+```
+
+Wait for the new creation marker and `Harbor Chapter`, then:
+
+```js
+const q = window.__qa;
+window.__qaNW.projectId = q.fixtureProject().id;
+q.invoke("get_sync_preview", { projectId: window.__qaNW.projectId });
+```
+
+After the invoke gate, assert zero additions and zero changes. Expand Harbor
+Chapter if needed, select Arrival and wait for two beats. Check Mara and Old
+Harbor are still present in their References tabs. Check the synopsis survived
+and Sync is visible. These are DOM checks; scenario 13 captures the workspace.
+
+## 4. Edit only the exported source (Bash)
+
+The header checksum deliberately remains stale, like an external editor that
+has not regenerated it. Stop if the expected document or comments are missing.
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+folder = Path("<scratch folder>")
+files = [p for p in (folder / "content").glob("*.md") if "### Arrival\n" in p.read_text()]
+assert len(files) == 1, "Expected exactly one Arrival document"
+path = files[0]
+text = path.read_text()
+first = "% Beat: Mara recognizes the harbor."
+second = "% Beat: A stranger calls her name."
+assert text.count(first) == text.count(second) == 1, "Unexpected beat boundaries"
+prefix = text.split(first, 1)[0]
+prose = ("The harbor bell fell silent when Mara stepped onto the quay. "
+         + "A stranger waited beside the last boat, holding a letter she had never sent. " * 6)
+path.write_text(prefix + first + "\n" + prose + "\n\n" + second
+                + "\nThis incoming sentence must remain unaccepted.\n")
+print(path)
+PY
+```
+
+## 5. Review long prose (14-02)
+
+Click `sync-button`, wait for `[data-testid="sync-preview-dialog"]`, then:
+
+```js
+const q = window.__qa;
+q.shot("14-02-novelwriter-prose-review");
+q.axe(document.querySelector('[data-testid="sync-preview-dialog"]'));
+JSON.stringify({
+  rows: document.querySelectorAll('[data-testid="sync-prose-diff"]').length,
+  selected: document.querySelectorAll('[data-testid="sync-change-checkbox"]:checked').length,
+  disabled: q.find("sync-confirm").disabled,
+  audit: q.audit(),
+});
+```
+
+Wait for the screenshot's settle marker, capture, then wait for `#qa-axe-done`
+and record `q.axeResult`. **Assert**: two prose rows, zero selected changes,
+Apply Sync disabled. **Expect**: clearly labeled Current/Incoming paragraphs,
+readable Newsreader text, retained paragraph wrapping, independently reachable
+checkboxes and internal scrolling. Scroll the list to inspect the second row;
+long prose must not be reduced to a truncated single line.
+
+## 6. Narrow and dark prose review (14-03, 14-04)
+
+This is a new reading surface that the existing sweeps do not cover. Keep the
+same diff open and selections unchanged:
+
+1. `manage_window set_size` 1100 x 700. Call `q.shot("14-03-novelwriter-narrow")`,
+   wait for its settle marker, capture and record `q.overflow()` and `q.audit()`.
+2. Restore 1600 x 1000. Call `q.setTheme("dark")`, wait for
+   `#qa-settled-theme`, then `q.shot("14-04-novelwriter-dark")`, wait for its
+   settle marker, capture and record `q.audit()`.
+3. Restore the original theme with `q.restoreTheme()` and wait for
+   `#qa-settled-theme` before continuing.
+
+**Expect**: both prose columns wrap within the dialog; the footer and checkbox
+controls remain accessible at narrow width. In dark mode, body text has clear
+contrast against the dialog surfaces, and labels, selected controls and the
+scrim all follow the theme. Record any clipping or horizontal overflow.
+
+## 7. Accept one change, leave the other untouched (14-05)
+
+```js
+const q = window.__qa;
+const first = document.querySelector('[data-testid="sync-prose-diff"]');
+first.closest("label").querySelector('[data-testid="sync-change-checkbox"]').click();
+```
+
+Next call: assert exactly one checked `sync-change-checkbox`, then click
+`sync-confirm`. Wait for `[data-testid="sync-summary-dialog"]`. Assert the
+summary says one prose item updated and one preserved, then click
+`dialog-close`.
+
+Select Arrival if necessary; wait for its beats, then:
+
+```js
+const q = window.__qa;
+q.run([
+  ["14-retained-open", () => q.clickNth("beat-header", 1), 400],
+  [
+    "14-retained-check",
+    () =>
+      q.mark("14-retained", {
+        prose: q.getProse(),
+        expected: window.__qaNW.retained,
+      }),
+    0,
+  ],
+  ["14-updated-open", () => q.clickNth("beat-header", 0), 400],
+  [
+    "14-updated-check",
+    () =>
+      q.mark("14-updated", {
+        prose: q.getProse(),
+        expectedStart: "The harbor bell fell silent",
+      }),
+    0,
+  ],
+  [
+    "14-updated-shot",
+    () => {
+      q.shot("14-05-novelwriter-updated-editor");
+      q.done("14");
+    },
+    0,
+  ],
+]);
+```
+
+Wait for `#qa-done-14` and `#qa-settled-14-05-novelwriter-updated-editor`, then
+capture. **Assert**: the second beat still equals `retained`; the first starts
+with `expectedStart`. **Expect**: the accepted prose appears in the normal
+editor, prompts remain intact, and the other beat is still present.
+
+Run `get_sync_preview` again through `q.invoke`: exactly one prose change must
+remain, for the unaccepted second beat. Record `q.flush()` and `q.takeErrors()`.
+
+## Cleanup
+
+Close any dialog, restore the original theme and 1600 x 1000 window. Restore
+Simple Story before the usual sweeps (see scenario 13). At final cleanup,
+`q.cleanupFixtures()` deletes the seed and novelWriter imports by their captured
+IDs. Wait for successful cleanup before removing the exact temporary folder
+created in step 1. Do not delete other `/tmp` projects or change checked-in
+fixtures. A failed cleanup retains ownership for retry.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ rusqlite = { version = "0.38", features = ["bundled"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 quick-xml = "0.39"
+sha1 = "0.10"
 encoding_rs = "0.8"
 walkdir = "2"
 thiserror = "2"

--- a/src-tauri/src/commands/crud.rs
+++ b/src-tauri/src/commands/crud.rs
@@ -1405,15 +1405,32 @@ pub async fn reclassify_references(
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let conn = state.db.lock().map_err(|e| e.to_string())?;
 
+    reclassify_references_with_connection(&conn, project_uuid, &changes)
+}
+
+fn reclassify_references_with_connection(
+    conn: &rusqlite::Connection,
+    project_uuid: Uuid,
+    changes: &[ReferenceReclassification],
+) -> Result<Project, String> {
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
 
     let result: Result<Project, String> = (|| {
-        for change in &changes {
+        for change in changes {
             let reference_uuid =
                 Uuid::parse_str(&change.reference_id).map_err(|e| e.to_string())?;
             let target_type = change.new_type.trim().to_lowercase();
-            if target_type.is_empty() {
-                continue;
+            if !matches!(
+                target_type.as_str(),
+                "characters"
+                    | "locations"
+                    | "items"
+                    | "objectives"
+                    | "organizations"
+                    | "timelines"
+                    | "custom"
+            ) {
+                return Err(format!("Unknown reference type: {}", change.new_type));
             }
 
             let current_character =
@@ -1425,7 +1442,7 @@ pub async fn reclassify_references(
 
             let (current_type, scene_states) = if current_character.is_some() {
                 let states = db::get_scene_reference_states_for_reference(
-                    &conn,
+                    conn,
                     "characters",
                     &reference_uuid,
                 )
@@ -1433,7 +1450,7 @@ pub async fn reclassify_references(
                 ("characters".to_string(), states)
             } else if current_location.is_some() {
                 let states = db::get_scene_reference_states_for_reference(
-                    &conn,
+                    conn,
                     "locations",
                     &reference_uuid,
                 )
@@ -1441,7 +1458,7 @@ pub async fn reclassify_references(
                 ("locations".to_string(), states)
             } else if let Some(item) = &current_reference_item {
                 let states = db::get_scene_reference_states_for_reference(
-                    &conn,
+                    conn,
                     &item.reference_type,
                     &reference_uuid,
                 )
@@ -1466,14 +1483,14 @@ pub async fn reclassify_references(
 
             if !scene_states.is_empty() {
                 db::delete_scene_reference_states_for_reference(
-                    &conn,
+                    conn,
                     &current_type,
                     &reference_uuid,
                 )
                 .map_err(|e| e.to_string())?;
                 for state in &scene_states {
                     let max_position = db::get_scene_reference_state_max_position(
-                        &conn,
+                        conn,
                         &state.scene_id,
                         &target_type,
                     )
@@ -1512,7 +1529,7 @@ pub async fn reclassify_references(
                             }
                             db::delete_character(&tx, &character.id).map_err(|e| e.to_string())?;
                         }
-                        "items" | "objectives" | "organizations" => {
+                        "items" | "objectives" | "organizations" | "timelines" | "custom" => {
                             let item = ReferenceItem {
                                 id: character.id,
                                 project_id: character.project_id,
@@ -1554,7 +1571,7 @@ pub async fn reclassify_references(
                             }
                             db::delete_location(&tx, &location.id).map_err(|e| e.to_string())?;
                         }
-                        "items" | "objectives" | "organizations" => {
+                        "items" | "objectives" | "organizations" | "timelines" | "custom" => {
                             let item = ReferenceItem {
                                 id: location.id,
                                 project_id: location.project_id,
@@ -1616,7 +1633,7 @@ pub async fn reclassify_references(
                             db::delete_scene_reference_item_refs_for_item(&tx, &reference_uuid)
                                 .map_err(|e| e.to_string())?;
                         }
-                        "items" | "objectives" | "organizations" => {
+                        "items" | "objectives" | "organizations" | "timelines" | "custom" => {
                             db::update_reference_item_type(&tx, &item.id, &target_type)
                                 .map_err(|e| e.to_string())?;
                         }
@@ -1874,4 +1891,115 @@ pub async fn move_scene_to_chapter(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod reclassification_tests {
+    use super::*;
+    use crate::parsers::novelwriter::tests::fixture;
+
+    #[test]
+    fn reclassification_preserves_links_state_attributes_and_identity() {
+        for target in ["timelines", "custom"] {
+            for original in ["characters", "locations", "items"] {
+                let (conn, project) = fixture();
+                let (id, name) = match original {
+                    "characters" => {
+                        let c = db::get_characters(&conn, &project.id).unwrap().remove(0);
+                        (c.id, c.name)
+                    }
+                    "locations" => {
+                        let l = db::get_locations(&conn, &project.id).unwrap().remove(0);
+                        (l.id, l.name)
+                    }
+                    _ => {
+                        let r = db::get_all_reference_items(&conn, &project.id)
+                            .unwrap()
+                            .remove(0);
+                        (r.id, r.name)
+                    }
+                };
+                let scene = db::get_all_project_scenes(&conn, &project.id)
+                    .unwrap()
+                    .remove(0);
+                db::insert_scene_reference_state(
+                    &conn,
+                    &SceneReferenceState {
+                        scene_id: scene.id,
+                        reference_type: original.into(),
+                        reference_id: id,
+                        position: 0,
+                        expanded: true,
+                    },
+                )
+                .unwrap();
+                let result = reclassify_references_with_connection(
+                    &conn,
+                    project.id,
+                    &[ReferenceReclassification {
+                        reference_id: id.to_string(),
+                        new_type: target.into(),
+                    }],
+                )
+                .unwrap();
+                assert!(result.reference_types.contains(&target.to_string()));
+                let item = db::get_reference_item_by_id(&conn, &id).unwrap().unwrap();
+                assert_eq!(item.name, name);
+                assert!(!item.attributes.is_empty());
+                assert_eq!(item.reference_type, target);
+                assert_eq!(
+                    db::get_scene_ids_for_reference_item(&conn, &id).unwrap(),
+                    vec![scene.id]
+                );
+                let states =
+                    db::get_scene_reference_states_for_reference(&conn, target, &id).unwrap();
+                assert_eq!(states.len(), 1);
+                assert!(states[0].expanded);
+                reclassify_references_with_connection(
+                    &conn,
+                    project.id,
+                    &[ReferenceReclassification {
+                        reference_id: id.to_string(),
+                        new_type: "characters".into(),
+                    }],
+                )
+                .unwrap();
+                assert_eq!(
+                    db::get_scene_ids_for_character(&conn, &id).unwrap(),
+                    vec![scene.id]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_target_rolls_back_the_whole_batch_without_losing_links() {
+        let (conn, project) = fixture();
+        let character = db::get_characters(&conn, &project.id).unwrap().remove(0);
+        let before = db::get_scene_ids_for_character(&conn, &character.id).unwrap();
+        for target in ["", "not-a-type"] {
+            assert!(reclassify_references_with_connection(
+                &conn,
+                project.id,
+                &[
+                    ReferenceReclassification {
+                        reference_id: character.id.to_string(),
+                        new_type: "custom".into()
+                    },
+                    ReferenceReclassification {
+                        reference_id: character.id.to_string(),
+                        new_type: target.into()
+                    },
+                ]
+            )
+            .is_err());
+            assert!(db::get_character_by_id(&conn, &character.id)
+                .unwrap()
+                .is_some());
+            assert_eq!(
+                db::get_scene_ids_for_character(&conn, &character.id).unwrap(),
+                before
+            );
+        }
+    }
 }

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -588,192 +588,30 @@ fn transform_text(text: &str) -> String {
 ///
 /// Also applies smart quotes and punctuation normalization.
 fn parse_html_to_paragraphs(html: &str) -> Vec<FormattedParagraph> {
-    use quick_xml::events::Event;
-    use quick_xml::Reader;
-
-    let mut paragraphs: Vec<FormattedParagraph> = Vec::new();
-    let mut current_runs: Vec<FormattedRun> = Vec::new();
-    let mut bold_depth: u32 = 0;
-    let mut italic_depth: u32 = 0;
-    let mut underline_depth: u32 = 0;
-    let mut blockquote_depth: u32 = 0;
-    let mut current_para_type = ParagraphType::Normal;
-
-    let mut reader = Reader::from_str(html);
-    reader.config_mut().trim_text(false);
-
-    let mut buf = Vec::new();
-
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) => {
-                let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_lowercase();
-                match tag_name.as_str() {
-                    "strong" | "b" => bold_depth += 1,
-                    "em" | "i" => italic_depth += 1,
-                    "u" => underline_depth += 1,
-                    "blockquote" => {
-                        if !current_runs.is_empty() {
-                            paragraphs.push(FormattedParagraph {
-                                runs: std::mem::take(&mut current_runs),
-                                paragraph_type: current_para_type,
-                            });
-                        }
-                        blockquote_depth += 1;
-                        current_para_type = ParagraphType::Blockquote;
-                    }
-                    "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
-                        if !current_runs.is_empty() {
-                            paragraphs.push(FormattedParagraph {
-                                runs: std::mem::take(&mut current_runs),
-                                paragraph_type: current_para_type,
-                            });
-                        }
-                        let level = tag_name.as_bytes()[1] - b'0';
-                        current_para_type = ParagraphType::Heading(level);
-                    }
-                    "p" => {
-                        if !current_runs.is_empty() {
-                            paragraphs.push(FormattedParagraph {
-                                runs: std::mem::take(&mut current_runs),
-                                paragraph_type: current_para_type,
-                            });
-                        }
-                        current_para_type = if blockquote_depth > 0 {
-                            ParagraphType::Blockquote
-                        } else {
-                            ParagraphType::Normal
-                        };
-                    }
-                    _ => {}
-                }
-            }
-            Ok(Event::End(e)) => {
-                let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_lowercase();
-                match tag_name.as_str() {
-                    "strong" | "b" => bold_depth = bold_depth.saturating_sub(1),
-                    "em" | "i" => italic_depth = italic_depth.saturating_sub(1),
-                    "u" => underline_depth = underline_depth.saturating_sub(1),
-                    "blockquote" => {
-                        if !current_runs.is_empty() {
-                            paragraphs.push(FormattedParagraph {
-                                runs: std::mem::take(&mut current_runs),
-                                paragraph_type: current_para_type,
-                            });
-                        }
-                        blockquote_depth = blockquote_depth.saturating_sub(1);
-                        current_para_type = if blockquote_depth > 0 {
-                            ParagraphType::Blockquote
-                        } else {
-                            ParagraphType::Normal
-                        };
-                    }
-                    "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
-                        if !current_runs.is_empty() {
-                            paragraphs.push(FormattedParagraph {
-                                runs: std::mem::take(&mut current_runs),
-                                paragraph_type: current_para_type,
-                            });
-                        }
-                        current_para_type = if blockquote_depth > 0 {
-                            ParagraphType::Blockquote
-                        } else {
-                            ParagraphType::Normal
-                        };
-                    }
-                    "p" if !current_runs.is_empty() => {
-                        paragraphs.push(FormattedParagraph {
-                            runs: std::mem::take(&mut current_runs),
-                            paragraph_type: current_para_type,
-                        });
-                    }
-                    _ => {}
-                }
-            }
-            Ok(Event::Empty(e)) => {
-                let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_lowercase();
-                if tag_name == "br" {
-                    current_runs.push(FormattedRun {
-                        text: "\n".to_string(),
-                        bold: bold_depth > 0,
-                        italic: italic_depth > 0,
-                        underline: underline_depth > 0,
-                    });
-                }
-            }
-            Ok(Event::Text(e)) => {
-                let text = String::from_utf8_lossy(&e).to_string();
-                if !text.is_empty() {
-                    let transformed = transform_text(&text);
-                    if !transformed.is_empty() {
-                        current_runs.push(FormattedRun {
-                            text: transformed,
-                            bold: bold_depth > 0,
-                            italic: italic_depth > 0,
-                            underline: underline_depth > 0,
-                        });
-                    }
-                }
-            }
-            Ok(Event::GeneralRef(e)) => {
-                let entity = String::from_utf8_lossy(&e);
-                let decoded = match entity.as_ref() {
-                    "amp" => "&",
-                    "lt" => "<",
-                    "gt" => ">",
-                    "quot" => "\"",
-                    "apos" => "'",
-                    "nbsp" => " ",
-                    _ => "",
-                };
-                if !decoded.is_empty() {
-                    let transformed = transform_text(decoded);
-                    current_runs.push(FormattedRun {
-                        text: transformed,
-                        bold: bold_depth > 0,
-                        italic: italic_depth > 0,
-                        underline: underline_depth > 0,
-                    });
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => {
-                let plain = strip_html(html);
-                let transformed = transform_text(&plain);
-                if !transformed.is_empty() {
-                    return vec![FormattedParagraph {
-                        runs: vec![FormattedRun {
-                            text: transformed,
-                            bold: false,
-                            italic: false,
-                            underline: false,
-                        }],
-                        paragraph_type: ParagraphType::Normal,
-                    }];
-                }
-                return vec![];
-            }
-            _ => {}
-        }
-        buf.clear();
-    }
-
-    // Don't forget any remaining runs
-    if !current_runs.is_empty() {
-        paragraphs.push(FormattedParagraph {
-            runs: current_runs,
-            paragraph_type: current_para_type,
-        });
-    }
-
-    // Filter out empty paragraphs and merge adjacent runs with same formatting
-    paragraphs
+    use crate::parsers::html::{html_paragraphs, ParagraphKind};
+    html_paragraphs(html, transform_text)
         .into_iter()
-        .map(|p| FormattedParagraph {
-            runs: merge_adjacent_runs(p.runs),
-            paragraph_type: p.paragraph_type,
+        .map(|paragraph| {
+            let runs = paragraph
+                .runs
+                .into_iter()
+                .map(|run| FormattedRun {
+                    text: run.text,
+                    bold: run.marks[0],
+                    italic: run.marks[1],
+                    underline: run.marks[3],
+                })
+                .collect();
+            FormattedParagraph {
+                runs: merge_adjacent_runs(runs),
+                paragraph_type: match paragraph.kind {
+                    ParagraphKind::Normal => ParagraphType::Normal,
+                    ParagraphKind::Heading(level) => ParagraphType::Heading(level),
+                    ParagraphKind::Blockquote => ParagraphType::Blockquote,
+                },
+            }
         })
-        .filter(|p| !p.runs.is_empty() && p.runs.iter().any(|r| !r.text.trim().is_empty()))
+        .filter(|p| p.runs.iter().any(|r| !r.text.trim().is_empty()))
         .collect()
 }
 
@@ -1387,6 +1225,7 @@ fn generate_longform_scene_frontmatter(
     scene: &Scene,
     characters: &[String],
     setting: Option<&String>,
+    references: &std::collections::BTreeMap<String, Vec<String>>,
 ) -> Result<String, String> {
     #[derive(Serialize)]
     struct SceneFrontmatter {
@@ -1400,6 +1239,8 @@ fn generate_longform_scene_frontmatter(
         setting: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         synopsis: Option<String>,
+        #[serde(flatten)]
+        references: std::collections::BTreeMap<String, Vec<String>>,
     }
 
     let frontmatter = SceneFrontmatter {
@@ -1409,6 +1250,15 @@ fn generate_longform_scene_frontmatter(
         characters: characters.iter().map(|c| format_wikilink(c)).collect(),
         setting: setting.map(|name| format_wikilink(name)),
         synopsis: scene.synopsis.clone().filter(|s| !s.trim().is_empty()),
+        references: references
+            .iter()
+            .map(|(kind, names)| {
+                (
+                    kind.clone(),
+                    names.iter().map(|name| format_wikilink(name)).collect(),
+                )
+            })
+            .collect(),
     };
 
     let mut yaml = serde_yaml::to_string(&frontmatter).map_err(|e| e.to_string())?;
@@ -1425,8 +1275,10 @@ fn generate_longform_scene_markdown(
     beats: &[Beat],
     characters: &[String],
     setting: Option<&String>,
+    references: &std::collections::BTreeMap<String, Vec<String>>,
 ) -> Result<String, String> {
-    let mut content = generate_longform_scene_frontmatter(project, scene, characters, setting)?;
+    let mut content =
+        generate_longform_scene_frontmatter(project, scene, characters, setting, references)?;
 
     if !scene.title.trim().is_empty() {
         content.push_str(&format!("# {}\n\n", scene.title.trim()));
@@ -1514,10 +1366,14 @@ fn generate_reference_note_markdown(note: ReferenceNoteContent<'_>) -> Result<St
     extra.remove("notes");
     extra.remove("note");
 
+    let previous_appearance = extra.remove("first_appearance");
     let frontmatter = ReferenceFrontmatter {
         note_type: note.note_type.to_string(),
         role: note.role.cloned(),
-        first_appearance: note.first_appearance.map(|scene| format_wikilink(scene)),
+        first_appearance: note
+            .first_appearance
+            .map(|scene| format_wikilink(scene))
+            .or(previous_appearance),
         attributes: extra,
     };
 
@@ -1939,9 +1795,17 @@ pub async fn export_to_longform(
     }
 
     let conn = state.db.lock().map_err(|e| e.to_string())?;
-    let project = db::queries::get_project(&conn, &project_uuid)
+    export_to_longform_with_connection(&conn, project_uuid, options)
+}
+
+fn export_to_longform_with_connection(
+    conn: &rusqlite::Connection,
+    project_uuid: Uuid,
+    options: LongformExportOptions,
+) -> Result<ExportResult, String> {
+    let project = db::queries::get_project(conn, &project_uuid)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Project not found: {}", project_id))?;
+        .ok_or_else(|| format!("Project not found: {}", project_uuid))?;
 
     let output_base = PathBuf::from(&options.output_path);
     let export_name = options
@@ -1969,13 +1833,13 @@ pub async fn export_to_longform(
     match &options.scope {
         ExportScope::Project => {
             let chapters =
-                db::queries::get_chapters(&conn, &project_uuid).map_err(|e| e.to_string())?;
+                db::queries::get_chapters(conn, &project_uuid).map_err(|e| e.to_string())?;
             for chapter in chapters.iter().filter(|c| !c.archived) {
                 let scenes =
-                    db::queries::get_scenes(&conn, &chapter.id).map_err(|e| e.to_string())?;
+                    db::queries::get_scenes(conn, &chapter.id).map_err(|e| e.to_string())?;
                 for scene in scenes.into_iter().filter(|s| !s.archived) {
                     let beats =
-                        db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+                        db::queries::get_beats(conn, &scene.id).map_err(|e| e.to_string())?;
                     chapter_ids.insert(scene.chapter_id);
                     scenes_to_export.push((scene, beats));
                 }
@@ -1984,7 +1848,7 @@ pub async fn export_to_longform(
         ExportScope::Chapter(chapter_id) => {
             let chapter_uuid = Uuid::parse_str(chapter_id).map_err(|e| e.to_string())?;
             let chapters =
-                db::queries::get_chapters(&conn, &project_uuid).map_err(|e| e.to_string())?;
+                db::queries::get_chapters(conn, &project_uuid).map_err(|e| e.to_string())?;
             let chapter = chapters
                 .iter()
                 .find(|c| c.id == chapter_uuid)
@@ -1994,16 +1858,16 @@ pub async fn export_to_longform(
                 return Err("Cannot export an archived chapter".to_string());
             }
 
-            let scenes = db::queries::get_scenes(&conn, &chapter.id).map_err(|e| e.to_string())?;
+            let scenes = db::queries::get_scenes(conn, &chapter.id).map_err(|e| e.to_string())?;
             for scene in scenes.into_iter().filter(|s| !s.archived) {
-                let beats = db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+                let beats = db::queries::get_beats(conn, &scene.id).map_err(|e| e.to_string())?;
                 chapter_ids.insert(scene.chapter_id);
                 scenes_to_export.push((scene, beats));
             }
         }
         ExportScope::Scene(scene_id) => {
             let scene_uuid = Uuid::parse_str(scene_id).map_err(|e| e.to_string())?;
-            let scene = db::queries::get_scene_by_id(&conn, &scene_uuid)
+            let scene = db::queries::get_scene_by_id(conn, &scene_uuid)
                 .map_err(|e| e.to_string())?
                 .ok_or_else(|| format!("Scene not found: {}", scene_id))?;
 
@@ -2011,17 +1875,16 @@ pub async fn export_to_longform(
                 return Err("Cannot export an archived scene".to_string());
             }
 
-            let beats = db::queries::get_beats(&conn, &scene.id).map_err(|e| e.to_string())?;
+            let beats = db::queries::get_beats(conn, &scene.id).map_err(|e| e.to_string())?;
             chapter_ids.insert(scene.chapter_id);
             scenes_to_export.push((scene, beats));
         }
     }
 
-    let characters =
-        db::queries::get_characters(&conn, &project_uuid).map_err(|e| e.to_string())?;
-    let locations = db::queries::get_locations(&conn, &project_uuid).map_err(|e| e.to_string())?;
+    let characters = db::queries::get_characters(conn, &project_uuid).map_err(|e| e.to_string())?;
+    let locations = db::queries::get_locations(conn, &project_uuid).map_err(|e| e.to_string())?;
     let reference_items =
-        db::queries::get_all_reference_items(&conn, &project_uuid).map_err(|e| e.to_string())?;
+        db::queries::get_all_reference_items(conn, &project_uuid).map_err(|e| e.to_string())?;
     let mut character_map = HashMap::new();
     for character in characters {
         character_map.insert(character.id, character);
@@ -2035,12 +1898,12 @@ pub async fn export_to_longform(
         reference_item_map.insert(item.id, item);
     }
 
-    let scene_character_refs = db::queries::get_all_scene_character_refs(&conn, &project_uuid)
+    let scene_character_refs = db::queries::get_all_scene_character_refs(conn, &project_uuid)
         .map_err(|e| e.to_string())?;
-    let scene_location_refs = db::queries::get_all_scene_location_refs(&conn, &project_uuid)
-        .map_err(|e| e.to_string())?;
+    let scene_location_refs =
+        db::queries::get_all_scene_location_refs(conn, &project_uuid).map_err(|e| e.to_string())?;
     let scene_reference_item_refs =
-        db::queries::get_all_scene_reference_item_refs(&conn, &project_uuid)
+        db::queries::get_all_scene_reference_item_refs(conn, &project_uuid)
             .map_err(|e| e.to_string())?;
 
     let scene_ids: HashSet<Uuid> = scenes_to_export.iter().map(|(scene, _)| scene.id).collect();
@@ -2090,12 +1953,31 @@ pub async fn export_to_longform(
             .get(&scene.id)
             .and_then(|locations| locations.first())
             .and_then(|id| location_map.get(id).map(|l| l.name.clone()));
+        let mut reference_names = std::collections::BTreeMap::<String, Vec<String>>::new();
+        for id in scene_reference_item_map
+            .get(&scene.id)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(item) = reference_item_map.get(id) {
+                if matches!(
+                    item.reference_type.as_str(),
+                    "items" | "objectives" | "organizations" | "timelines" | "custom"
+                ) {
+                    reference_names
+                        .entry(item.reference_type.clone())
+                        .or_default()
+                        .push(item.name.clone());
+                }
+            }
+        }
         let markdown = generate_longform_scene_markdown(
             &project,
             scene,
             beats,
             &character_names,
             setting.as_ref(),
+            &reference_names,
         )
         .map_err(|e| format!("Failed to generate scene markdown: {}", e))?;
         fs::write(&scene_file, markdown)
@@ -2122,6 +2004,7 @@ pub async fn export_to_longform(
         let mut item_scene_map: HashMap<Uuid, Vec<String>> = HashMap::new();
         let mut objective_scene_map: HashMap<Uuid, Vec<String>> = HashMap::new();
         let mut organization_scene_map: HashMap<Uuid, Vec<String>> = HashMap::new();
+        let mut extra_scene_map: HashMap<Uuid, Vec<String>> = HashMap::new();
         let scene_order: Vec<(Uuid, String)> = scenes_to_export
             .iter()
             .map(|(scene, _)| (scene.id, scene.title.clone()))
@@ -2166,7 +2049,12 @@ pub async fn export_to_longform(
                                     .or_default()
                                     .push(scene_title.clone());
                             }
-                            _ => {}
+                            _ => {
+                                extra_scene_map
+                                    .entry(*reference_item_id)
+                                    .or_default()
+                                    .push(scene_title.clone());
+                            }
                         }
                     }
                 }
@@ -2191,7 +2079,9 @@ pub async fn export_to_longform(
                     "organizations" => {
                         organization_scene_map.entry(*item_id).or_default();
                     }
-                    _ => {}
+                    _ => {
+                        extra_scene_map.entry(*item_id).or_default();
+                    }
                 }
             }
         }
@@ -2367,6 +2257,37 @@ pub async fn export_to_longform(
                         .map_err(|e| format!("Failed to write organization note: {}", e))?;
                     reference_files_created += 1;
                 }
+            }
+        }
+        let mut used_extra_names = HashMap::new();
+        for (item_id, scenes) in extra_scene_map {
+            if let Some(item) = reference_item_map.get(&item_id) {
+                let (folder, note_type) = if item.reference_type == "timelines" {
+                    ("timelines", "timeline")
+                } else {
+                    ("notes", "custom")
+                };
+                let directory = project_folder.join(folder);
+                fs::create_dir_all(&directory).map_err(|e| e.to_string())?;
+                let names = used_extra_names.entry(folder).or_insert_with(HashMap::new);
+                let stem = ensure_unique_scene_stem(sanitize_filename(&item.name), names);
+                let markdown = generate_reference_note_markdown(ReferenceNoteContent {
+                    note_type,
+                    name: &item.name,
+                    description: item.description.as_ref(),
+                    notes: item
+                        .attributes
+                        .get("notes")
+                        .or_else(|| item.attributes.get("note")),
+                    role: None,
+                    first_appearance: scenes.first(),
+                    appearances: &scenes,
+                    attributes: &item.attributes,
+                })
+                .map_err(|e| e.to_string())?;
+                fs::write(directory.join(format!("{stem}.md")), markdown)
+                    .map_err(|e| e.to_string())?;
+                reference_files_created += 1;
             }
         }
     }
@@ -4889,6 +4810,161 @@ fn append_to_scrivx(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn longform_exports_timeline_and_custom_notes_for_project_and_scene_scopes() {
+        use crate::models::ReferenceItem;
+        let (conn, project) = crate::parsers::novelwriter::tests::fixture();
+        let scene = db::get_all_project_scenes(&conn, &project.id)
+            .unwrap()
+            .remove(0);
+        for kind in ["timelines", "custom"] {
+            for linked in [true, false] {
+                let mut item = ReferenceItem::new(
+                    project.id,
+                    kind.into(),
+                    format!("{kind}-{linked}"),
+                    Some("Preserved description.\n\nSecond paragraph.\n\n## Era\n\nAfter the subheading.".into()),
+                    None,
+                );
+                item.attributes.insert("Era".into(), "Ancient".into());
+                item.attributes.insert(
+                    "notes".into(),
+                    "Keep these notes.\n\nAnd this paragraph.".into(),
+                );
+                db::insert_reference_item(&conn, &item).unwrap();
+                if linked {
+                    db::add_scene_reference_item_ref(&conn, &scene.id, &item.id).unwrap();
+                }
+            }
+        }
+        for scope in [
+            ExportScope::Project,
+            ExportScope::Scene(scene.id.to_string()),
+        ] {
+            let all = matches!(scope, ExportScope::Project);
+            let temp = tempfile::tempdir().unwrap();
+            let result = export_to_longform_with_connection(
+                &conn,
+                project.id,
+                LongformExportOptions {
+                    scope,
+                    output_path: temp.path().to_string_lossy().into_owned(),
+                    export_name: None,
+                    delete_existing: false,
+                    create_snapshot: false,
+                },
+            )
+            .unwrap();
+            let index = std::path::Path::new(&result.output_path)
+                .join(format!("{}.md", sanitize_filename(&project.name)));
+            let parsed = crate::parsers::parse_longform_index(&index).unwrap();
+            for kind in ["timelines", "custom"] {
+                let notes: Vec<_> = parsed
+                    .reference_items
+                    .iter()
+                    .filter(|item| item.reference_type == kind)
+                    .collect();
+                assert_eq!(notes.len(), if all { 2 } else { 1 });
+                assert!(parsed.project.reference_types.contains(&kind.to_string()));
+                for note in notes {
+                    assert_eq!(
+                        note.description.as_deref(),
+                        Some("Preserved description.\n\nSecond paragraph.\n\n## Era\n\nAfter the subheading.")
+                    );
+                    assert_eq!(note.attributes["Era"], "Ancient");
+                    assert_eq!(
+                        note.attributes["notes"],
+                        "Keep these notes.\n\nAnd this paragraph."
+                    );
+                    assert!(note.source_id.is_some());
+                    let linked = parsed
+                        .scene_reference_item_refs
+                        .iter()
+                        .any(|(_, id)| *id == note.id);
+                    assert_eq!(linked, note.name.ends_with("true"));
+                }
+            }
+            // Persist the imported models and export again: a round trip must
+            // not emit duplicate frontmatter keys or drop notes on the next pass.
+            let imported_conn = rusqlite::Connection::open_in_memory().unwrap();
+            db::initialize_schema(&imported_conn).unwrap();
+            db::insert_project(&imported_conn, &parsed.project).unwrap();
+            for chapter in &parsed.chapters {
+                db::insert_chapter(&imported_conn, chapter).unwrap();
+            }
+            for scene in &parsed.scenes {
+                db::insert_scene(&imported_conn, scene).unwrap();
+            }
+            for beat in &parsed.beats {
+                db::insert_beat(&imported_conn, beat).unwrap();
+            }
+            for item in &parsed.reference_items {
+                db::insert_reference_item(&imported_conn, item).unwrap();
+            }
+            for (scene, item) in &parsed.scene_reference_item_refs {
+                db::add_scene_reference_item_ref(&imported_conn, scene, item).unwrap();
+            }
+            let second = tempfile::tempdir().unwrap();
+            let exported = export_to_longform_with_connection(
+                &imported_conn,
+                parsed.project.id,
+                LongformExportOptions {
+                    scope: ExportScope::Project,
+                    output_path: second.path().to_string_lossy().into_owned(),
+                    export_name: None,
+                    delete_existing: false,
+                    create_snapshot: false,
+                },
+            )
+            .unwrap();
+            let index = std::path::Path::new(&exported.output_path)
+                .join(format!("{}.md", sanitize_filename(&parsed.project.name)));
+            let again = crate::parsers::parse_longform_index(&index).unwrap();
+            for item in parsed
+                .reference_items
+                .iter()
+                .filter(|item| matches!(item.reference_type.as_str(), "timelines" | "custom"))
+            {
+                let other = again
+                    .reference_items
+                    .iter()
+                    .find(|r| r.name == item.name && r.reference_type == item.reference_type)
+                    .unwrap();
+                assert_eq!(other.description, item.description);
+                assert_eq!(other.attributes, item.attributes);
+                assert_eq!(other.source_id, item.source_id);
+                assert_eq!(
+                    again
+                        .scene_reference_item_refs
+                        .iter()
+                        .any(|(_, id)| *id == other.id),
+                    item.name.ends_with("true")
+                );
+            }
+            for (kind, folder) in [("timelines", "timelines"), ("custom", "notes")] {
+                let dir = std::path::Path::new(&result.output_path).join(folder);
+                assert_eq!(
+                    std::fs::read_dir(&dir).unwrap().count(),
+                    if all { 2 } else { 1 }
+                );
+                let text = std::fs::read_to_string(dir.join(format!("{kind}-true.md"))).unwrap();
+                assert!(text.contains("Preserved description"));
+                assert!(text.contains("Ancient"));
+                assert!(text.contains("Arrival"));
+            }
+        }
+    }
+
+    #[test]
+    fn manuscript_html_walker_preserves_imported_delimiters() {
+        let paragraphs =
+            parse_html_to_paragraphs("<p>Tom & Jerry saw 1 < 2.</p><p><b>Still here.</b></p>");
+        assert_eq!(paragraphs.len(), 2);
+        assert_eq!(paragraphs[0].runs[0].text, "Tom & Jerry saw 1 < 2.");
+        assert_eq!(paragraphs[1].runs[0].text, "Still here.");
+        assert!(paragraphs[1].runs[0].bold);
+    }
+
     use super::*;
 
     #[test]
@@ -5897,6 +5973,7 @@ mod tests {
             &[beat],
             &["Sarah".to_string()],
             Some(&"Downtown Cafe".to_string()),
+            &Default::default(),
         )
         .unwrap();
         assert!(markdown.starts_with("---"));
@@ -7303,4 +7380,51 @@ mod tests {
         assert_eq!(escape_xml("normal text"), "normal text");
         assert_eq!(escape_xml("a & b < c"), "a &amp; b &lt; c");
     }
+}
+
+#[tauri::command]
+pub async fn export_to_novelwriter(
+    project_id: String,
+    output_path: String,
+    options: crate::parsers::novelwriter::NovelWriterExportOptions,
+    app_handle: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ExportResult, String> {
+    if options.create_snapshot {
+        super::create_snapshot(
+            project_id.clone(),
+            super::CreateSnapshotOptions {
+                name: "Pre-novelWriter-export snapshot".into(),
+                description: Some("Automatic snapshot before novelWriter export".into()),
+                trigger_type: SnapshotTrigger::Export,
+            },
+            app_handle,
+            state.clone(),
+        )
+        .await?;
+    }
+    let id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let count = crate::parsers::novelwriter::export_novelwriter_project(
+        &conn,
+        &id,
+        std::path::Path::new(&output_path),
+        &options,
+    )?;
+    let chapters = db::get_chapters(&conn, &id).map_err(|e| e.to_string())?;
+    let chapter_ids: std::collections::HashSet<_> = chapters
+        .iter()
+        .filter(|c| !c.archived)
+        .map(|c| c.id)
+        .collect();
+    Ok(ExportResult {
+        output_path,
+        files_created: count + 1,
+        chapters_exported: chapter_ids.len(),
+        scenes_exported: db::get_all_project_scenes(&conn, &id)
+            .map_err(|e| e.to_string())?
+            .iter()
+            .filter(|s| !s.archived && chapter_ids.contains(&s.chapter_id))
+            .count(),
+    })
 }

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -73,6 +73,19 @@ pub async fn preview_import(path: String, format: String) -> Result<ImportPrevie
                 location_count: parsed.locations.len() as i32,
             }
         }
+        "novelwriter" => {
+            let p =
+                crate::parsers::novelwriter::parse_novelwriter_project(std::path::Path::new(&path))
+                    .map_err(|e| e.to_string())?;
+            ImportPreview {
+                project_name: p.project.name,
+                chapter_count: p.chapters.len() as i32,
+                scene_count: p.scenes.len() as i32,
+                beat_count: p.beats.len() as i32,
+                character_count: p.characters.len() as i32,
+                location_count: p.locations.len() as i32,
+            }
+        }
         "scrivener" => {
             let parsed =
                 parse_scrivener_bundle(std::path::Path::new(&path)).map_err(|e| e.to_string())?;
@@ -289,4 +302,53 @@ pub async fn import_scrivener(path: String, state: State<'_, AppState>) -> Resul
     tx.commit().map_err(|e| e.to_string())?;
 
     Ok(parsed.project)
+}
+
+#[tauri::command]
+pub async fn import_novelwriter(
+    path: String,
+    state: State<'_, AppState>,
+) -> Result<Project, String> {
+    let parsed =
+        crate::parsers::novelwriter::parse_novelwriter_project(std::path::Path::new(&path))
+            .map_err(|e| e.to_string())?;
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    insert_novelwriter(&conn, &parsed)?;
+    Ok(parsed.project)
+}
+
+pub(crate) fn insert_novelwriter(
+    conn: &rusqlite::Connection,
+    parsed: &crate::parsers::novelwriter::ParsedNovelWriter,
+) -> Result<(), String> {
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    db::insert_project(&tx, &parsed.project).map_err(|e| e.to_string())?;
+    for item in &parsed.chapters {
+        db::insert_chapter(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for item in &parsed.scenes {
+        db::insert_scene(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for item in &parsed.beats {
+        db::insert_beat(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for item in &parsed.characters {
+        db::insert_character(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for item in &parsed.locations {
+        db::insert_location(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for item in &parsed.reference_items {
+        db::insert_reference_item(&tx, item).map_err(|e| e.to_string())?;
+    }
+    for (scene, item) in &parsed.scene_character_refs {
+        db::add_scene_character_ref(&tx, scene, item).map_err(|e| e.to_string())?;
+    }
+    for (scene, item) in &parsed.scene_location_refs {
+        db::add_scene_location_ref(&tx, scene, item).map_err(|e| e.to_string())?;
+    }
+    for (scene, item) in &parsed.scene_reference_item_refs {
+        db::add_scene_reference_item_ref(&tx, scene, item).map_err(|e| e.to_string())?;
+    }
+    tx.commit().map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod feedback;
 mod fields;
 mod import;
 mod lock;
+mod novelwriter_sync;
 mod sample_project;
 mod screenplay_project;
 mod settings;

--- a/src-tauri/src/commands/novelwriter_sync.rs
+++ b/src-tauri/src/commands/novelwriter_sync.rs
@@ -1,0 +1,510 @@
+//! novelWriter adds user-reviewed prose to sync without changing the behavior of
+//! outline-only sources. Preview and apply share the same change construction.
+use super::sync::{ReimportSummary, SyncAddition, SyncChange, SyncPreview};
+use crate::{db, models::*, parsers::novelwriter::*};
+use rusqlite::Connection;
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+use uuid::Uuid;
+
+pub(super) fn load(_conn: &Connection, project: &Project) -> Result<ParsedNovelWriter, String> {
+    let path = project
+        .source_path
+        .as_deref()
+        .ok_or("Project has no novelWriter source folder")?;
+    let parsed = parse_novelwriter_project(Path::new(path)).map_err(|e| e.to_string())?;
+    Ok(parsed)
+}
+fn change(
+    out: &mut SyncPreview,
+    kind: &str,
+    id: Uuid,
+    title: &str,
+    field: &str,
+    before: &str,
+    after: &str,
+) {
+    if before != after {
+        out.changes.push(SyncChange {
+            id: format!("{kind}-{field}-{id}"),
+            item_type: kind.into(),
+            field: field.into(),
+            item_title: title.into(),
+            current_value: before.into(),
+            new_value: after.into(),
+            db_id: id.to_string(),
+        });
+    }
+}
+fn addition(out: &mut SyncPreview, kind: &str, source: &str, title: &str, parent: Option<&str>) {
+    out.additions.push(SyncAddition {
+        id: format!("{kind}-{source}"),
+        item_type: kind.into(),
+        title: title.into(),
+        parent_title: parent.map(str::to_string),
+    });
+}
+fn prose(value: Option<&str>) -> String {
+    html_to_nw(value.unwrap_or_default())
+}
+fn scene_prose(scene: &Scene, beats: &[Beat]) -> String {
+    if scene.editor_mode == EditorMode::Page {
+        return prose(scene.prose.as_deref());
+    }
+    let mut ordered: Vec<_> = beats.iter().filter(|b| b.scene_id == scene.id).collect();
+    ordered.sort_by_key(|b| b.position);
+    ordered
+        .iter()
+        .map(|b| prose(b.prose.as_deref()))
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+pub(super) fn preview(
+    conn: &Connection,
+    project: &Project,
+    parsed: &ParsedNovelWriter,
+) -> Result<SyncPreview, String> {
+    let chapters = db::get_chapters(conn, &project.id).map_err(|e| e.to_string())?;
+    let scenes = db::get_all_project_scenes(conn, &project.id).map_err(|e| e.to_string())?;
+    let beats = db::get_all_project_beats(conn, &project.id).map_err(|e| e.to_string())?;
+    let chapters_by_source: HashMap<_, _> = chapters
+        .iter()
+        .filter_map(|c| c.source_id.as_deref().map(|id| (id, c)))
+        .collect();
+    let scenes_by_source: HashMap<_, _> = scenes
+        .iter()
+        .filter_map(|s| s.source_id.as_deref().map(|id| (id, s)))
+        .collect();
+    let locked_chapters: HashSet<_> = chapters.iter().filter(|c| c.locked).map(|c| c.id).collect();
+    let mut beats_by_source = HashMap::new();
+    for beat in &beats {
+        if let Some(source) = beat.source_id.as_deref() {
+            if beats_by_source.insert(source, beat).is_some() {
+                return Err("Duplicate novelWriter beat identities. Import the source into a new project to review it safely; your current prose has been kept.".into());
+            }
+        }
+    }
+    let mut out = SyncPreview {
+        additions: vec![],
+        changes: vec![],
+    };
+    for chapter in &parsed.chapters {
+        let source = chapter.source_id.as_deref().unwrap();
+        let local_chapter = chapters_by_source.get(source).copied();
+        if local_chapter.is_some_and(|c| c.locked) {
+            continue;
+        }
+        if let Some(local) = local_chapter {
+            change(
+                &mut out,
+                "chapter",
+                local.id,
+                &local.title,
+                "title",
+                &local.title,
+                &chapter.title,
+            );
+        } else {
+            addition(&mut out, "chapter", source, &chapter.title, None);
+        }
+        for scene in parsed.scenes.iter().filter(|s| s.chapter_id == chapter.id) {
+            let source = scene.source_id.as_deref().unwrap();
+            let local = scenes_by_source.get(source).copied();
+            if local.is_some_and(|s| s.locked || locked_chapters.contains(&s.chapter_id)) {
+                continue;
+            }
+            if let Some(local) = local {
+                change(
+                    &mut out,
+                    "scene",
+                    local.id,
+                    &local.title,
+                    "title",
+                    &local.title,
+                    &scene.title,
+                );
+                change(
+                    &mut out,
+                    "scene",
+                    local.id,
+                    &local.title,
+                    "synopsis",
+                    local.synopsis.as_deref().unwrap_or_default(),
+                    scene.synopsis.as_deref().unwrap_or_default(),
+                );
+                if local.editor_mode == EditorMode::Page
+                    || !parsed.scenes_with_beat_comments.contains(source)
+                {
+                    change(
+                        &mut out,
+                        "scene",
+                        local.id,
+                        &local.title,
+                        "prose",
+                        &scene_prose(local, &beats),
+                        &prose(scene.prose.as_deref()),
+                    );
+                    // Unmarked text cannot identify or replace local planning beats.
+                    if !parsed.scenes_with_beat_comments.contains(source) {
+                        continue;
+                    }
+                }
+            } else {
+                addition(
+                    &mut out,
+                    "scene",
+                    source,
+                    &scene.title,
+                    Some(&chapter.title),
+                );
+            }
+            for beat in parsed.beats.iter().filter(|b| b.scene_id == scene.id) {
+                let source = beat.source_id.as_deref().unwrap();
+                if let Some(existing) = beats_by_source
+                    .get(source)
+                    .copied()
+                    .filter(|b| local.is_some_and(|s| s.id == b.scene_id))
+                {
+                    change(
+                        &mut out,
+                        "beat",
+                        existing.id,
+                        &existing.content,
+                        "content",
+                        &existing.content,
+                        &beat.content,
+                    );
+                    if local.is_some_and(|s| s.editor_mode == EditorMode::Beat) {
+                        change(
+                            &mut out,
+                            "beat",
+                            existing.id,
+                            &existing.content,
+                            "prose",
+                            &prose(existing.prose.as_deref()),
+                            &prose(beat.prose.as_deref()),
+                        );
+                    }
+                } else {
+                    addition(&mut out, "beat", source, &beat.content, Some(&scene.title));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+pub(super) fn apply(
+    conn: &Connection,
+    project: &Project,
+    parsed: &ParsedNovelWriter,
+    accepted: &[String],
+    additions: &[String],
+) -> Result<ReimportSummary, String> {
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    let preview = preview(&tx, project, parsed)?;
+    let accepted: HashSet<_> = accepted.iter().collect();
+    let additions: HashSet<_> = additions.iter().collect();
+    let available: HashSet<_> = preview.additions.iter().map(|a| &a.id).collect();
+    let mut summary = ReimportSummary {
+        chapters_added: 0,
+        chapters_updated: 0,
+        scenes_added: 0,
+        scenes_updated: 0,
+        beats_added: 0,
+        beats_updated: 0,
+        prose_preserved: 0,
+        prose_updated: 0,
+    };
+    let scenes: HashMap<_, _> = db::get_all_project_scenes(&tx, &project.id)
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .map(|s| (s.id, s))
+        .collect();
+    for change in preview.changes {
+        if !accepted.contains(&change.id) {
+            if change.field == "prose" {
+                summary.prose_preserved += 1;
+            }
+            continue;
+        }
+        let id = Uuid::parse_str(&change.db_id).map_err(|e| e.to_string())?;
+        if change.field == "prose" {
+            let html = nw_to_html(&change.new_value);
+            if change.item_type == "beat" {
+                db::update_beat_prose(&tx, &id, &html).map_err(|e| e.to_string())?;
+            } else {
+                let scene = scenes.get(&id).ok_or("Scene no longer exists")?;
+                if scene.editor_mode == EditorMode::Page {
+                    db::update_scene_prose(&tx, &id, &html).map_err(|e| e.to_string())?;
+                } else {
+                    // A single accepted scene replacement has no beat boundaries.
+                    // Keep planning beats and mode; place text in the first beat
+                    // and clear the remaining prose as part of that same choice.
+                    let beats = db::get_beats(&tx, &id).map_err(|e| e.to_string())?;
+                    if beats.is_empty() {
+                        let mut beat = Beat::new(id, "Scene Content".into(), 0);
+                        beat.prose = Some(html);
+                        beat.source_id = scene
+                            .source_id
+                            .as_deref()
+                            .map(|s| novelwriter_beat_source_id(s, 0));
+                        db::insert_beat(&tx, &beat).map_err(|e| e.to_string())?;
+                    } else {
+                        for (i, beat) in beats.iter().enumerate() {
+                            db::update_beat_prose(&tx, &beat.id, if i == 0 { &html } else { "" })
+                                .map_err(|e| e.to_string())?;
+                        }
+                    }
+                }
+            }
+            summary.prose_updated += 1;
+        } else {
+            // The table/column pair comes exclusively from our own preview.
+            let (table, column) = match (change.item_type.as_str(), change.field.as_str()) {
+                ("chapter", "title") => {
+                    summary.chapters_updated += 1;
+                    ("chapters", "title")
+                }
+                ("scene", "title") => {
+                    summary.scenes_updated += 1;
+                    ("scenes", "title")
+                }
+                ("scene", "synopsis") => {
+                    summary.scenes_updated += 1;
+                    ("scenes", "synopsis")
+                }
+                ("beat", "content") => {
+                    summary.beats_updated += 1;
+                    ("beats", "content")
+                }
+                _ => return Err("Unknown novelWriter sync field".into()),
+            };
+            tx.execute(
+                &format!("UPDATE {table} SET {column} = ?1 WHERE id = ?2"),
+                rusqlite::params![change.new_value, id.to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+    }
+    let mut chapter_ids = HashMap::new();
+    for c in &parsed.chapters {
+        let source = c.source_id.as_deref().unwrap();
+        if let Some(existing) =
+            db::find_chapter_by_source_id(&tx, &project.id, source).map_err(|e| e.to_string())?
+        {
+            chapter_ids.insert(c.id, existing.id);
+        } else {
+            let key = format!("chapter-{source}");
+            if additions.contains(&key) && available.contains(&key) {
+                let mut c = c.clone();
+                c.project_id = project.id;
+                db::insert_chapter(&tx, &c).map_err(|e| e.to_string())?;
+                chapter_ids.insert(c.id, c.id);
+                summary.chapters_added += 1;
+            }
+        }
+    }
+    let mut scene_ids = HashMap::new();
+    for s in &parsed.scenes {
+        let Some(chapter) = chapter_ids.get(&s.chapter_id) else {
+            continue;
+        };
+        let source = s.source_id.as_deref().unwrap();
+        if let Some(existing) =
+            db::find_scene_by_source_id(&tx, chapter, source).map_err(|e| e.to_string())?
+        {
+            scene_ids.insert(s.id, existing.id);
+        } else {
+            let key = format!("scene-{source}");
+            if additions.contains(&key) && available.contains(&key) {
+                let mut s = s.clone();
+                s.chapter_id = *chapter;
+                db::insert_scene(&tx, &s).map_err(|e| e.to_string())?;
+                scene_ids.insert(s.id, s.id);
+                summary.scenes_added += 1;
+            }
+        }
+    }
+    for b in &parsed.beats {
+        let Some(scene) = scene_ids.get(&b.scene_id) else {
+            continue;
+        };
+        let key = format!("beat-{}", b.source_id.as_deref().unwrap());
+        if additions.contains(&key) && available.contains(&key) {
+            let mut b = b.clone();
+            b.scene_id = *scene;
+            db::insert_beat(&tx, &b).map_err(|e| e.to_string())?;
+            summary.beats_added += 1;
+        }
+    }
+    db::update_project_modified(&tx, &project.id).map_err(|e| e.to_string())?;
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parsers::novelwriter::tests::fixture;
+    fn imported() -> (Connection, Project, tempfile::TempDir) {
+        let (conn, project) = fixture();
+        let temp = tempfile::tempdir().unwrap();
+        export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default()).unwrap();
+        let parsed = parse_novelwriter_project(temp.path()).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        super::super::import::insert_novelwriter(&conn, &parsed).unwrap();
+        (conn, parsed.project, temp)
+    }
+    #[test]
+    fn selective_prose_sync_and_locks() {
+        let (conn, project, _temp) = imported();
+        let mut parsed = load(&conn, &project).unwrap();
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap()
+            .changes
+            .is_empty());
+        let local = db::get_all_project_beats(&conn, &project.id).unwrap();
+        // TipTap representation changes alone do not produce false prose changes.
+        db::update_beat_prose(
+            &conn,
+            &local[0].id,
+            &local[0]
+                .prose
+                .clone()
+                .unwrap()
+                .replace("strong", "b")
+                .replace("em>", "i>"),
+        )
+        .unwrap();
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap()
+            .changes
+            .is_empty());
+        parsed.beats[0].prose = Some("<p>The visitor called.</p>".into());
+        parsed.beats[1].prose = Some("<p>Unaccepted.</p>".into());
+        let changes = preview(&conn, &project, &parsed).unwrap().changes;
+        assert_eq!(changes.len(), 2);
+        assert!(changes.iter().all(|c| c.field == "prose"));
+        let summary = apply(&conn, &project, &parsed, &[changes[0].id.clone()], &[]).unwrap();
+        assert_eq!((summary.prose_updated, summary.prose_preserved), (1, 1));
+        let updated = db::get_all_project_beats(&conn, &project.id).unwrap();
+        assert_eq!(
+            updated[0].prose.as_deref(),
+            Some("<p>The visitor called.</p>")
+        );
+        assert_eq!(updated[1].prose, local[1].prose);
+        conn.execute("UPDATE chapters SET locked = 1", []).unwrap();
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap()
+            .changes
+            .is_empty());
+        assert_eq!(
+            apply(&conn, &project, &parsed, &[changes[1].id.clone()], &[])
+                .unwrap()
+                .prose_updated,
+            0
+        );
+        conn.execute("UPDATE chapters SET locked = 0", []).unwrap();
+        conn.execute("UPDATE scenes SET locked = 1", []).unwrap();
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap()
+            .changes
+            .is_empty());
+    }
+    #[test]
+    fn page_and_unmarked_scene_prose_use_correct_home() {
+        let (conn, project, temp) = imported();
+        let mut parsed = load(&conn, &project).unwrap();
+        let local = db::get_all_project_scenes(&conn, &project.id)
+            .unwrap()
+            .remove(0);
+        conn.execute(
+            "UPDATE scenes SET editor_mode = 'page', prose = '<p>Local page</p>' WHERE id = ?1",
+            [local.id.to_string()],
+        )
+        .unwrap();
+        parsed.scenes[0].prose = Some("<p>Incoming page</p>".into());
+        let changes = preview(&conn, &project, &parsed).unwrap().changes;
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].item_type, "scene");
+        apply(&conn, &project, &parsed, &[changes[0].id.clone()], &[]).unwrap();
+        let scene = db::get_all_project_scenes(&conn, &project.id)
+            .unwrap()
+            .remove(0);
+        assert_eq!(scene.editor_mode, EditorMode::Page);
+        assert_eq!(scene.prose.as_deref(), Some("<p>Incoming page</p>"));
+        conn.execute("UPDATE scenes SET editor_mode = 'beat'", [])
+            .unwrap();
+        let handle = local.source_id.unwrap();
+        let file = temp.path().join("content").join(format!("{handle}.md"));
+        std::fs::write(file, "### Arrival\n%Synopsis: A stranger arrives.\n%Synopsis: At midnight.\n\nWhole replacement.\n").unwrap();
+        let parsed = load(&conn, &project).unwrap();
+        let diff = preview(&conn, &project, &parsed).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert!(diff.additions.is_empty());
+        assert_eq!(diff.changes[0].item_type, "scene");
+        apply(&conn, &project, &parsed, &[diff.changes[0].id.clone()], &[]).unwrap();
+        let beats = db::get_beats(&conn, &scene.id).unwrap();
+        assert_eq!(beats.len(), 2);
+        assert_eq!(beats[0].prose.as_deref(), Some("<p>Whole replacement.</p>"));
+        assert_eq!(beats[1].prose.as_deref(), Some(""));
+        assert_eq!(
+            db::get_all_project_scenes(&conn, &project.id).unwrap()[0].editor_mode,
+            EditorMode::Beat
+        );
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap()
+            .changes
+            .is_empty());
+    }
+    #[test]
+    fn split_beats_remain_local_and_preview_never_backfills() {
+        let (conn, project, temp) = imported();
+        let beats = db::get_all_project_beats(&conn, &project.id).unwrap();
+        let scene = beats[0].scene_id;
+        db::shift_beat_positions(&conn, &scene, 1).unwrap();
+        let mut split = Beat::new(scene, "Split off locally".into(), 1);
+        split.prose = Some("<p>Keep this local prose.</p>".into());
+        db::insert_beat(&conn, &split).unwrap();
+        let mut parsed = load(&conn, &project).unwrap();
+        parsed.beats[1].prose = Some("<p>Incoming second beat.</p>".into());
+        for _ in 0..2 {
+            let changes = preview(&conn, &project, &parsed).unwrap().changes;
+            assert_eq!(changes.len(), 1);
+            assert_eq!(changes[0].db_id, beats[1].id.to_string());
+            assert!(db::get_beat(&conn, &split.id)
+                .unwrap()
+                .unwrap()
+                .source_id
+                .is_none());
+        }
+        let changes = preview(&conn, &project, &parsed).unwrap().changes;
+        apply(&conn, &project, &parsed, &[changes[0].id.clone()], &[]).unwrap();
+        assert_eq!(
+            db::get_beat(&conn, &split.id).unwrap().unwrap().prose,
+            split.prose
+        );
+        assert_eq!(
+            db::get_beat(&conn, &beats[1].id)
+                .unwrap()
+                .unwrap()
+                .prose
+                .as_deref(),
+            Some("<p>Incoming second beat.</p>")
+        );
+        db::update_beat_source_id(&conn, &split.id, beats[1].source_id.as_deref().unwrap())
+            .unwrap();
+        assert!(preview(&conn, &project, &parsed)
+            .unwrap_err()
+            .contains("Duplicate"));
+        assert!(apply(&conn, &project, &parsed, &[changes[0].id.clone()], &[]).is_err());
+        std::fs::remove_file(temp.path().join("nwProject.nwx")).unwrap();
+        assert!(load(&conn, &project).unwrap_err().contains("nwProject.nwx"));
+    }
+}

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -28,6 +28,7 @@ pub struct ReimportSummary {
     pub beats_added: i32,
     pub beats_updated: i32,
     pub prose_preserved: i32,
+    pub prose_updated: i32,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -66,9 +67,15 @@ pub async fn reimport_project(
 ) -> Result<ReimportSummary, String> {
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let conn = state.db.lock().map_err(|e| e.to_string())?;
+    reimport_project_with_connection(&conn, project_uuid)
+}
 
+fn reimport_project_with_connection(
+    conn: &Connection,
+    project_uuid: Uuid,
+) -> Result<ReimportSummary, String> {
     // Get the existing project to find source path and type
-    let project = db::get_project(&conn, &project_uuid)
+    let project = db::get_project(conn, &project_uuid)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "Project not found".to_string())?;
 
@@ -78,7 +85,7 @@ pub async fn reimport_project(
         .ok_or_else(|| "Project has no source path for reimport".to_string())?;
 
     if matches!(project.source_type, crate::models::SourceType::Markdown) {
-        ensure_markdown_source_ids(&conn, &project_uuid)?;
+        ensure_markdown_source_ids(conn, &project_uuid)?;
     }
 
     // Re-parse the source file based on source type
@@ -132,6 +139,26 @@ pub async fn reimport_project(
                 scene_location_refs: Vec::new(),
             }
         }
+        crate::models::SourceType::NovelWriter => {
+            let parsed = super::novelwriter_sync::load(conn, &project)?;
+            let preview = super::novelwriter_sync::preview(conn, &project, &parsed)?;
+            return super::novelwriter_sync::apply(
+                conn,
+                &project,
+                &parsed,
+                &preview
+                    .changes
+                    .into_iter()
+                    .filter(|c| c.field != "prose")
+                    .map(|c| c.id)
+                    .collect::<Vec<_>>(),
+                &preview
+                    .additions
+                    .into_iter()
+                    .map(|a| a.id)
+                    .collect::<Vec<_>>(),
+            );
+        }
         crate::models::SourceType::Blank => {
             return Err("Blank projects have no source to reimport".to_string());
         }
@@ -145,6 +172,7 @@ pub async fn reimport_project(
         beats_added: 0,
         beats_updated: 0,
         prose_preserved: 0,
+        prose_updated: 0,
     };
 
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
@@ -157,13 +185,8 @@ pub async fn reimport_project(
                 .map_err(|e| e.to_string())?
             {
                 // Update existing chapter
-                db::update_chapter(
-                    &conn,
-                    &existing.id,
-                    &new_chapter.title,
-                    new_chapter.position,
-                )
-                .map_err(|e| e.to_string())?;
+                db::update_chapter(conn, &existing.id, &new_chapter.title, new_chapter.position)
+                    .map_err(|e| e.to_string())?;
                 summary.chapters_updated += 1;
             } else {
                 // Insert new chapter with project's actual UUID
@@ -217,7 +240,7 @@ pub async fn reimport_project(
             {
                 // Update existing scene (preserving prose!)
                 db::update_scene(
-                    &conn,
+                    conn,
                     &existing.id,
                     &new_scene.title,
                     new_scene.synopsis.as_deref(),
@@ -318,9 +341,15 @@ pub async fn get_sync_preview(
 ) -> Result<SyncPreview, String> {
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let conn = state.db.lock().map_err(|e| e.to_string())?;
+    get_sync_preview_with_connection(&conn, project_uuid)
+}
 
+fn get_sync_preview_with_connection(
+    conn: &Connection,
+    project_uuid: Uuid,
+) -> Result<SyncPreview, String> {
     // Get the existing project to find source path and type
-    let project = db::get_project(&conn, &project_uuid)
+    let project = db::get_project(conn, &project_uuid)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "Project not found".to_string())?;
 
@@ -378,6 +407,10 @@ pub async fn get_sync_preview(
                 scene_location_refs: Vec::new(),
             }
         }
+        crate::models::SourceType::NovelWriter => {
+            let parsed = super::novelwriter_sync::load(conn, &project)?;
+            return super::novelwriter_sync::preview(conn, &project, &parsed);
+        }
         crate::models::SourceType::Blank => {
             return Err("Blank projects have no source to reimport".to_string());
         }
@@ -389,7 +422,7 @@ pub async fn get_sync_preview(
     };
 
     // Get existing DB data
-    let db_chapters = db::get_chapters(&conn, &project_uuid).map_err(|e| e.to_string())?;
+    let db_chapters = db::get_chapters(conn, &project_uuid).map_err(|e| e.to_string())?;
     let chapter_source_to_db: HashMap<String, &Chapter> = db_chapters
         .iter()
         .filter_map(|c| c.source_id.as_ref().map(|sid| (sid.clone(), c)))
@@ -432,7 +465,7 @@ pub async fn get_sync_preview(
     }
 
     // Get all scenes for the project
-    let db_scenes = db::get_all_project_scenes(&conn, &project_uuid).map_err(|e| e.to_string())?;
+    let db_scenes = db::get_all_project_scenes(conn, &project_uuid).map_err(|e| e.to_string())?;
     let scene_source_to_db: HashMap<String, &Scene> = db_scenes
         .iter()
         .filter_map(|s| s.source_id.as_ref().map(|sid| (sid.clone(), s)))
@@ -514,7 +547,7 @@ pub async fn get_sync_preview(
     }
 
     // Get all beats for the project
-    let db_beats = db::get_all_project_beats(&conn, &project_uuid).map_err(|e| e.to_string())?;
+    let db_beats = db::get_all_project_beats(conn, &project_uuid).map_err(|e| e.to_string())?;
     let beat_source_to_db: HashMap<String, &Beat> = db_beats
         .iter()
         .filter_map(|b| b.source_id.as_ref().map(|sid| (sid.clone(), b)))
@@ -652,9 +685,22 @@ pub async fn apply_sync(
 ) -> Result<ReimportSummary, String> {
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let conn = state.db.lock().map_err(|e| e.to_string())?;
+    apply_sync_with_connection(
+        &conn,
+        project_uuid,
+        accepted_change_ids,
+        accepted_addition_ids,
+    )
+}
 
+fn apply_sync_with_connection(
+    conn: &Connection,
+    project_uuid: Uuid,
+    accepted_change_ids: Vec<String>,
+    accepted_addition_ids: Vec<String>,
+) -> Result<ReimportSummary, String> {
     // Get the existing project to find source path and type
-    let project = db::get_project(&conn, &project_uuid)
+    let project = db::get_project(conn, &project_uuid)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "Project not found".to_string())?;
 
@@ -712,6 +758,16 @@ pub async fn apply_sync(
                 scene_location_refs: Vec::new(),
             }
         }
+        crate::models::SourceType::NovelWriter => {
+            let parsed = super::novelwriter_sync::load(conn, &project)?;
+            return super::novelwriter_sync::apply(
+                conn,
+                &project,
+                &parsed,
+                &accepted_change_ids,
+                &accepted_addition_ids,
+            );
+        }
         crate::models::SourceType::Blank => {
             return Err("Blank projects have no source to reimport".to_string());
         }
@@ -728,6 +784,7 @@ pub async fn apply_sync(
         beats_added: 0,
         beats_updated: 0,
         prose_preserved: 0,
+        prose_updated: 0,
     };
 
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
@@ -747,7 +804,7 @@ pub async fn apply_sync(
                 let change_id = format!("chapter-title-{}", existing.id);
                 if accepted_set.contains(&change_id) && existing.title != new_chapter.title {
                     db::update_chapter(
-                        &conn,
+                        conn,
                         &existing.id,
                         &new_chapter.title,
                         new_chapter.position,
@@ -833,7 +890,7 @@ pub async fn apply_sync(
 
                 if updated {
                     db::update_scene(
-                        &conn,
+                        conn,
                         &existing.id,
                         &new_title,
                         new_synopsis.as_deref(),
@@ -961,5 +1018,127 @@ mod tests {
     fn test_truncate_string_longer_than_limit() {
         let input = "This is a longer string";
         assert_eq!(truncate_string(input, 4), "This...");
+    }
+}
+
+#[cfg(test)]
+mod source_regression_tests {
+    use super::*;
+    use crate::models::Project;
+
+    fn exercise(project: Project, chapters: Vec<Chapter>, scenes: Vec<Scene>, beats: Vec<Beat>) {
+        let conn = Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        db::insert_project(&conn, &project).unwrap();
+        for c in &chapters {
+            db::insert_chapter(&conn, c).unwrap();
+        }
+        for s in &scenes {
+            db::insert_scene(&conn, s).unwrap();
+        }
+        for b in &beats {
+            db::insert_beat(&conn, b).unwrap();
+        }
+        for s in &scenes {
+            db::update_scene_prose(&conn, &s.id, "<p>Local page prose</p>").unwrap();
+        }
+        for b in &beats {
+            db::update_beat_prose(&conn, &b.id, "<p>Local beat prose</p>").unwrap();
+        }
+        let preview = get_sync_preview_with_connection(&conn, project.id).unwrap();
+        assert!(preview.changes.iter().all(|c| c.field != "prose"));
+        let chapter = chapters.iter().find(|c| c.source_id.is_some()).unwrap();
+        conn.execute(
+            "UPDATE chapters SET title = 'Local title' WHERE id = ?1",
+            [chapter.id.to_string()],
+        )
+        .unwrap();
+        let preview = get_sync_preview_with_connection(&conn, project.id).unwrap();
+        let title = preview
+            .changes
+            .iter()
+            .find(|c| c.db_id == chapter.id.to_string())
+            .unwrap();
+        assert_eq!(
+            (&title.field, &title.current_value, &title.new_value),
+            (&"title".into(), &"Local title".into(), &chapter.title)
+        );
+        let summary =
+            apply_sync_with_connection(&conn, project.id, vec![title.id.clone()], vec![]).unwrap();
+        assert_eq!(summary.chapters_updated, 1);
+        assert_eq!(summary.prose_updated, 0);
+        // The serialized contract for old sources has no new summary field.
+        assert!(serde_json::to_value(&summary)
+            .unwrap()
+            .get("prose_updated")
+            .is_some());
+        reimport_project_with_connection(&conn, project.id).unwrap();
+        for s in db::get_all_project_scenes(&conn, &project.id).unwrap() {
+            assert_eq!(s.prose.as_deref(), Some("<p>Local page prose</p>"));
+        }
+        for b in db::get_all_project_beats(&conn, &project.id).unwrap() {
+            assert_eq!(b.prose.as_deref(), Some("<p>Local beat prose</p>"));
+        }
+    }
+    #[test]
+    fn existing_sources_never_diff_or_overwrite_prose() {
+        let fixtures = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+        let p = parse_plottr_file(fixtures.join("hamlet.pltr")).unwrap();
+        exercise(p.project, p.chapters, p.scenes, p.beats);
+        let p = parse_ywriter_file(fixtures.join("hamlet.yw7")).unwrap();
+        exercise(p.project, p.chapters, p.scenes, p.beats);
+        let p = parse_markdown_outline(fixtures.join("hamlet.md")).unwrap();
+        exercise(p.project, p.chapters, p.scenes, p.beats);
+        let temp = tempfile::tempdir().unwrap();
+        let index = temp.path().join("Index.md");
+        std::fs::write(&index, "---\nlongform:\n  format: scenes\n  title: Test\n  sceneFolder: /\n  scenes:\n    - Opening\n---\n").unwrap();
+        std::fs::write(
+            temp.path().join("Opening.md"),
+            "Incoming prose.\n\n<!-- kindling: beats -->\n- First beat\n",
+        )
+        .unwrap();
+        let p = parse_longform_index(&index).unwrap();
+        exercise(p.project, p.chapters, p.scenes, p.beats);
+    }
+    #[test]
+    fn novelwriter_all_three_commands_dispatch_and_reimport_preserves_prose() {
+        let (original, project) = crate::parsers::novelwriter::tests::fixture();
+        let temp = tempfile::tempdir().unwrap();
+        crate::parsers::novelwriter::export_novelwriter_project(
+            &original,
+            &project.id,
+            temp.path(),
+            &Default::default(),
+        )
+        .unwrap();
+        let parsed = crate::parsers::novelwriter::parse_novelwriter_project(temp.path()).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        super::super::import::insert_novelwriter(&conn, &parsed).unwrap();
+        let project = parsed.project;
+        let beat = &parsed.beats[0];
+        db::update_beat_prose(&conn, &beat.id, "<p>Local draft</p>").unwrap();
+        let preview = get_sync_preview_with_connection(&conn, project.id).unwrap();
+        assert_eq!(preview.changes.len(), 1);
+        assert_eq!(preview.changes[0].field, "prose");
+        reimport_project_with_connection(&conn, project.id).unwrap();
+        assert_eq!(
+            db::get_beats(&conn, &beat.scene_id).unwrap()[0]
+                .prose
+                .as_deref(),
+            Some("<p>Local draft</p>")
+        );
+        let summary = apply_sync_with_connection(
+            &conn,
+            project.id,
+            vec![preview.changes[0].id.clone()],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(summary.prose_updated, 1);
+        assert!(get_sync_preview_with_connection(&conn, project.id)
+            .unwrap()
+            .changes
+            .is_empty());
     }
 }

--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -1298,6 +1298,8 @@ pub fn get_scene_reference_states_for_reference(
     Ok(states)
 }
 
+// MAX always returns a row; NULL means this scene/category has no saved state.
+// Decode the column as Option<i32> rather than treating absence of rows as None.
 pub fn get_scene_reference_state_max_position(
     conn: &Connection,
     scene_id: &Uuid,
@@ -1308,7 +1310,6 @@ pub fn get_scene_reference_state_max_position(
         params![scene_id.to_string(), reference_type],
         |row| row.get(0),
     )
-    .optional()
 }
 
 pub fn insert_scene_reference_state(conn: &Connection, state: &SceneReferenceState) -> Result<()> {
@@ -2606,6 +2607,69 @@ mod tests {
     // ========================================================================
     // Project Tests
     // ========================================================================
+
+    #[test]
+    fn reference_state_max_position_handles_null_and_scopes() {
+        let conn = setup_test_db();
+        let project = create_test_project(&conn);
+        let chapter = create_test_chapter(&conn, project.id);
+        let scene = create_test_scene(&conn, chapter.id);
+        let other = create_test_scene(&conn, chapter.id);
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &scene.id, "timelines").unwrap(),
+            None
+        );
+        for (scene_id, reference_type, position) in [
+            (scene.id, "timelines", 0),
+            (scene.id, "timelines", 3),
+            (scene.id, "custom", 9),
+            (other.id, "timelines", 12),
+        ] {
+            insert_scene_reference_state(
+                &conn,
+                &SceneReferenceState {
+                    scene_id,
+                    reference_type: reference_type.into(),
+                    reference_id: Uuid::new_v4(),
+                    position,
+                    expanded: false,
+                },
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &scene.id, "timelines").unwrap(),
+            Some(3)
+        );
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &scene.id, "custom").unwrap(),
+            Some(9)
+        );
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &other.id, "timelines").unwrap(),
+            Some(12)
+        );
+        delete_scene_reference_states_for_type(&conn, &scene.id, "timelines").unwrap();
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &scene.id, "timelines").unwrap(),
+            None
+        );
+        insert_scene_reference_state(
+            &conn,
+            &SceneReferenceState {
+                scene_id: scene.id,
+                reference_type: "timelines".into(),
+                reference_id: Uuid::new_v4(),
+                position: 0,
+                expanded: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            get_scene_reference_state_max_position(&conn, &scene.id, "timelines").unwrap(),
+            Some(0)
+        );
+    }
 
     #[test]
     fn test_insert_and_get_project() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
             commands::import_markdown,
             commands::import_longform,
             commands::import_scrivener,
+            commands::import_novelwriter,
             commands::preview_import,
             commands::create_sample_project,
             commands::create_blank_project,
@@ -213,6 +214,7 @@ pub fn run() {
             commands::generate_treatment,
             commands::preview_scrivener_matches,
             commands::export_to_scrivener,
+            commands::export_to_novelwriter,
             // Snapshot commands
             commands::create_snapshot,
             commands::list_snapshots,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -20,6 +20,7 @@ pub mod menu_ids {
     pub const IMPORT_YWRITER: &str = "import_ywriter";
     pub const IMPORT_MARKDOWN: &str = "import_markdown";
     pub const IMPORT_LONGFORM: &str = "import_longform";
+    pub const IMPORT_NOVELWRITER: &str = "import_novelwriter";
     pub const IMPORT_SCRIVENER: &str = "import_scrivener";
     pub const EXPORT: &str = "export";
     pub const CLOSE_PROJECT: &str = "close_project";
@@ -63,12 +64,17 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .accelerator("CmdOrCtrl+Shift+I")
         .build(app)?;
 
+    let import_novelwriter = MenuItemBuilder::new("novelWriter (Project Folder)")
+        .id(menu_ids::IMPORT_NOVELWRITER)
+        .build(app)?;
+
     let import_submenu = SubmenuBuilder::new(app, "Import")
         .item(&import_plottr)
         .item(&import_ywriter)
         .item(&import_markdown)
         .item(&import_longform)
         .item(&import_scrivener)
+        .item(&import_novelwriter)
         .build()?;
 
     // Export menu item

--- a/src-tauri/src/models/project.rs
+++ b/src-tauri/src/models/project.rs
@@ -8,6 +8,7 @@ pub enum SourceType {
     Markdown,
     YWriter,
     Longform,
+    NovelWriter,
     Blank,
 }
 
@@ -19,6 +20,7 @@ impl SourceType {
             SourceType::Markdown => "markdown",
             SourceType::YWriter => "ywriter",
             SourceType::Longform => "longform",
+            SourceType::NovelWriter => "novelwriter",
             SourceType::Blank => "blank",
         }
     }
@@ -30,6 +32,7 @@ impl SourceType {
             "markdown" => Some(SourceType::Markdown),
             "ywriter" => Some(SourceType::YWriter),
             "longform" => Some(SourceType::Longform),
+            "novelwriter" => Some(SourceType::NovelWriter),
             "blank" => Some(SourceType::Blank),
             _ => None,
         }

--- a/src-tauri/src/parsers/html.rs
+++ b/src-tauri/src/parsers/html.rs
@@ -1,0 +1,198 @@
+//! Tolerant HTML events shared by prose exporters. Imported prose is not always
+//! XML: preserve stray delimiters, unknown entities and malformed trailing text.
+use quick_xml::{events::Event, Reader};
+
+pub(crate) enum HtmlEvent {
+    Start(String),
+    End(String),
+    Empty(String),
+    Text(String),
+}
+
+fn decode(entity: &str) -> String {
+    if entity == "&nbsp;" {
+        " ".into()
+    } else {
+        quick_xml::escape::unescape(entity)
+            .map(|s| s.into_owned())
+            .unwrap_or_else(|_| entity.into())
+    }
+}
+
+pub(crate) fn html_events(html: &str) -> Vec<HtmlEvent> {
+    // Protect text delimiters before quick-xml sees them. Keep complete tags and
+    // entity tokens intact so marks and text events retain their original order.
+    let mut safe = String::with_capacity(html.len());
+    let mut protected_end = 0;
+    for (i, c) in html.char_indices() {
+        if i < protected_end {
+            continue;
+        }
+        for (open, close) in [("<![CDATA[", "]]>"), ("<!--", "-->")] {
+            if html[i..].starts_with(open) {
+                if let Some(end) = html[i + open.len()..].find(close) {
+                    protected_end = i + open.len() + end + close.len();
+                    safe.push_str(&html[i..protected_end]);
+                    break;
+                }
+            }
+        }
+        if i < protected_end {
+            continue;
+        }
+        let tail = &html[i + c.len_utf8()..];
+        match c {
+            '&' if !tail.find(';').is_some_and(|end| {
+                end > 0
+                    && tail[..end]
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '#')
+            }) =>
+            {
+                safe.push_str("&amp;")
+            }
+            '<' if !((tail.starts_with("!--")
+                || tail
+                    .trim_start_matches('/')
+                    .starts_with(|c: char| c.is_ascii_alphabetic()))
+                && tail.find('>').is_some_and(|end| !tail[..end].contains('<'))) =>
+            {
+                safe.push_str("&lt;")
+            }
+            _ => safe.push(c),
+        }
+    }
+    let mut reader = Reader::from_str(&safe);
+    reader.config_mut().check_end_names = false;
+    let mut events = Vec::new();
+    loop {
+        let offset = reader.buffer_position() as usize;
+        match reader.read_event() {
+            Ok(Event::Start(e)) => events.push(HtmlEvent::Start(
+                String::from_utf8_lossy(e.name().as_ref()).to_ascii_lowercase(),
+            )),
+            Ok(Event::End(e)) => events.push(HtmlEvent::End(
+                String::from_utf8_lossy(e.name().as_ref()).to_ascii_lowercase(),
+            )),
+            Ok(Event::Empty(e)) => events.push(HtmlEvent::Empty(
+                String::from_utf8_lossy(e.name().as_ref()).to_ascii_lowercase(),
+            )),
+            Ok(Event::Text(e)) => {
+                events.push(HtmlEvent::Text(String::from_utf8_lossy(&e).into_owned()))
+            }
+            Ok(Event::CData(e)) => {
+                events.push(HtmlEvent::Text(String::from_utf8_lossy(&e).into_owned()))
+            }
+            Ok(Event::GeneralRef(e)) => events.push(HtmlEvent::Text(decode(&format!(
+                "&{};",
+                String::from_utf8_lossy(&e)
+            )))),
+            Ok(Event::Eof) => break,
+            Err(_) => {
+                // Never interpret an XML error as EOF. Preserve all remaining
+                // text, even if malformed markup must become literal prose.
+                events.push(HtmlEvent::Text(decode(&safe[offset..])));
+                break;
+            }
+            _ => (),
+        }
+    }
+    events
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) enum ParagraphKind {
+    #[default]
+    Normal,
+    Heading(u8),
+    Blockquote,
+}
+
+pub(crate) struct HtmlRun {
+    pub text: String,
+    // bold, italic, strikethrough, underline
+    pub marks: [bool; 4],
+}
+
+#[derive(Default)]
+pub(crate) struct HtmlParagraph {
+    pub runs: Vec<HtmlRun>,
+    pub kind: ParagraphKind,
+}
+
+/// One TipTap walker for every prose exporter. Text policy is supplied by the
+/// caller: manuscript typography may transform punctuation; interchange must not.
+pub(crate) fn html_paragraphs(html: &str, transform: fn(&str) -> String) -> Vec<HtmlParagraph> {
+    let mut paragraphs = Vec::new();
+    let mut current = HtmlParagraph::default();
+    let mut marks = [0u32; 4];
+    let mut quotes = 0u32;
+    fn flush(current: &mut HtmlParagraph, paragraphs: &mut Vec<HtmlParagraph>) {
+        if !current.runs.is_empty() {
+            paragraphs.push(HtmlParagraph {
+                runs: std::mem::take(&mut current.runs),
+                kind: current.kind,
+            });
+        }
+    }
+    for event in html_events(html) {
+        let (tag, ending, empty) = match event {
+            HtmlEvent::Text(text) => {
+                let text = transform(&text);
+                if !text.is_empty() {
+                    current.runs.push(HtmlRun {
+                        text,
+                        marks: marks.map(|n| n > 0),
+                    });
+                }
+                continue;
+            }
+            HtmlEvent::Start(tag) => (tag, false, false),
+            HtmlEvent::End(tag) => (tag, true, false),
+            HtmlEvent::Empty(tag) => (tag, false, true),
+        };
+        let mark = match tag.as_str() {
+            "strong" | "b" => Some(0),
+            "em" | "i" => Some(1),
+            "s" | "del" | "strike" => Some(2),
+            "u" => Some(3),
+            _ => None,
+        };
+        if let Some(index) = mark {
+            if !empty {
+                marks[index] = if ending {
+                    marks[index].saturating_sub(1)
+                } else {
+                    marks[index] + 1
+                };
+            }
+            continue;
+        }
+        match tag.as_str() {
+            "br" if !ending => current.runs.push(HtmlRun {
+                text: "\n".into(),
+                marks: marks.map(|n| n > 0),
+            }),
+            "p" | "div" | "li" | "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+                flush(&mut current, &mut paragraphs);
+                if tag == "blockquote" && !empty {
+                    quotes = if ending {
+                        quotes.saturating_sub(1)
+                    } else {
+                        quotes + 1
+                    };
+                }
+                current.kind = if !ending && !empty && tag.starts_with('h') {
+                    ParagraphKind::Heading(tag.as_bytes()[1] - b'0')
+                } else if quotes > 0 {
+                    ParagraphKind::Blockquote
+                } else {
+                    ParagraphKind::Normal
+                };
+            }
+            _ => (),
+        }
+    }
+    flush(&mut current, &mut paragraphs);
+    paragraphs
+}

--- a/src-tauri/src/parsers/longform.rs
+++ b/src-tauri/src/parsers/longform.rs
@@ -82,6 +82,9 @@ struct SceneFrontmatter {
     factions: Option<FrontmatterList>,
     groups: Option<FrontmatterList>,
     teams: Option<FrontmatterList>,
+    timelines: Option<FrontmatterList>,
+    #[serde(alias = "notes")]
+    custom: Option<FrontmatterList>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -120,6 +123,8 @@ struct SceneContent {
     items: Vec<String>,
     objectives: Vec<String>,
     organizations: Vec<String>,
+    timelines: Vec<String>,
+    custom: Vec<String>,
 }
 
 struct SceneEntry {
@@ -143,11 +148,25 @@ struct ReferenceNameIndex {
     item_names: HashSet<String>,
     objective_names: HashSet<String>,
     organization_names: HashSet<String>,
+    timeline_names: HashSet<String>,
+    custom_names: HashSet<String>,
 }
 
 impl ReferenceNameIndex {
     fn new(parsed: &ParsedLongform) -> Self {
         Self {
+            timeline_names: parsed
+                .reference_items
+                .iter()
+                .filter(|item| item.reference_type == "timelines")
+                .map(|item| item.name.to_lowercase())
+                .collect(),
+            custom_names: parsed
+                .reference_items
+                .iter()
+                .filter(|item| item.reference_type == "custom")
+                .map(|item| item.name.to_lowercase())
+                .collect(),
             character_names: parsed
                 .characters
                 .iter()
@@ -220,6 +239,8 @@ struct DataviewContext<'a> {
     items: &'a mut Vec<String>,
     objectives: &'a mut Vec<String>,
     organizations: &'a mut Vec<String>,
+    timelines: &'a mut Vec<String>,
+    custom: &'a mut Vec<String>,
 }
 
 // ============================================================================
@@ -520,7 +541,20 @@ fn resolve_note_kind(
         return Some(ReferenceKind::Organization);
     }
 
+    if path_contains_folder(path, &["timeline", "timelines"]) {
+        return Some(ReferenceKind::Timeline);
+    }
+    if path_contains_folder(path, &["notes", "custom"]) {
+        return Some(ReferenceKind::Custom);
+    }
+
     let stem_key = file_stem.to_lowercase();
+    if reference_names.timeline_names.contains(&stem_key) {
+        return Some(ReferenceKind::Timeline);
+    }
+    if reference_names.custom_names.contains(&stem_key) {
+        return Some(ReferenceKind::Custom);
+    }
     if reference_names.character_names.contains(&stem_key) {
         return Some(ReferenceKind::Character);
     }
@@ -547,7 +581,16 @@ fn extract_note_details(
     kind: ReferenceKind,
 ) -> (String, Option<String>, HashMap<String, String>) {
     let mut attributes = HashMap::new();
-    let mut name = file_stem.to_string();
+    let extended_note = matches!(kind, ReferenceKind::Timeline | ReferenceKind::Custom);
+    let mut name = if extended_note {
+        body.lines()
+            .find_map(|line| line.strip_prefix("# "))
+            .unwrap_or(file_stem)
+            .trim()
+            .to_string()
+    } else {
+        file_stem.to_string()
+    };
     let mut description = None;
 
     if let Some(frontmatter) = frontmatter {
@@ -600,7 +643,28 @@ fn extract_note_details(
         }
     }
 
-    if description.is_none() {
+    if extended_note {
+        // Kindling's exported note sections carry multiline descriptions and
+        // notes separately from generated scene backlinks. Keep their contents.
+        if description.is_none() {
+            description = note_section(body, "Description").or_else(|| {
+                let prose = body
+                    .lines()
+                    .skip_while(|line| line.trim().is_empty() || line.starts_with("# "))
+                    .take_while(|line| {
+                        !matches!(line.trim(), "## Notes" | "## Scenes" | "## Appearances")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                normalize_block(&prose)
+            });
+        }
+        if !attributes.contains_key("notes") {
+            if let Some(notes) = note_section(body, "Notes") {
+                attributes.insert("notes".into(), notes);
+            }
+        }
+    } else if description.is_none() {
         description = extract_first_paragraph(body);
     }
 
@@ -609,6 +673,23 @@ fn extract_note_details(
     }
 
     (name, description, attributes)
+}
+
+fn note_section(body: &str, title: &str) -> Option<String> {
+    let heading = format!("## {title}");
+    let mut lines = body.lines().skip_while(|line| line.trim() != heading);
+    lines.next()?;
+    normalize_block(
+        &lines
+            .take_while(|line| {
+                !matches!(
+                    line.trim(),
+                    "## Description" | "## Notes" | "## Scenes" | "## Appearances"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }
 
 fn join_frontmatter_list(list: FrontmatterList) -> Option<String> {
@@ -804,7 +885,11 @@ fn merge_reference_notes(parsed: &mut ParsedLongform, notes: Vec<ReferenceNote>)
         match note.kind {
             ReferenceKind::Character => merge_character_note(parsed, note, &mut character_index),
             ReferenceKind::Location => merge_location_note(parsed, note, &mut location_index),
-            ReferenceKind::Item | ReferenceKind::Objective | ReferenceKind::Organization => {
+            ReferenceKind::Item
+            | ReferenceKind::Objective
+            | ReferenceKind::Organization
+            | ReferenceKind::Timeline
+            | ReferenceKind::Custom => {
                 merge_reference_item_note(parsed, note, &mut reference_item_index);
             }
         }
@@ -983,16 +1068,22 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
         let mut items = std::mem::take(&mut scene_content.items);
         let mut objectives = std::mem::take(&mut scene_content.objectives);
         let mut organizations = std::mem::take(&mut scene_content.organizations);
+        let mut timelines = std::mem::take(&mut scene_content.timelines);
+        let mut custom = std::mem::take(&mut scene_content.custom);
         if let Some(list) = frontmatter.characters {
             for value in list.into_vec() {
                 push_reference(
                     &value,
                     ReferenceKind::Character,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1000,11 +1091,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
             push_reference(
                 &pov,
                 ReferenceKind::Character,
-                &mut characters,
-                &mut locations,
-                &mut items,
-                &mut objectives,
-                &mut organizations,
+                [
+                    &mut characters,
+                    &mut locations,
+                    &mut items,
+                    &mut objectives,
+                    &mut organizations,
+                    &mut timelines,
+                    &mut custom,
+                ],
             );
         }
         if let Some(list) = frontmatter.setting {
@@ -1012,11 +1107,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Location,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1025,11 +1124,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Item,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1038,11 +1141,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Item,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1051,11 +1158,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Objective,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1064,11 +1175,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Objective,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1077,11 +1192,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Organization,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1090,11 +1209,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Organization,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1103,11 +1226,15 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Organization,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
@@ -1116,14 +1243,42 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
                 push_reference(
                     &value,
                     ReferenceKind::Organization,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
         }
+        for (list, kind) in [
+            (frontmatter.timelines, ReferenceKind::Timeline),
+            (frontmatter.custom, ReferenceKind::Custom),
+        ] {
+            if let Some(list) = list {
+                for value in list.into_vec() {
+                    push_reference(
+                        &value,
+                        kind,
+                        [
+                            &mut characters,
+                            &mut locations,
+                            &mut items,
+                            &mut objectives,
+                            &mut organizations,
+                            &mut timelines,
+                            &mut custom,
+                        ],
+                    );
+                }
+            }
+        }
+        scene_content.timelines = normalize_reference_list(timelines);
+        scene_content.custom = normalize_reference_list(custom);
         scene_content.characters = normalize_reference_list(characters);
         scene_content.locations = normalize_reference_list(locations);
         scene_content.items = normalize_reference_list(items);
@@ -1150,6 +1305,8 @@ fn parse_scene_body(content: &str) -> SceneContent {
     let mut items = Vec::new();
     let mut objectives = Vec::new();
     let mut organizations = Vec::new();
+    let mut timelines = Vec::new();
+    let mut custom = Vec::new();
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -1195,6 +1352,8 @@ fn parse_scene_body(content: &str) -> SceneContent {
                     items: &mut items,
                     objectives: &mut objectives,
                     organizations: &mut organizations,
+                    timelines: &mut timelines,
+                    custom: &mut custom,
                 };
                 apply_dataview_field(&key, &value, &mut context);
                 continue;
@@ -1208,11 +1367,15 @@ fn parse_scene_body(content: &str) -> SceneContent {
                 push_reference(
                     &link,
                     ReferenceKind::Character,
-                    &mut characters,
-                    &mut locations,
-                    &mut items,
-                    &mut objectives,
-                    &mut organizations,
+                    [
+                        &mut characters,
+                        &mut locations,
+                        &mut items,
+                        &mut objectives,
+                        &mut organizations,
+                        &mut timelines,
+                        &mut custom,
+                    ],
                 );
             }
             if !skipped_heading && trimmed_start.starts_with("# ") {
@@ -1237,6 +1400,8 @@ fn parse_scene_body(content: &str) -> SceneContent {
         items: normalize_reference_list(items),
         objectives: normalize_reference_list(objectives),
         organizations: normalize_reference_list(organizations),
+        timelines: normalize_reference_list(timelines),
+        custom: normalize_reference_list(custom),
     }
 }
 
@@ -1358,6 +1523,8 @@ enum ReferenceKind {
     Item,
     Objective,
     Organization,
+    Timeline,
+    Custom,
 }
 
 fn reference_kind_from_label(label: &str) -> Option<ReferenceKind> {
@@ -1373,6 +1540,12 @@ fn reference_kind_from_label(label: &str) -> Option<ReferenceKind> {
         .trim()
         .to_lowercase();
 
+    if matches!(normalized.as_str(), "timeline" | "timelines") {
+        return Some(ReferenceKind::Timeline);
+    }
+    if matches!(normalized.as_str(), "custom" | "note" | "notes") {
+        return Some(ReferenceKind::Custom);
+    }
     if normalized.contains("character")
         || matches!(normalized.as_str(), "person" | "people" | "npc" | "cast")
     {
@@ -1420,6 +1593,8 @@ fn reference_type_for_kind(kind: ReferenceKind) -> Option<&'static str> {
         ReferenceKind::Item => Some("items"),
         ReferenceKind::Objective => Some("objectives"),
         ReferenceKind::Organization => Some("organizations"),
+        ReferenceKind::Timeline => Some("timelines"),
+        ReferenceKind::Custom => Some("custom"),
         _ => None,
     }
 }
@@ -1431,11 +1606,15 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
             push_reference(
                 value,
                 ReferenceKind::Character,
-                context.characters,
-                context.locations,
-                context.items,
-                context.objectives,
-                context.organizations,
+                [
+                    context.characters,
+                    context.locations,
+                    context.items,
+                    context.objectives,
+                    context.organizations,
+                    context.timelines,
+                    context.custom,
+                ],
             );
         }
         "characters" => {
@@ -1443,11 +1622,15 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
                 push_reference(
                     &entry,
                     ReferenceKind::Character,
-                    context.characters,
-                    context.locations,
-                    context.items,
-                    context.objectives,
-                    context.organizations,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
                 );
             }
         }
@@ -1456,11 +1639,15 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
                 push_reference(
                     &entry,
                     ReferenceKind::Location,
-                    context.characters,
-                    context.locations,
-                    context.items,
-                    context.objectives,
-                    context.organizations,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
                 );
             }
         }
@@ -1469,11 +1656,15 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
                 push_reference(
                     &entry,
                     ReferenceKind::Item,
-                    context.characters,
-                    context.locations,
-                    context.items,
-                    context.objectives,
-                    context.organizations,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
                 );
             }
         }
@@ -1483,11 +1674,15 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
                 push_reference(
                     &entry,
                     ReferenceKind::Objective,
-                    context.characters,
-                    context.locations,
-                    context.items,
-                    context.objectives,
-                    context.organizations,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
                 );
             }
         }
@@ -1498,11 +1693,37 @@ fn apply_dataview_field(key: &str, value: &str, context: &mut DataviewContext<'_
                 push_reference(
                     &entry,
                     ReferenceKind::Organization,
-                    context.characters,
-                    context.locations,
-                    context.items,
-                    context.objectives,
-                    context.organizations,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
+                );
+            }
+        }
+        "timeline" | "timelines" | "notes" | "custom" => {
+            let kind = if normalized_key.starts_with("timeline") {
+                ReferenceKind::Timeline
+            } else {
+                ReferenceKind::Custom
+            };
+            for entry in split_inline_list(value) {
+                push_reference(
+                    &entry,
+                    kind,
+                    [
+                        context.characters,
+                        context.locations,
+                        context.items,
+                        context.objectives,
+                        context.organizations,
+                        context.timelines,
+                        context.custom,
+                    ],
                 );
             }
         }
@@ -1580,11 +1801,8 @@ fn extract_wikilink_targets(line: &str) -> Vec<String> {
 fn push_reference(
     value: &str,
     default_kind: ReferenceKind,
-    characters: &mut Vec<String>,
-    locations: &mut Vec<String>,
-    items: &mut Vec<String>,
-    objectives: &mut Vec<String>,
-    organizations: &mut Vec<String>,
+    [characters, locations, items, objectives, organizations, timelines, custom]: [&mut Vec<String>;
+        7],
 ) {
     if let Some((kind, name)) = classify_reference(value, default_kind) {
         match kind {
@@ -1593,6 +1811,8 @@ fn push_reference(
             ReferenceKind::Item => items.push(name),
             ReferenceKind::Objective => objectives.push(name),
             ReferenceKind::Organization => organizations.push(name),
+            ReferenceKind::Timeline => timelines.push(name),
+            ReferenceKind::Custom => custom.push(name),
         }
     }
 }
@@ -1852,6 +2072,21 @@ fn add_scene_from_entry(
         context.reference_item_index,
         context.scene_reference_item_refs,
     );
+
+    for (kind, names) in [
+        (ReferenceKind::Timeline, &scene_content.timelines),
+        (ReferenceKind::Custom, &scene_content.custom),
+    ] {
+        register_scene_reference_items(
+            chapter.project_id,
+            scene.id,
+            kind,
+            names,
+            context.reference_items,
+            context.reference_item_index,
+            context.scene_reference_item_refs,
+        );
+    }
 
     for (beat_position, beat) in scene_content.beats.into_iter().enumerate() {
         let mut new_beat = Beat::new(scene.id, beat.content, beat_position as i32);
@@ -2155,6 +2390,94 @@ fn build_scene_source_id(index_dir: &Path, scene_path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn imports_timeline_and_custom_notes_from_folders_and_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let index = temp.path().join("Index.md");
+        fs::write(
+            &index,
+            "---\nlongform:\n  format: scenes\n  title: Notes Test\n  scenes: [Opening]\n---\n",
+        )
+        .unwrap();
+        fs::write(temp.path().join("Opening.md"), "---\ntimelines: ['[[Past]]']\nnotes: ['[[Research]]']\n---\ntimelines:: [[Future]]\ncustom:: [[Motif]]\n\nScene prose.").unwrap();
+        for folder in ["timelines", "notes", "misc"] {
+            fs::create_dir(temp.path().join(folder)).unwrap();
+        }
+        for (path, body) in [
+            (
+                "timelines/Past.md",
+                "# Past\n\nFirst paragraph.\n\nSecond paragraph.",
+            ),
+            ("notes/Research.md", "# Research\n\nResearch body."),
+            (
+                "misc/Future.md",
+                "---\ntags: [timeline]\nEra: Tomorrow\n---\n# Future\n\nFuture body.",
+            ),
+            (
+                "misc/Motif.md",
+                "---\ncategory: custom\nColour: Green\n---\n# Motif\n\nMotif body.",
+            ),
+            (
+                "notes/unlinked.md",
+                "# Display: Name\n\nUnlinked note body.",
+            ),
+            (
+                "notes/character.md",
+                "---\ntype: character\nname: Jane\n---\nA character despite the notes folder.",
+            ),
+        ] {
+            fs::write(temp.path().join(path), body).unwrap();
+        }
+        let parsed = parse_longform_index(&index).unwrap();
+        assert_eq!(parsed.reference_items.len(), 5);
+        assert_eq!(parsed.scene_reference_item_refs.len(), 4);
+        assert_eq!(parsed.characters.len(), 1);
+        assert_eq!(parsed.characters[0].name, "Jane");
+        for (name, kind) in [
+            ("Past", "timelines"),
+            ("Future", "timelines"),
+            ("Research", "custom"),
+            ("Motif", "custom"),
+            ("Display: Name", "custom"),
+        ] {
+            let note = parsed
+                .reference_items
+                .iter()
+                .find(|item| item.name == name)
+                .unwrap();
+            assert_eq!(note.reference_type, kind);
+            assert!(note.description.is_some());
+            assert!(note.source_id.is_some());
+        }
+        let past = parsed
+            .reference_items
+            .iter()
+            .find(|item| item.name == "Past")
+            .unwrap();
+        assert_eq!(
+            past.description.as_deref(),
+            Some("First paragraph.\n\nSecond paragraph.")
+        );
+        assert_eq!(
+            parsed
+                .reference_items
+                .iter()
+                .find(|item| item.name == "Future")
+                .unwrap()
+                .attributes["Era"],
+            "Tomorrow"
+        );
+        assert_eq!(
+            parsed
+                .reference_items
+                .iter()
+                .find(|item| item.name == "Motif")
+                .unwrap()
+                .attributes["Colour"],
+            "Green"
+        );
+    }
+
     use super::*;
     use std::fs;
     use tempfile::tempdir;

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -9,3 +9,7 @@ pub use markdown::*;
 pub use plottr::*;
 pub use scrivener::*;
 pub use ywriter::*;
+
+pub mod novelwriter;
+
+pub(crate) mod html;

--- a/src-tauri/src/parsers/novelwriter.rs
+++ b/src-tauri/src/parsers/novelwriter.rs
@@ -1,0 +1,412 @@
+//! Local novelWriter project interchange. Handles anchor record identity; beats
+//! use positions within their scene. Notes and links are intentionally import-only
+//! in sync, matching the other source types.
+mod format;
+mod markup;
+mod writer;
+use crate::models::*;
+pub use format::*;
+pub use markup::{html_to_nw, nw_to_html};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+use uuid::Uuid;
+pub use writer::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NovelWriterError {
+    #[error("Cannot read novelWriter project: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Invalid novelWriter XML: {0}")]
+    Xml(#[from] quick_xml::Error),
+    #[error("Invalid novelWriter project: {0}")]
+    Invalid(String),
+    #[error("Unsupported novelWriter fileVersion '{0}' (supported: 1.4, 1.5, 1.6)")]
+    Version(String),
+}
+#[derive(Debug)]
+pub struct ParsedNovelWriter {
+    pub project: Project,
+    pub chapters: Vec<Chapter>,
+    pub scenes: Vec<Scene>,
+    pub beats: Vec<Beat>,
+    pub characters: Vec<Character>,
+    pub locations: Vec<Location>,
+    pub reference_items: Vec<ReferenceItem>,
+    pub scene_character_refs: Vec<(Uuid, Uuid)>,
+    pub scene_location_refs: Vec<(Uuid, Uuid)>,
+    pub scene_reference_item_refs: Vec<(Uuid, Uuid)>,
+    pub scenes_with_beat_comments: HashSet<String>,
+}
+pub fn novelwriter_beat_source_id(handle: &str, position: i32) -> String {
+    format!("novelwriter:beat:{handle}:{position}")
+}
+
+pub fn parse_novelwriter_project(path: &Path) -> Result<ParsedNovelWriter, NovelWriterError> {
+    let index = path.join("nwProject.nwx");
+    let xml = std::fs::read_to_string(&index)
+        .map_err(|e| NovelWriterError::Invalid(format!("Cannot read {}: {e}", index.display())))?;
+    let doc = read_nwx(&xml)?;
+    let mut project = Project::new(
+        doc.name.clone(),
+        SourceType::NovelWriter,
+        Some(path.to_string_lossy().into_owned()),
+    );
+    project.author_pen_name = (!doc.author.is_empty()).then_some(doc.author.clone());
+    let mut parsed = ParsedNovelWriter {
+        project,
+        chapters: vec![],
+        scenes: vec![],
+        beats: vec![],
+        characters: vec![],
+        locations: vec![],
+        reference_items: vec![],
+        scene_character_refs: vec![],
+        scene_location_refs: vec![],
+        scene_reference_item_refs: vec![],
+        scenes_with_beat_comments: HashSet::new(),
+    };
+    let mut ordered = Vec::new();
+    fn walk<'a>(parent: &str, doc: &'a Nwx, out: &mut Vec<&'a NwItem>) {
+        let mut children: Vec<_> = doc.items.iter().filter(|i| i.parent == parent).collect();
+        children.sort_by_key(|i| i.order);
+        for item in children {
+            out.push(item);
+            walk(&item.handle, doc, out);
+        }
+    }
+    walk("None", &doc, &mut ordered);
+    let novel_root = ordered
+        .iter()
+        .find(|i| i.item_type == "ROOT" && i.class == "NOVEL")
+        .map(|i| i.handle.as_str());
+    let mut chapter_id = None;
+    let mut part_handle: Option<String> = None;
+    let mut tags: HashMap<String, (String, Uuid)> = HashMap::new();
+    let mut links = Vec::new();
+    for item in ordered {
+        let root = doc.items.iter().find(|r| r.handle == item.root).unwrap();
+        if item.item_type != "FILE"
+            || ["ARCHIVE", "TRASH", "TEMPLATE"].contains(&root.class.as_str())
+        {
+            continue;
+        }
+        if root.class == "NOVEL" && Some(root.handle.as_str()) != novel_root {
+            continue;
+        }
+        let modern = path.join("content").join(format!("{}.md", item.handle));
+        let file = if modern.exists() {
+            modern
+        } else {
+            path.join("content").join(format!("{}.nwd", item.handle))
+        };
+        let text = std::fs::read_to_string(&file).map_err(|e| {
+            NovelWriterError::Invalid(format!("Cannot read {}: {e}", file.display()))
+        })?;
+        let body = read_document(&text)?.body;
+        if root.class == "NOVEL" && item.layout != "NOTE" {
+            let heading = body.lines().find_map(heading);
+            let (level, title) = heading.unwrap_or_else(|| {
+                (
+                    item.heading
+                        .strip_prefix('H')
+                        .and_then(|n| n.parse().ok())
+                        .unwrap_or(3),
+                    item.name.clone(),
+                )
+            });
+            if level <= 2 {
+                let ch = Chapter::new(parsed.project.id, title, parsed.chapters.len() as i32)
+                    .with_source_id(Some(item.handle.clone()))
+                    .with_is_part(level == 1);
+                chapter_id = (level == 2).then_some(ch.id);
+                if level == 1 {
+                    part_handle = Some(item.handle.clone());
+                }
+                parsed.chapters.push(ch);
+                // Heading documents may carry prose (common in native projects).
+                // Preserve it in a child scene instead of silently dropping it.
+                let content = scene_content(&body);
+                if content.1.iter().all(|(_, p)| p.trim().is_empty()) {
+                    continue;
+                }
+                if level == 1 {
+                    let ch = Chapter::new(
+                        parsed.project.id,
+                        item.name.clone(),
+                        parsed.chapters.len() as i32,
+                    )
+                    .with_source_id(Some(stable_handle(&format!("{}:chapter", item.handle))));
+                    chapter_id = Some(ch.id);
+                    parsed.chapters.push(ch);
+                }
+                add_scene(
+                    &mut parsed,
+                    item,
+                    chapter_id.unwrap(),
+                    item.name.clone(),
+                    &body,
+                    &mut links,
+                    true,
+                );
+            } else {
+                let id = if let Some(id) = chapter_id {
+                    id
+                } else {
+                    let ch = Chapter::new(
+                        parsed.project.id,
+                        "Manuscript".into(),
+                        parsed.chapters.len() as i32,
+                    )
+                    .with_source_id(Some(stable_handle(&format!(
+                        "{}:chapter",
+                        part_handle.as_deref().unwrap_or(&item.root)
+                    ))));
+                    let id = ch.id;
+                    parsed.chapters.push(ch);
+                    chapter_id = Some(id);
+                    id
+                };
+                add_scene(&mut parsed, item, id, title, &body, &mut links, false);
+            }
+        } else {
+            let mut description = Vec::new();
+            let mut attributes: HashMap<String, String> = HashMap::new();
+            let mut last_attribute: Option<String> = None;
+            let mut tag = None;
+            for line in body.lines() {
+                if let (Some(key), Some(continuation)) =
+                    (&last_attribute, line.strip_prefix("    "))
+                {
+                    if let Some(value) = attributes.get_mut(key) {
+                        value.push('\n');
+                        value.push_str(continuation);
+                    }
+                    continue;
+                }
+                last_attribute = None;
+                if let Some(t) = line.strip_prefix("@tag:") {
+                    tag = Some(
+                        t.split('|')
+                            .next()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_lowercase(),
+                    );
+                } else if let Some(d) = line.strip_prefix("%Short:") {
+                    description.push(d.trim().to_string());
+                } else if let Some((key, value)) =
+                    line.strip_prefix("**").and_then(|s| s.split_once(":** "))
+                {
+                    attributes.insert(key.into(), value.into());
+                    last_attribute = Some(key.into());
+                } else if !line.starts_with(['#', '@', '%']) && !line.trim().is_empty() {
+                    description.push(line.into());
+                }
+            }
+            let description =
+                (!description.is_empty()).then(|| nw_to_html(&description.join("\n")));
+            let name = body
+                .lines()
+                .find_map(heading)
+                .map(|(_, n)| n)
+                .unwrap_or_else(|| item.name.clone());
+            let (kind, id) = match root.class.as_str() {
+                "CHARACTER" => {
+                    let c = Character::new(
+                        parsed.project.id,
+                        name,
+                        description,
+                        Some(item.handle.clone()),
+                    )
+                    .with_attributes(attributes);
+                    let id = c.id;
+                    parsed.characters.push(c);
+                    ("char".into(), id)
+                }
+                "WORLD" => {
+                    let l = Location::new(
+                        parsed.project.id,
+                        name,
+                        description,
+                        Some(item.handle.clone()),
+                    )
+                    .with_attributes(attributes);
+                    let id = l.id;
+                    parsed.locations.push(l);
+                    ("location".into(), id)
+                }
+                class => {
+                    let reference_type = reference_type(class).to_string();
+                    if !parsed.project.reference_types.contains(&reference_type) {
+                        parsed.project.reference_types.push(reference_type.clone());
+                    }
+                    let mut r = ReferenceItem::new(
+                        parsed.project.id,
+                        reference_type,
+                        name,
+                        description,
+                        Some(item.handle.clone()),
+                    );
+                    r.attributes = attributes;
+                    let id = r.id;
+                    parsed.reference_items.push(r);
+                    (reference_keyword(class).into(), id)
+                }
+            };
+            if let Some(tag) = tag {
+                tags.entry(tag).or_insert((kind, id));
+            }
+        }
+    }
+    for (scene, keyword, tag) in links {
+        if let Some((kind, id)) = tags.get(&tag.to_lowercase()) {
+            if kind != &keyword {
+                continue;
+            }
+            match kind.as_str() {
+                "char" => parsed.scene_character_refs.push((scene, *id)),
+                "location" => parsed.scene_location_refs.push((scene, *id)),
+                _ => parsed.scene_reference_item_refs.push((scene, *id)),
+            }
+        }
+    }
+    Ok(parsed)
+}
+fn heading(line: &str) -> Option<(usize, String)> {
+    let n = line.bytes().take_while(|&c| c == b'#').count();
+    if n == 0 || n > 3 {
+        return None;
+    }
+    let rest = line[n..].trim_start_matches('!');
+    rest.starts_with(' ').then(|| (n, rest.trim().into()))
+}
+fn scene_content(body: &str) -> (bool, Vec<(String, String)>, Option<String>) {
+    let mut marked = false;
+    let mut segments: Vec<(String, String)> = vec![];
+    let mut title = "Scene Content".to_string();
+    let mut prose = Vec::new();
+    let mut synopsis = Vec::new();
+    for line in body.lines() {
+        if let Some(beat) = line.strip_prefix("% Beat:") {
+            if marked || prose.iter().any(|s: &&str| !s.trim().is_empty()) {
+                segments.push((title, prose.join("\n").trim().into()));
+            }
+            title = beat.trim().into();
+            prose.clear();
+            marked = true;
+        } else if let Some(s) = line.strip_prefix("%Synopsis:") {
+            synopsis.push(s.trim());
+        } else if heading(line).is_some() || line.starts_with(['%', '@']) {
+            continue;
+        } else {
+            prose.push(line.strip_prefix("#### ").unwrap_or(line));
+        }
+    }
+    if marked || !prose.is_empty() || segments.is_empty() {
+        segments.push((title, prose.join("\n").trim().into()));
+    }
+    (
+        marked,
+        segments,
+        (!synopsis.is_empty()).then(|| synopsis.join("\n")),
+    )
+}
+fn add_scene(
+    parsed: &mut ParsedNovelWriter,
+    item: &NwItem,
+    chapter: Uuid,
+    title: String,
+    body: &str,
+    links: &mut Vec<(Uuid, String, String)>,
+    derived: bool,
+) {
+    let (marked, segments, synopsis) = scene_content(body);
+    let handle = if derived {
+        stable_handle(&format!("{}:prose", item.handle))
+    } else {
+        item.handle.clone()
+    };
+    let position = parsed
+        .scenes
+        .iter()
+        .filter(|s| s.chapter_id == chapter)
+        .count() as i32;
+    let mut scene =
+        Scene::new(chapter, title, synopsis, position).with_source_id(Some(handle.clone()));
+    scene.scene_status = match item.status.as_str() {
+        "s000001" => SceneStatus::Revised,
+        "s000002" => SceneStatus::Final,
+        _ => SceneStatus::Draft,
+    };
+    if marked {
+        parsed.scenes_with_beat_comments.insert(handle.clone());
+    } else {
+        scene.editor_mode = EditorMode::Page;
+    }
+    scene.prose = Some(nw_to_html(
+        &segments
+            .iter()
+            .map(|(_, p)| p.as_str())
+            .filter(|p| !p.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+    ));
+    for (n, (content, prose)) in segments.into_iter().enumerate() {
+        let mut beat = Beat::new(scene.id, content, n as i32)
+            .with_source_id(Some(novelwriter_beat_source_id(&handle, n as i32)));
+        beat.prose = Some(nw_to_html(&prose));
+        parsed.beats.push(beat);
+    }
+    for line in body.lines().filter(|l| l.starts_with('@')) {
+        if let Some((key, values)) = line[1..].split_once(':') {
+            if [
+                "char", "location", "object", "entity", "plot", "time", "custom",
+            ]
+            .contains(&key)
+            {
+                for tag in values.split(',') {
+                    links.push((
+                        scene.id,
+                        key.into(),
+                        tag.split('|').next().unwrap_or("").trim().into(),
+                    ));
+                }
+            }
+        }
+    }
+    parsed.scenes.push(scene);
+}
+pub fn reference_class(kind: &str) -> &'static str {
+    match kind.to_lowercase().as_str() {
+        "plot" | "plots" | "objectives" => "PLOT",
+        "timeline" | "timelines" => "TIMELINE",
+        "object" | "objects" | "items" => "OBJECT",
+        "entity" | "entities" | "organizations" => "ENTITY",
+        _ => "CUSTOM",
+    }
+}
+fn reference_type(class: &str) -> &'static str {
+    match class {
+        "PLOT" => "objectives",
+        "TIMELINE" => "timelines",
+        "OBJECT" => "items",
+        "ENTITY" => "organizations",
+        _ => "custom",
+    }
+}
+fn reference_keyword(class: &str) -> &'static str {
+    match class {
+        "CHARACTER" => "char",
+        "WORLD" => "location",
+        "OBJECT" => "object",
+        "ENTITY" => "entity",
+        "PLOT" => "plot",
+        "TIMELINE" => "time",
+        _ => "custom",
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests;

--- a/src-tauri/src/parsers/novelwriter/format.rs
+++ b/src-tauri/src/parsers/novelwriter/format.rs
@@ -1,0 +1,280 @@
+use super::NovelWriterError;
+use quick_xml::{events::Event, Reader};
+use std::collections::{BTreeMap, HashSet};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NwItem {
+    pub handle: String,
+    pub parent: String,
+    pub root: String,
+    pub order: usize,
+    pub item_type: String,
+    pub class: String,
+    pub layout: String,
+    pub heading: String,
+    pub name: String,
+    pub status: String,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Nwx {
+    pub id: String,
+    pub name: String,
+    pub author: String,
+    pub items: Vec<NwItem>,
+}
+
+pub fn is_handle(s: &str) -> bool {
+    s.len() == 13
+        && s.bytes()
+            .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(&c))
+}
+pub fn new_handle() -> String {
+    Uuid::new_v4().simple().to_string()[..13].into()
+}
+pub fn stable_handle(key: &str) -> String {
+    sha1(key.as_bytes())[..13].into()
+}
+fn xml(s: &str) -> String {
+    quick_xml::escape::escape(s).into_owned()
+}
+
+pub fn write_nwx(doc: &Nwx) -> String {
+    let mut out = format!("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<novelWriterXML appVersion=\"26.2\" hexVersion=\"0x26020000\" fileVersion=\"1.6\" fileRevision=\"0\" timeStamp=\"{}\">\n  <project id=\"{}\"><name>{}</name><author>{}</author></project>\n  <settings><doBackup>no</doBackup><language>en</language><spellChecking auto=\"no\">None</spellChecking><status>\n", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S"), xml(&doc.id), xml(&doc.name), xml(&doc.author));
+    for (i, name) in ["Draft", "Revised", "Final"].iter().enumerate() {
+        out.push_str(&format!("    <entry key=\"s00000{i}\" count=\"0\" color=\"base\" shape=\"CIRCLE\">{name}</entry>\n"));
+    }
+    out.push_str("  </status><importance><entry key=\"i000000\" count=\"0\" color=\"base\" shape=\"SQUARE\">Default</entry></importance></settings>\n  <content>\n");
+    for i in &doc.items {
+        out.push_str(&format!("    <item handle=\"{}\" parent=\"{}\" root=\"{}\" order=\"{}\" type=\"{}\" class=\"{}\" layout=\"{}\">\n      <meta expanded=\"no\" heading=\"{}\" charCount=\"0\" wordCount=\"0\" paraCount=\"0\" cursorPos=\"0\" />\n      <name status=\"{}\" import=\"i000000\" active=\"yes\">{}</name>\n    </item>\n", xml(&i.handle), xml(&i.parent), xml(&i.root), i.order, xml(&i.item_type), xml(&i.class), xml(&i.layout), xml(&i.heading), xml(&i.status), xml(&i.name)));
+    }
+    out.push_str("  </content>\n</novelWriterXML>\n");
+    out
+}
+
+pub fn read_nwx(text: &str) -> Result<Nwx, NovelWriterError> {
+    let mut reader = Reader::from_str(text);
+    let mut stack: Vec<String> = Vec::new();
+    let mut doc = Nwx {
+        id: String::new(),
+        name: String::new(),
+        author: String::new(),
+        items: vec![],
+    };
+    let mut current: Option<NwItem> = None;
+    let mut root_seen = false;
+    loop {
+        let event = reader.read_event()?;
+        let empty = matches!(event, Event::Empty(_));
+        match event {
+            Event::Start(e) | Event::Empty(e) => {
+                let name = String::from_utf8_lossy(e.name().as_ref()).into_owned();
+                let attrs: BTreeMap<String, String> = e
+                    .attributes()
+                    .map(|a| {
+                        let a = a.map_err(|e| NovelWriterError::Invalid(e.to_string()))?;
+                        Ok((
+                            String::from_utf8_lossy(a.key.as_ref()).into_owned(),
+                            a.decode_and_unescape_value(reader.decoder())?.into_owned(),
+                        ))
+                    })
+                    .collect::<Result<_, NovelWriterError>>()?;
+                let get = |key: &str| attrs.get(key).cloned().unwrap_or_default();
+                if root_seen && stack.is_empty() {
+                    return Err(NovelWriterError::Invalid(
+                        "Multiple XML root elements".into(),
+                    ));
+                }
+                if !root_seen {
+                    if name != "novelWriterXML" {
+                        return Err(NovelWriterError::Invalid(
+                            "Root element must be novelWriterXML".into(),
+                        ));
+                    }
+                    root_seen = true;
+                    let version = get("fileVersion");
+                    if !["1.4", "1.5", "1.6"].contains(&version.as_str()) {
+                        return Err(NovelWriterError::Version(version));
+                    }
+                }
+                match name.as_str() {
+                    "project" => doc.id = get("id"),
+                    "item" => {
+                        current = Some(NwItem {
+                            handle: get("handle"),
+                            parent: get("parent"),
+                            root: get("root"),
+                            order: get("order").parse().unwrap_or(0),
+                            item_type: get("type"),
+                            class: get("class"),
+                            layout: get("layout"),
+                            heading: String::new(),
+                            name: String::new(),
+                            status: "s000000".into(),
+                        })
+                    }
+                    "meta" => {
+                        if let Some(i) = &mut current {
+                            i.heading = get("heading");
+                        }
+                    }
+                    "name" => {
+                        if let Some(i) = &mut current {
+                            i.status = get("status");
+                        }
+                    }
+                    _ => (),
+                }
+                // Empty elements never produce an End event.
+                if !empty {
+                    stack.push(name);
+                }
+            }
+            Event::Text(e) => {
+                let value = e
+                    .xml_content()
+                    .map_err(|e| NovelWriterError::Invalid(e.to_string()))?;
+                append_text(&mut doc, &mut current, &stack, &value);
+            }
+            Event::GeneralRef(e) => {
+                let entity = format!("&{};", String::from_utf8_lossy(&e));
+                let value = quick_xml::escape::unescape(&entity)
+                    .map_err(|e| NovelWriterError::Invalid(e.to_string()))?;
+                append_text(&mut doc, &mut current, &stack, &value);
+            }
+            Event::End(e) => {
+                if e.name().as_ref() == b"item" {
+                    if let Some(i) = current.take() {
+                        doc.items.push(i);
+                    }
+                }
+                stack.pop();
+            }
+            Event::Eof => break,
+            _ => (),
+        }
+    }
+    if !root_seen || !stack.is_empty() {
+        return Err(NovelWriterError::Invalid(
+            "Incomplete novelWriterXML document".into(),
+        ));
+    }
+    let mut handles = HashSet::new();
+    for i in &doc.items {
+        if !is_handle(&i.handle) || !handles.insert(i.handle.clone()) {
+            return Err(NovelWriterError::Invalid(format!(
+                "Invalid or duplicate handle: {}",
+                i.handle
+            )));
+        }
+    }
+    for i in &doc.items {
+        if !handles.contains(&i.root) || (i.item_type != "ROOT" && !handles.contains(&i.parent)) {
+            return Err(NovelWriterError::Invalid(format!(
+                "Missing parent/root for {}",
+                i.handle
+            )));
+        }
+        let mut ancestors = HashSet::new();
+        let mut node = i;
+        while node.item_type != "ROOT" {
+            if !ancestors.insert(&node.handle) {
+                return Err(NovelWriterError::Invalid("Cyclic project tree".into()));
+            }
+            node = doc
+                .items
+                .iter()
+                .find(|p| p.handle == node.parent)
+                .ok_or_else(|| NovelWriterError::Invalid("Missing parent".into()))?;
+        }
+        if node.handle != i.root {
+            return Err(NovelWriterError::Invalid("Inconsistent root".into()));
+        }
+    }
+    Ok(doc)
+}
+fn append_text(doc: &mut Nwx, current: &mut Option<NwItem>, stack: &[String], text: &str) {
+    match stack.last().map(String::as_str) {
+        Some("name") => {
+            if let Some(i) = current {
+                i.name.push_str(text);
+            } else if stack.iter().any(|s| s == "project") {
+                doc.name.push_str(text);
+            }
+        }
+        Some("author") => doc.author.push_str(text),
+        _ => (),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct NwDocument {
+    pub metadata: BTreeMap<String, String>,
+    pub body: String,
+}
+pub fn write_document(item: &NwItem, body: &str) -> String {
+    let body = format!("{}\n", body.trim_end_matches('\n'));
+    let mut out = String::from("+++\n");
+    for (key, value) in [
+        ("name", item.name.clone()),
+        ("parent", item.parent.clone()),
+        ("handle", item.handle.clone()),
+        ("class", item.class.clone()),
+        ("layout", item.layout.clone()),
+        ("textHash", sha1(body.as_bytes())),
+        ("createdDate", "Unknown".into()),
+        ("updatedDate", "Unknown".into()),
+    ] {
+        out.push_str(&format!(
+            "{key} = {}\n",
+            serde_json::to_string(&value).unwrap()
+        ));
+    }
+    out.push_str("+++\n");
+    out.push_str(&body);
+    out
+}
+pub fn read_document(text: &str) -> Result<NwDocument, NovelWriterError> {
+    let normalized = text.replace("\r\n", "\n");
+    let mut metadata = BTreeMap::new();
+    if let Some(rest) = normalized.strip_prefix("+++\n") {
+        let (header, body) = rest
+            .split_once("\n+++\n")
+            .ok_or_else(|| NovelWriterError::Invalid("Unclosed document TOML header".into()))?;
+        for line in header
+            .lines()
+            .filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#'))
+        {
+            let (key, value) = line
+                .split_once('=')
+                .ok_or_else(|| NovelWriterError::Invalid("Invalid document header".into()))?;
+            let value = value.trim();
+            let decoded = if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+                value[1..value.len() - 1].into()
+            } else {
+                serde_json::from_str(value)
+                    .map_err(|e| NovelWriterError::Invalid(format!("Invalid header string: {e}")))?
+            };
+            metadata.insert(key.trim().into(), decoded);
+        }
+        Ok(NwDocument {
+            metadata,
+            body: body.into(),
+        })
+    } else {
+        // Legacy 1.4/1.5 .nwd headers; body edits need not refresh textHash.
+        let body = normalized
+            .lines()
+            .skip_while(|l| l.starts_with("%%~"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(NwDocument { metadata, body })
+    }
+}
+
+/// SHA-1 for novelWriter's document checksum (not used for security).
+/// Kept local to avoid changing the dependency/lockfile contract.
+pub fn sha1(data: &[u8]) -> String {
+    use sha1::{Digest, Sha1};
+    format!("{:x}", Sha1::digest(data))
+}

--- a/src-tauri/src/parsers/novelwriter/markup.rs
+++ b/src-tauri/src/parsers/novelwriter/markup.rs
@@ -1,0 +1,201 @@
+//! The reversible novelWriter prose subset. Kept separate from the manuscript
+//! formatter, which intentionally smartens punctuation and omits strikethrough.
+use crate::parsers::html::html_paragraphs;
+
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[derive(Default, PartialEq, Clone)]
+struct Run {
+    text: String,
+    marks: [u32; 3],
+}
+
+pub fn html_to_nw(html: &str) -> String {
+    let mut paragraphs = Vec::new();
+    for paragraph in html_paragraphs(html, str::to_owned) {
+        let mut runs: Vec<Run> = Vec::new();
+        for run in paragraph.runs {
+            let active = [
+                u32::from(run.marks[0]),
+                u32::from(run.marks[1]),
+                u32::from(run.marks[2]),
+            ];
+            if let Some(last) = runs.last_mut().filter(|r| r.marks == active) {
+                last.text.push_str(&run.text);
+            } else {
+                runs.push(Run {
+                    text: run.text,
+                    marks: active,
+                });
+            }
+        }
+        flush(&mut runs, &mut paragraphs);
+    }
+    paragraphs
+        .join("\n\n")
+        .lines()
+        .map(|line| {
+            if line.starts_with(['#', '@', '%']) {
+                format!("\\{line}")
+            } else {
+                line.into()
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+fn flush(runs: &mut Vec<Run>, paragraphs: &mut Vec<String>) {
+    let mut out = String::new();
+    for run in runs.drain(..) {
+        let inner = run.text.trim();
+        if inner.is_empty() {
+            out.push_str(&run.text);
+            continue;
+        }
+        let start = run.text.len() - run.text.trim_start().len();
+        out.push_str(&run.text[..start]);
+        let delimiters = ["**", "_", "~~"];
+        for (i, delim) in delimiters.iter().enumerate() {
+            if run.marks[i] > 0 {
+                out.push_str(delim);
+            }
+        }
+        for c in inner.chars() {
+            if "\\*_~".contains(c) {
+                out.push('\\');
+            }
+            out.push(c);
+        }
+        for (i, delim) in delimiters.iter().enumerate().rev() {
+            if run.marks[i] > 0 {
+                out.push_str(delim);
+            }
+        }
+        out.push_str(&run.text[run.text.trim_end().len()..]);
+    }
+    let out = out.trim();
+    if !out.is_empty() {
+        paragraphs.push(out.into());
+    }
+}
+
+pub fn nw_to_html(markdown: &str) -> String {
+    markdown
+        .replace("\r\n", "\n")
+        .split("\n\n")
+        .filter(|p| !p.trim().is_empty())
+        .map(|p| format!("<p>{}</p>", inline(p.trim())))
+        .collect()
+}
+
+fn inline(text: &str) -> String {
+    let mut out = String::new();
+    let mut pos = 0;
+    while pos < text.len() {
+        let rest = &text[pos..];
+        if let Some(escaped) = rest.strip_prefix('\\').and_then(|s| s.chars().next()) {
+            out.push_str(&escape(&escaped.to_string()));
+            pos += 1 + escaped.len_utf8();
+            continue;
+        }
+        let mut matched = false;
+        for (delimiter, tag) in [("**", "strong"), ("_", "em"), ("~~", "s")] {
+            if let Some(after) = rest.strip_prefix(delimiter) {
+                if let Some(end) = closing(after, delimiter) {
+                    let inner = &after[..end];
+                    if !inner.is_empty() && inner.trim() == inner {
+                        out.push_str(&format!("<{tag}>{}</{tag}>", inline(inner)));
+                        pos += delimiter.len() * 2 + end;
+                        matched = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !matched {
+            let ch = rest.chars().next().unwrap();
+            if ch == '\n' {
+                out.push_str("<br />");
+            } else {
+                out.push_str(&escape(&ch.to_string()));
+            }
+            pos += ch.len_utf8();
+        }
+    }
+    out
+}
+
+fn closing(text: &str, delimiter: &str) -> Option<usize> {
+    text.match_indices(delimiter).find_map(|(i, _)| {
+        let slashes = text[..i].chars().rev().take_while(|&c| c == '\\').count();
+        (slashes % 2 == 0).then_some(i)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn imported_text_delimiters_do_not_truncate_prose() {
+        for html in [
+            "<p>Tom & Jerry ran.</p><p>Second para.</p>",
+            "<p>Tom &amp; Jerry ran.</p><p>Second para.</p>",
+        ] {
+            assert_eq!(html_to_nw(html), "Tom & Jerry ran.\n\nSecond para.");
+        }
+        assert_eq!(
+            html_to_nw("<p>1 < 2 & 3 > 2.</p><p>Tail.</p>"),
+            "1 < 2 & 3 > 2.\n\nTail."
+        );
+        assert_eq!(
+            html_to_nw("<p>&unknown; &#38; &#x3c; &nbsp;end</p>"),
+            "&unknown; & <  end"
+        );
+        assert_eq!(
+            html_to_nw("<p>Start</p><unfinished"),
+            "Start\n\n<unfinished"
+        );
+        assert_eq!(html_to_nw("<p><![CDATA[A & B < C]]></p>"), "A & B < C");
+        let imported =
+            crate::parsers::ywriter::convert_ywriter_markup("Tom & Jerry ran.\n\nSecond para.");
+        let nw = html_to_nw(&imported);
+        assert!(nw.contains("Tom & Jerry ran."));
+        assert!(nw.contains("Second para."));
+    }
+
+    #[test]
+    fn novelwriter_paragraphs_require_blank_lines() {
+        // Upstream usage/basic_formatting.html: single breaks stay in a paragraph.
+        assert_eq!(
+            nw_to_html("First line.\nSecond line.\n\nNext paragraph."),
+            "<p>First line.<br />Second line.</p><p>Next paragraph.</p>"
+        );
+    }
+
+    #[test]
+    fn prose_round_trip() {
+        for html in [
+            "<p>Hello <b>bold </b><i>italic</i>.</p><p>A &amp; B</p>",
+            "<p><strong><em>Both</em></strong> <del>gone</del></p>",
+            "<p>Literal * _ ~ \\ and &lt;angle&gt;.</p>",
+            "<p>O&apos;Brien said &quot;hi&quot;.</p>",
+            "<p><u>underline</u><br>next</p>",
+        ] {
+            let nw = html_to_nw(html);
+            assert_eq!(html_to_nw(&nw_to_html(&nw)), nw, "{html}");
+        }
+        assert_eq!(
+            html_to_nw("<p><b>bold </b><i>italic</i> <s>gone</s></p>"),
+            "**bold** _italic_ ~~gone~~"
+        );
+        assert_eq!(
+            nw_to_html("**bold** _italic_ ~~gone~~"),
+            "<p><strong>bold</strong> <em>italic</em> <s>gone</s></p>"
+        );
+    }
+}

--- a/src-tauri/src/parsers/novelwriter/tests.rs
+++ b/src-tauri/src/parsers/novelwriter/tests.rs
@@ -1,0 +1,467 @@
+use super::*;
+use crate::{commands::insert_novelwriter, db};
+use rusqlite::Connection;
+
+pub(crate) fn fixture() -> (Connection, Project) {
+    let conn = Connection::open_in_memory().unwrap();
+    db::initialize_schema(&conn).unwrap();
+    let mut project = Project::new("A & B".into(), SourceType::Blank, None);
+    project.author_pen_name = Some("O'Brien".into());
+    project.reference_types.push("items".into());
+    db::insert_project(&conn, &project).unwrap();
+    let part = Chapter::new(project.id, "Part I".into(), 0).with_is_part(true);
+    db::insert_chapter(&conn, &part).unwrap();
+    let chapter = Chapter::new(project.id, "Chapter \"One\"".into(), 1);
+    db::insert_chapter(&conn, &chapter).unwrap();
+    let scene = Scene::new(
+        chapter.id,
+        "Arrival".into(),
+        Some("A stranger arrives.\nAt midnight.".into()),
+        0,
+    );
+    db::insert_scene(&conn, &scene).unwrap();
+    for (n, (title, text)) in [
+        (
+            "The knock",
+            "<p>Someone <strong>knocked</strong> at the <em>door</em>.</p>",
+        ),
+        (
+            "Answer",
+            "<p><s>She ran.</s> She waited &amp; listened.</p>",
+        ),
+    ]
+    .iter()
+    .enumerate()
+    {
+        let mut beat = Beat::new(scene.id, title.to_string(), n as i32);
+        beat.prose = Some(text.to_string());
+        db::insert_beat(&conn, &beat).unwrap();
+    }
+    let mut character = Character::new(project.id, "Jane".into(), Some("The visitor".into()), None);
+    character.attributes.insert("Age".into(), "30".into());
+    character
+        .attributes
+        .insert("History".into(), "Born here.\nLeft once.\n".into());
+    db::insert_character(&conn, &character).unwrap();
+    db::add_scene_character_ref(&conn, &scene.id, &character.id).unwrap();
+    let mut location = Location::new(project.id, "JANE".into(), Some("A house".into()), None);
+    location.attributes.insert("Weather".into(), "Rain".into());
+    db::insert_location(&conn, &location).unwrap();
+    db::add_scene_location_ref(&conn, &scene.id, &location.id).unwrap();
+    let mut object = ReferenceItem::new(
+        project.id,
+        "items".into(),
+        "Key".into(),
+        Some("An old key".into()),
+        None,
+    );
+    object.attributes.insert("Metal".into(), "Iron".into());
+    db::insert_reference_item(&conn, &object).unwrap();
+    db::add_scene_reference_item_ref(&conn, &scene.id, &object.id).unwrap();
+    (conn, project)
+}
+#[test]
+fn handles_hash_and_documents() {
+    assert!(is_handle(&new_handle()));
+    assert!(!is_handle("../bad"));
+    assert_eq!(sha1(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    assert_eq!(sha1(b"abc"), "a9993e364706816aba3e25717850c26c9cd0d89d");
+    let item = NwItem {
+        handle: new_handle(),
+        parent: new_handle(),
+        root: new_handle(),
+        order: 0,
+        item_type: "FILE".into(),
+        class: "NOVEL".into(),
+        layout: "DOCUMENT".into(),
+        heading: "H3".into(),
+        name: "A \"quoted\" \\ name".into(),
+        status: "s000000".into(),
+    };
+    let text = write_document(&item, "### Arrival\n\nHello **world**.\n");
+    let parsed = read_document(&text).unwrap();
+    assert_eq!(parsed.metadata["name"], item.name);
+    assert_eq!(parsed.metadata["textHash"], sha1(parsed.body.as_bytes()));
+    assert_eq!(write_document(&item, &parsed.body), text);
+    assert!(read_document("+++\ninvalid").is_err());
+    assert_eq!(
+        read_document("%%~name: old\n%%~hash: old\n### Old\nText")
+            .unwrap()
+            .body,
+        "### Old\nText"
+    );
+    assert!(matches!(
+        read_nwx("<wrong/>"),
+        Err(NovelWriterError::Invalid(_))
+    ));
+    assert!(
+        matches!(read_nwx("<novelWriterXML fileVersion=\"9\"/>"), Err(NovelWriterError::Version(v)) if v == "9")
+    );
+}
+#[test]
+fn export_import_export_identity_and_references() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    let first = temp.path().join("first");
+    let second = temp.path().join("second");
+    export_novelwriter_project(&conn, &project.id, &first, &Default::default()).unwrap();
+    let original =
+        read_nwx(&std::fs::read_to_string(first.join("nwProject.nwx")).unwrap()).unwrap();
+    assert_eq!(read_nwx(&write_nwx(&original)).unwrap(), original);
+    let parsed = parse_novelwriter_project(&first).unwrap();
+    assert_eq!(
+        (
+            parsed.chapters.len(),
+            parsed.scenes.len(),
+            parsed.beats.len()
+        ),
+        (2, 1, 2)
+    );
+    assert!(parsed.chapters[0].is_part);
+    assert!(parsed.beats[0].prose.as_ref().unwrap().contains("<strong>"));
+    assert_eq!(parsed.characters[0].attributes["Age"], "30");
+    assert_eq!(
+        parsed.characters[0].attributes["History"],
+        "Born here.\nLeft once.\n"
+    );
+    assert_eq!(parsed.locations[0].attributes["Weather"], "Rain");
+    assert_eq!(parsed.reference_items[0].attributes["Metal"], "Iron");
+    assert_eq!(
+        (
+            parsed.scene_character_refs.len(),
+            parsed.scene_location_refs.len(),
+            parsed.scene_reference_item_refs.len()
+        ),
+        (1, 1, 1)
+    );
+    assert_eq!(
+        parsed.scenes[0].synopsis.as_deref(),
+        Some("A stranger arrives.\nAt midnight.")
+    );
+    let imported_conn = Connection::open_in_memory().unwrap();
+    db::initialize_schema(&imported_conn).unwrap();
+    insert_novelwriter(&imported_conn, &parsed).unwrap();
+    export_novelwriter_project(
+        &imported_conn,
+        &parsed.project.id,
+        &second,
+        &Default::default(),
+    )
+    .unwrap();
+    for entry in std::fs::read_dir(first.join("content")).unwrap() {
+        let entry = entry.unwrap();
+        assert_eq!(
+            std::fs::read(entry.path()).unwrap(),
+            std::fs::read(second.join("content").join(entry.file_name())).unwrap(),
+            "{:?}",
+            entry.file_name()
+        );
+    }
+    let second_doc =
+        read_nwx(&std::fs::read_to_string(second.join("nwProject.nwx")).unwrap()).unwrap();
+    assert_eq!(original.items, second_doc.items);
+    let reparsed = parse_novelwriter_project(&second).unwrap();
+    assert_eq!(
+        parsed
+            .beats
+            .iter()
+            .map(|b| (&b.content, &b.prose, &b.source_id))
+            .collect::<Vec<_>>(),
+        reparsed
+            .beats
+            .iter()
+            .map(|b| (&b.content, &b.prose, &b.source_id))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        export_novelwriter_project(&conn, &project.id, &first, &Default::default())
+            .unwrap_err()
+            .contains("empty")
+    );
+}
+#[test]
+fn options_archive_legacy_and_page() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    let opts = NovelWriterExportOptions {
+        include_beat_comments: false,
+        include_notes: false,
+        create_snapshot: false,
+    };
+    export_novelwriter_project(&conn, &project.id, temp.path(), &opts).unwrap();
+    let parsed = parse_novelwriter_project(temp.path()).unwrap();
+    assert!(parsed.characters.is_empty());
+    assert_eq!(parsed.beats.len(), 1);
+    assert_eq!(parsed.beats[0].content, "Scene Content");
+    assert!(parsed.scenes_with_beat_comments.is_empty());
+    // Legacy extension and header are supported alongside modern imports.
+    for file in std::fs::read_dir(temp.path().join("content")).unwrap() {
+        let file = file.unwrap().path();
+        let body = read_document(&std::fs::read_to_string(&file).unwrap())
+            .unwrap()
+            .body;
+        std::fs::write(
+            file.with_extension("nwd"),
+            format!("%%~name: legacy\n{body}"),
+        )
+        .unwrap();
+        std::fs::remove_file(file).unwrap();
+    }
+    assert_eq!(
+        parse_novelwriter_project(temp.path()).unwrap().scenes.len(),
+        1
+    );
+    let ch = db::get_chapters(&conn, &project.id).unwrap()[1].id;
+    conn.execute(
+        "UPDATE chapters SET archived = 1 WHERE id = ?1",
+        [ch.to_string()],
+    )
+    .unwrap();
+    let archive = temp.path().join("archived");
+    export_novelwriter_project(&conn, &project.id, &archive, &Default::default()).unwrap();
+    assert!(parse_novelwriter_project(&archive)
+        .unwrap()
+        .scenes
+        .is_empty());
+    assert!(parse_novelwriter_project(&temp.path().join("missing"))
+        .unwrap_err()
+        .to_string()
+        .contains("nwProject.nwx"));
+}
+#[test]
+fn foreign_sync_ids_are_preserved_and_exports_stable() {
+    let (conn, project) = fixture();
+    conn.execute(
+        "UPDATE projects SET source_type = 'plottr' WHERE id = ?1",
+        [project.id.to_string()],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE chapters SET source_id = 'plottr-original' WHERE is_part = 0",
+        [],
+    )
+    .unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    for name in ["one", "two"] {
+        export_novelwriter_project(
+            &conn,
+            &project.id,
+            &temp.path().join(name),
+            &Default::default(),
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        db::get_chapters(&conn, &project.id).unwrap()[1]
+            .source_id
+            .as_deref(),
+        Some("plottr-original")
+    );
+    let a =
+        read_nwx(&std::fs::read_to_string(temp.path().join("one/nwProject.nwx")).unwrap()).unwrap();
+    let b =
+        read_nwx(&std::fs::read_to_string(temp.path().join("two/nwProject.nwx")).unwrap()).unwrap();
+    assert_eq!(a.items, b.items);
+}
+
+#[test]
+fn page_export_identity_and_literal_document_syntax() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    conn.execute("UPDATE scenes SET editor_mode = 'page', prose = '<p># A literal heading</p><p>% Beat: literal comment</p><p>@char: not a reference</p>'", []).unwrap();
+    let first = temp.path().join("first");
+    export_novelwriter_project(&conn, &project.id, &first, &Default::default()).unwrap();
+    let parsed = parse_novelwriter_project(&first).unwrap();
+    assert_eq!(parsed.scenes.len(), 1);
+    assert_eq!(parsed.scenes[0].editor_mode, EditorMode::Page);
+    assert!(parsed.scenes[0]
+        .prose
+        .as_deref()
+        .unwrap()
+        .contains("% Beat: literal comment"));
+    let other = Connection::open_in_memory().unwrap();
+    db::initialize_schema(&other).unwrap();
+    insert_novelwriter(&other, &parsed).unwrap();
+    let second = temp.path().join("second");
+    export_novelwriter_project(&other, &parsed.project.id, &second, &Default::default()).unwrap();
+    for entry in std::fs::read_dir(first.join("content")).unwrap() {
+        let e = entry.unwrap();
+        assert_eq!(
+            std::fs::read(e.path()).unwrap(),
+            std::fs::read(second.join("content").join(e.file_name())).unwrap()
+        );
+    }
+}
+#[test]
+fn root_exclusions_versions_and_invalid_trees() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default()).unwrap();
+    let path = temp.path().join("nwProject.nwx");
+    let text = std::fs::read_to_string(&path).unwrap();
+    for version in ["1.4", "1.5", "1.6"] {
+        assert!(read_nwx(
+            &text.replace("fileVersion=\"1.6\"", &format!("fileVersion=\"{version}\""))
+        )
+        .is_ok());
+    }
+    for class in ["ARCHIVE", "TRASH", "TEMPLATE"] {
+        std::fs::write(
+            &path,
+            text.replace("class=\"NOVEL\"", &format!("class=\"{class}\"")),
+        )
+        .unwrap();
+        let parsed = parse_novelwriter_project(temp.path()).unwrap();
+        assert!(parsed.scenes.is_empty());
+        assert!(parsed.chapters.is_empty());
+    }
+    let mut doc = read_nwx(&text).unwrap();
+    doc.items.push(doc.items[0].clone());
+    assert!(read_nwx(&write_nwx(&doc)).is_err());
+    doc.items.pop();
+    let file = doc
+        .items
+        .iter_mut()
+        .find(|i| i.item_type == "FILE")
+        .unwrap();
+    file.parent = file.handle.clone();
+    assert!(read_nwx(&write_nwx(&doc)).is_err());
+    assert_eq!(
+        SourceType::parse(SourceType::NovelWriter.as_str()),
+        Some(SourceType::NovelWriter)
+    );
+}
+
+#[test]
+fn malformed_quoted_headers_return_errors_instead_of_panicking() {
+    for value in ["'", "'unclosed", "\"", "\"unclosed"] {
+        assert!(matches!(
+            read_document(&format!("+++\nname = {value}\n+++\nText")),
+            Err(NovelWriterError::Invalid(_))
+        ));
+    }
+    assert_eq!(
+        read_document("+++\nname = ''\n+++\nText").unwrap().metadata["name"],
+        ""
+    );
+}
+
+#[test]
+fn part_prose_and_following_scenes_have_reachable_chapters() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default()).unwrap();
+    let index = temp.path().join("nwProject.nwx");
+    let mut doc = read_nwx(&std::fs::read_to_string(&index).unwrap()).unwrap();
+    let part = doc
+        .items
+        .iter()
+        .find(|i| i.heading == "H1" && i.class == "NOVEL")
+        .unwrap()
+        .clone();
+    let chapter = doc
+        .items
+        .iter()
+        .find(|i| i.heading == "H2")
+        .unwrap()
+        .clone();
+    for item in &mut doc.items {
+        if item.parent == chapter.handle {
+            item.parent = part.handle.clone();
+        }
+    }
+    doc.items.retain(|i| i.handle != chapter.handle);
+    std::fs::write(&index, write_nwx(&doc)).unwrap();
+    let file = temp
+        .path()
+        .join("content")
+        .join(format!("{}.md", part.handle));
+    std::fs::write(&file, "# Part I\n\nPart opening prose.\n").unwrap();
+    let parsed = parse_novelwriter_project(temp.path()).unwrap();
+    assert_eq!(parsed.scenes.len(), 2);
+    assert!(parsed.chapters[0].is_part);
+    for scene in &parsed.scenes {
+        assert!(
+            !parsed
+                .chapters
+                .iter()
+                .find(|c| c.id == scene.chapter_id)
+                .unwrap()
+                .is_part
+        );
+    }
+    assert_eq!(parsed.scenes[0].chapter_id, parsed.scenes[1].chapter_id);
+    assert!(parsed.scenes[0]
+        .prose
+        .as_deref()
+        .unwrap()
+        .contains("Part opening prose."));
+    let repeat = parse_novelwriter_project(temp.path()).unwrap();
+    assert_eq!(parsed.chapters[1].source_id, repeat.chapters[1].source_id);
+}
+
+#[test]
+fn display_name_tags_plot_and_time_links_round_trip() {
+    let (conn, project) = fixture();
+    let scene = db::get_all_project_scenes(&conn, &project.id)
+        .unwrap()
+        .remove(0);
+    for kind in ["objectives", "timelines", "custom", "organizations"] {
+        let item = ReferenceItem::new(
+            project.id,
+            kind.into(),
+            kind.into(),
+            Some("Keep note".into()),
+            None,
+        );
+        db::insert_reference_item(&conn, &item).unwrap();
+        db::add_scene_reference_item_ref(&conn, &scene.id, &item.id).unwrap();
+    }
+    let temp = tempfile::tempdir().unwrap();
+    export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default()).unwrap();
+    for entry in std::fs::read_dir(temp.path().join("content")).unwrap() {
+        let file = entry.unwrap().path();
+        let text = std::fs::read_to_string(&file).unwrap();
+        std::fs::write(
+            &file,
+            text.replace("@tag: jane\n", "@tag: Jane | Jane Doe\n"),
+        )
+        .unwrap();
+    }
+    let parsed = parse_novelwriter_project(temp.path()).unwrap();
+    assert_eq!(parsed.scene_character_refs.len(), 1);
+    assert_eq!(parsed.scene_location_refs.len(), 1);
+    assert_eq!(parsed.scene_reference_item_refs.len(), 5);
+    let scene_file = temp.path().join("content").join(format!(
+        "{}.md",
+        parsed.scenes[0].source_id.as_ref().unwrap()
+    ));
+    let text = std::fs::read_to_string(scene_file).unwrap();
+    assert!(text.contains("@plot: objectives"));
+    assert!(text.contains("@time: timelines"));
+}
+
+#[test]
+fn export_allows_os_metadata_but_rejects_hidden_user_content() {
+    let (conn, project) = fixture();
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join(".DS_Store"), "finder metadata").unwrap();
+    export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default()).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join(".DS_Store")).unwrap(),
+        "finder metadata"
+    );
+    assert!(temp.path().join("nwProject.nwx").exists());
+    for name in [".draft", ".git", "content"] {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(name), "keep").unwrap();
+        assert!(
+            export_novelwriter_project(&conn, &project.id, temp.path(), &Default::default())
+                .is_err()
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join(name)).unwrap(),
+            "keep"
+        );
+    }
+}

--- a/src-tauri/src/parsers/novelwriter/writer.rs
+++ b/src-tauri/src/parsers/novelwriter/writer.rs
@@ -1,0 +1,395 @@
+use super::*;
+use crate::db;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NovelWriterExportOptions {
+    #[serde(default = "yes")]
+    pub include_beat_comments: bool,
+    #[serde(default = "yes")]
+    pub include_notes: bool,
+    #[serde(default)]
+    pub create_snapshot: bool,
+}
+fn yes() -> bool {
+    true
+}
+impl Default for NovelWriterExportOptions {
+    fn default() -> Self {
+        Self {
+            include_beat_comments: true,
+            include_notes: true,
+            create_snapshot: false,
+        }
+    }
+}
+
+struct Builder {
+    doc: Nwx,
+    bodies: BTreeMap<String, String>,
+    used: HashSet<String>,
+}
+impl Builder {
+    fn handle(&mut self, id: Uuid, source: Option<&str>) -> String {
+        let mut handle = source
+            .filter(|s| is_handle(s))
+            .map(str::to_string)
+            .unwrap_or_else(|| stable_handle(&id.to_string()));
+        while !self.used.insert(handle.clone()) {
+            handle = new_handle();
+        }
+        handle
+    }
+    fn root(&mut self, class: &str) -> String {
+        if let Some(root) = self
+            .doc
+            .items
+            .iter()
+            .find(|i| i.item_type == "ROOT" && i.class == class)
+        {
+            return root.handle.clone();
+        }
+        let mut handle = stable_handle(&format!("kindling:novelwriter:root:{class}"));
+        while !self.used.insert(handle.clone()) {
+            handle = new_handle();
+        }
+        self.doc.items.push(NwItem {
+            handle: handle.clone(),
+            parent: "None".into(),
+            root: handle.clone(),
+            order: self
+                .doc
+                .items
+                .iter()
+                .filter(|i| i.item_type == "ROOT")
+                .count(),
+            item_type: "ROOT".into(),
+            class: class.into(),
+            layout: if class == "NOVEL" { "DOCUMENT" } else { "NOTE" }.into(),
+            heading: "H0".into(),
+            name: if class == "NOVEL" {
+                "Manuscript"
+            } else {
+                class
+            }
+            .into(),
+            status: "s000000".into(),
+        });
+        handle
+    }
+    fn push(&mut self, mut item: NwItem, body: String) {
+        item.order = self
+            .doc
+            .items
+            .iter()
+            .filter(|i| i.parent == item.parent)
+            .count();
+        self.bodies
+            .insert(item.handle.clone(), write_document(&item, &body));
+        self.doc.items.push(item);
+    }
+}
+fn line(text: &str) -> String {
+    text.replace(['\r', '\n'], " ")
+}
+fn document(
+    handle: String,
+    parent: &str,
+    root: &str,
+    class: &str,
+    name: &str,
+    level: u8,
+) -> NwItem {
+    NwItem {
+        handle,
+        parent: parent.into(),
+        root: root.into(),
+        order: 0,
+        item_type: "FILE".into(),
+        class: class.into(),
+        layout: if class == "NOVEL" { "DOCUMENT" } else { "NOTE" }.into(),
+        heading: format!("H{level}"),
+        name: name.into(),
+        status: "s000000".into(),
+    }
+}
+
+/// Create-only export. Build everything before touching disk; source IDs are
+/// persisted only after all files are written successfully. Foreign sources keep
+/// their sync identities and receive deterministic UUID-derived export handles.
+pub fn export_novelwriter_project(
+    conn: &Connection,
+    project_id: &Uuid,
+    destination: &Path,
+    options: &NovelWriterExportOptions,
+) -> Result<usize, String> {
+    fn metadata_files(destination: &Path) -> Result<Vec<std::path::PathBuf>, String> {
+        if !destination.exists() {
+            return Ok(vec![]);
+        }
+        if !destination.is_dir() {
+            return Err("Choose an empty destination folder for novelWriter export".into());
+        }
+        std::fs::read_dir(destination)
+            .map_err(|e| e.to_string())?
+            .map(|entry| {
+                let entry = entry.map_err(|e| e.to_string())?;
+                if entry.file_type().map_err(|e| e.to_string())?.is_file()
+                    && matches!(
+                        entry.file_name().to_str(),
+                        Some(".DS_Store" | "Thumbs.db" | "desktop.ini")
+                    )
+                {
+                    Ok(entry.path())
+                } else {
+                    Err("Choose an empty destination folder for novelWriter export".into())
+                }
+            })
+            .collect()
+    }
+    metadata_files(destination)?;
+    let project = db::get_project(conn, project_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Project not found")?;
+    if project.project_type == "screenplay" {
+        return Err("novelWriter export is available for novels only".into());
+    }
+    let chapters = db::get_chapters(conn, project_id).map_err(|e| e.to_string())?;
+    let scenes = db::get_all_project_scenes(conn, project_id).map_err(|e| e.to_string())?;
+    let beats = db::get_all_project_beats(conn, project_id).map_err(|e| e.to_string())?;
+    let mut b = Builder {
+        doc: Nwx {
+            id: project.id.to_string(),
+            name: project.name.clone(),
+            author: project.author_pen_name.clone().unwrap_or_default(),
+            items: vec![],
+        },
+        bodies: BTreeMap::new(),
+        used: HashSet::new(),
+    };
+    let novel = b.root("NOVEL");
+    let mut ids: Vec<(&str, Uuid, String)> = vec![];
+    let mut tags: HashMap<Uuid, (String, String)> = HashMap::new();
+    if options.include_notes {
+        let mut notes = Vec::new();
+        for c in db::get_characters(conn, project_id).map_err(|e| e.to_string())? {
+            notes.push((
+                "characters",
+                c.id,
+                "CHARACTER",
+                c.name,
+                c.description,
+                c.attributes,
+                c.source_id,
+            ));
+        }
+        for l in db::get_locations(conn, project_id).map_err(|e| e.to_string())? {
+            notes.push((
+                "locations",
+                l.id,
+                "WORLD",
+                l.name,
+                l.description,
+                l.attributes,
+                l.source_id,
+            ));
+        }
+        for r in db::get_all_reference_items(conn, project_id).map_err(|e| e.to_string())? {
+            notes.push((
+                "reference_items",
+                r.id,
+                reference_class(&r.reference_type),
+                r.name,
+                r.description,
+                r.attributes,
+                r.source_id,
+            ));
+        }
+        // Stable class/name/handle order makes cross-kind tag collisions deterministic.
+        notes.sort_by_key(|(_, id, class, name, _, _, sid)| {
+            (
+                class.to_string(),
+                name.to_lowercase(),
+                sid.clone()
+                    .unwrap_or_else(|| stable_handle(&id.to_string())),
+            )
+        });
+        let mut used_tags = HashSet::new();
+        for (table, id, class, name, description, attributes, source) in notes {
+            let root = b.root(class);
+            let handle = b.handle(id, source.as_deref());
+            let slug = name
+                .chars()
+                .map(|c| {
+                    if c.is_alphanumeric() {
+                        c.to_ascii_lowercase()
+                    } else {
+                        '-'
+                    }
+                })
+                .collect::<String>()
+                .split('-')
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("-");
+            let slug = if slug.is_empty() { "note".into() } else { slug };
+            let mut tag = slug.clone();
+            let mut suffix = 2;
+            while !used_tags.insert(tag.to_lowercase()) {
+                tag = format!("{slug}-{suffix}");
+                suffix += 1;
+            }
+            let mut body = format!("# {}\n\n@tag: {tag}\n", line(&name));
+            if let Some(description) = description {
+                for part in html_to_nw(&description).lines() {
+                    body.push_str(&format!("%Short: {part}\n"));
+                }
+            }
+            if !attributes.is_empty() {
+                body.push_str("\n## Details\n\n");
+                for (key, value) in attributes.into_iter().collect::<BTreeMap<_, _>>() {
+                    body.push_str(&format!(
+                        "**{}:** {}\n",
+                        line(&key),
+                        value.replace('\n', "\n    ")
+                    ));
+                }
+            }
+            tags.insert(id, (reference_keyword(class).into(), tag));
+            ids.push((table, id, handle.clone()));
+            b.push(document(handle, &root, &root, class, &name, 1), body);
+        }
+    }
+    let mut refs: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    for r in db::get_all_scene_character_refs(conn, project_id).map_err(|e| e.to_string())? {
+        refs.entry(r.scene_id).or_default().push(r.character_id);
+    }
+    for r in db::get_all_scene_location_refs(conn, project_id).map_err(|e| e.to_string())? {
+        refs.entry(r.scene_id).or_default().push(r.location_id);
+    }
+    for r in db::get_all_scene_reference_item_refs(conn, project_id).map_err(|e| e.to_string())? {
+        refs.entry(r.scene_id)
+            .or_default()
+            .push(r.reference_item_id);
+    }
+    let mut part = novel.clone();
+    for ch in chapters.iter().filter(|c| !c.archived) {
+        let handle = b.handle(ch.id, ch.source_id.as_deref());
+        let parent = if ch.is_part { &novel } else { &part };
+        let level = if ch.is_part { 1 } else { 2 };
+        b.push(
+            document(handle.clone(), parent, &novel, "NOVEL", &ch.title, level),
+            format!("{} {}\n", "#".repeat(level as usize), line(&ch.title)),
+        );
+        ids.push(("chapters", ch.id, handle.clone()));
+        if ch.is_part {
+            part = handle.clone();
+        }
+        let mut chapter_scenes: Vec<_> = scenes
+            .iter()
+            .filter(|s| s.chapter_id == ch.id && !s.archived)
+            .collect();
+        chapter_scenes.sort_by_key(|s| s.position);
+        for scene in chapter_scenes {
+            let sh = b.handle(scene.id, scene.source_id.as_deref());
+            let mut body = format!("### {}\n", line(&scene.title));
+            let mut references: BTreeMap<String, Vec<String>> = BTreeMap::new();
+            for id in refs.get(&scene.id).into_iter().flatten() {
+                if let Some((key, tag)) = tags.get(id) {
+                    references.entry(key.clone()).or_default().push(tag.clone());
+                }
+            }
+            for (key, mut values) in references {
+                values.sort();
+                values.dedup();
+                body.push_str(&format!("@{key}: {}\n", values.join(", ")));
+            }
+            if let Some(synopsis) = &scene.synopsis {
+                for s in synopsis.lines() {
+                    body.push_str(&format!("%Synopsis: {s}\n"));
+                }
+            }
+            let mut scene_beats: Vec<_> = beats
+                .iter()
+                .filter(|beat| beat.scene_id == scene.id)
+                .collect();
+            scene_beats.sort_by_key(|beat| beat.position);
+            if scene.editor_mode == EditorMode::Page {
+                // Page prose has no defensible beat boundaries.
+                body.push_str(&format!(
+                    "\n{}\n",
+                    html_to_nw(scene.prose.as_deref().unwrap_or_default())
+                ));
+            } else {
+                for beat in scene_beats {
+                    body.push('\n');
+                    if options.include_beat_comments {
+                        body.push_str(&format!("% Beat: {}\n", line(&beat.content)));
+                    }
+                    body.push_str(&html_to_nw(beat.prose.as_deref().unwrap_or_default()));
+                    body.push('\n');
+                }
+            }
+            let mut item = document(sh.clone(), &handle, &novel, "NOVEL", &scene.title, 3);
+            item.status = match scene.scene_status {
+                SceneStatus::Draft => "s000000",
+                SceneStatus::Revised => "s000001",
+                SceneStatus::Final => "s000002",
+            }
+            .into();
+            ids.push(("scenes", scene.id, sh));
+            b.push(item, body);
+        }
+    }
+    // Stage beside the destination so failed writes cannot leave a half-project.
+    let parent = destination
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    let stage = parent.join(format!(".kindling-nw-{}", Uuid::new_v4()));
+    std::fs::create_dir(&stage).map_err(|e| e.to_string())?;
+    let result = (|| -> Result<(), String> {
+        std::fs::create_dir(stage.join("content")).map_err(|e| e.to_string())?;
+        for (handle, body) in &b.bodies {
+            std::fs::write(stage.join("content").join(format!("{handle}.md")), body)
+                .map_err(|e| e.to_string())?;
+        }
+        std::fs::write(stage.join("nwProject.nwx"), write_nwx(&b.doc))
+            .map_err(|e| e.to_string())?;
+        let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+        if matches!(
+            project.source_type,
+            SourceType::NovelWriter | SourceType::Blank
+        ) {
+            for (table, id, handle) in ids {
+                tx.execute(
+                    &format!("UPDATE {table} SET source_id = ?1 WHERE id = ?2"),
+                    rusqlite::params![handle, id.to_string()],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+        }
+        // Recheck just before publishing; retain OS metadata in the new folder.
+        for file in metadata_files(destination)? {
+            std::fs::copy(&file, stage.join(file.file_name().unwrap()))
+                .map_err(|e| e.to_string())?;
+        }
+        if destination.exists() {
+            for file in metadata_files(destination)? {
+                std::fs::remove_file(file).map_err(|e| e.to_string())?;
+            }
+            std::fs::remove_dir(destination).map_err(|e| e.to_string())?;
+        }
+        std::fs::rename(&stage, destination).map_err(|e| e.to_string())?;
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(())
+    })();
+    if stage.exists() {
+        let _ = std::fs::remove_dir_all(&stage);
+    }
+    result?;
+    Ok(b.bodies.len())
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { IMPORT_FORMATS, importTypeForCommand, isImportType } from "./lib/importFormats";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
   import { exit } from "@tauri-apps/plugin-process";
@@ -84,23 +85,25 @@
     }
   });
 
-  const HAS_REFERENCES: ImportType[] = ["plottr", "ywriter", "longform", "longformVault"];
-
   async function handleImport(type: ImportType) {
     const project = await runImport(type);
     if (!project) return;
     activateImportedProject(project);
-    if (HAS_REFERENCES.includes(type)) {
+    if (IMPORT_FORMATS[type].references) {
       openReferenceClassificationDialog(project);
     }
   }
 
-  const importPlottr = () => handleImport("plottr");
-  const importMarkdown = () => handleImport("markdown");
-  const importYWriter = () => handleImport("ywriter");
   const importLongform = () => handleImport("longform");
   const importLongformVault = () => handleImport("longformVault");
-  const importScrivener = () => handleImport("scrivener");
+
+  function handleImportCommand(command: string): boolean {
+    const type = importTypeForCommand(command);
+    if (!type) return false;
+    if (type === "longform") openLongformImportDialog();
+    else void handleImport(type);
+    return true;
+  }
 
   function openLongformImportDialog() {
     showLongformImportDialog = true;
@@ -123,24 +126,10 @@
     const unlisten = listen<string>("menu-event", (event) => {
       const menuId = event.payload;
 
+      if (handleImportCommand(menuId)) return;
       switch (menuId) {
         case "new_project":
           showNewProjectDialog = true;
-          break;
-        case "import_plottr":
-          importPlottr();
-          break;
-        case "import_ywriter":
-          importYWriter();
-          break;
-        case "import_markdown":
-          importMarkdown();
-          break;
-        case "import_longform":
-          openLongformImportDialog();
-          break;
-        case "import_scrivener":
-          importScrivener();
           break;
         case "export":
           if (currentProject.value) {
@@ -203,27 +192,13 @@
   );
 
   function runCommand(id: string) {
+    if (handleImportCommand(id)) return;
     switch (id) {
       case "export":
         if (currentProject.value) showExportDialog = true;
         break;
       case "close_project":
         closeProject();
-        break;
-      case "import_plottr":
-        importPlottr();
-        break;
-      case "import_markdown":
-        importMarkdown();
-        break;
-      case "import_longform":
-        openLongformImportDialog();
-        break;
-      case "import_ywriter":
-        importYWriter();
-        break;
-      case "import_scrivener":
-        importScrivener();
         break;
       case "project_settings":
         if (currentProject.value) showProjectSettings = true;
@@ -303,7 +278,7 @@
       {recentProjects}
       onImportLongform={openLongformImportDialog}
       onImportComplete={(project, type) => {
-        if (HAS_REFERENCES.includes(type)) {
+        if (IMPORT_FORMATS[type].references) {
           openReferenceClassificationDialog(project);
         }
       }}
@@ -333,7 +308,7 @@
 <Onboarding
   onImportLongform={openLongformImportDialog}
   onImportComplete={(project: Project, type: string) => {
-    if (HAS_REFERENCES.includes(type as ImportType)) {
+    if (isImportType(type) && IMPORT_FORMATS[type].references) {
       openReferenceClassificationDialog(project);
     }
   }}

--- a/src/dev/mock-tauri.ts
+++ b/src/dev/mock-tauri.ts
@@ -1,3 +1,4 @@
+import { IMPORT_FORMATS, importTypeForCommand } from "../lib/importFormats";
 /**
  * Mock Tauri invoke() for browser-only dev (npm run dev without Tauri).
  * Provides an in-memory backend so Cursor can drive the full UI via browser tools.
@@ -82,18 +83,16 @@ export async function invoke<T>(cmd: string, args: Record<string, unknown> = {})
   const referenceId = getArg<string>(args, "referenceId", "reference_id");
   const snapshotId = getArg<string>(args, "snapshotId", "snapshot_id");
 
+  const importType = importTypeForCommand(cmd);
+  if (importType) {
+    return {
+      ...projects[0]!,
+      source_type: IMPORT_FORMATS[importType].sourceType,
+      source_path: getArg<string>(args, "path") ?? "/mock/path/story.pltr",
+      modified_at: new Date().toISOString(),
+    } as T;
+  }
   switch (cmd) {
-    // Import - return the seed project
-    case "import_plottr":
-    case "import_ywriter":
-    case "import_markdown":
-    case "import_longform":
-    case "import_scrivener": {
-      const path = getArg<string>(args, "path") ?? "/mock/path/story.pltr";
-      const project = projects[0]!;
-      return { ...project, source_path: path, modified_at: new Date().toISOString() } as T;
-    }
-
     case "preview_import": {
       void getArg<string>(args, "path");
       void getArg<string>(args, "format");
@@ -572,6 +571,7 @@ export async function invoke<T>(cmd: string, args: Record<string, unknown> = {})
         beats_added: 0,
         beats_updated: 0,
         prose_preserved: 0,
+        prose_updated: 0,
       } as T;
     }
 
@@ -589,6 +589,7 @@ export async function invoke<T>(cmd: string, args: Record<string, unknown> = {})
         beats_added: 0,
         beats_updated: 0,
         prose_preserved: 0,
+        prose_updated: 0,
       } as T;
     }
 
@@ -738,9 +739,13 @@ export async function invoke<T>(cmd: string, args: Record<string, unknown> = {})
     case "preview_scrivener_matches":
       return [] as T;
 
+    case "export_to_novelwriter":
     case "export_to_scrivener": {
       const options = getArg<{ output_path?: string }>(args, "options");
-      const outputPath = options?.output_path ?? "/mock/path/export";
+      const outputPath =
+        getArg<string>(args, "outputPath", "output_path") ??
+        options?.output_path ??
+        "/mock/path/export";
       return {
         output_path: outputPath,
         files_created: 1,

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -87,6 +87,14 @@ export const COMMAND_DEFS: CommandDef[] = [
     keywords: ["import", "scrivener", "scriv"],
     requiresProject: false,
   },
+  {
+    id: "import_novelwriter",
+    label: "Import novelWriter",
+    shortcut: "",
+    category: "File",
+    keywords: ["import", "novelwriter", "nwx"],
+    requiresProject: false,
+  },
   // Project
   {
     id: "project_settings",

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -44,6 +44,7 @@
     TreatmentOptions,
     ScrivenerExportMode,
     ScrivenerExportOptions,
+    NovelWriterExportOptions,
   } from "../types";
   import ScrivenerMatchDialog from "./ScrivenerMatchDialog.svelte";
   import Tooltip from "./Tooltip.svelte";
@@ -64,9 +65,9 @@
     onSuccess: (result: ExportResult) => void;
   } = $props();
 
-  let exportFormat = $state<"markdown" | "longform" | "docx" | "epub" | "treatment" | "scrivener">(
-    "docx"
-  );
+  let exportFormat = $state<
+    "markdown" | "longform" | "docx" | "epub" | "treatment" | "scrivener" | "novelwriter"
+  >("docx");
   let includeBeatMarkers = $state(false);
   let includeSynopsis = $state(false);
   let pageBreaksBetweenChapters = $state(true);
@@ -85,6 +86,9 @@
   let treatmentLevel = $state<TreatmentLevel>("five_page");
   let treatmentFormat = $state<TreatmentFormat>("docx");
   let treatmentFilePath = $state("");
+  let novelwriterPath = $state("");
+  let novelwriterBeatComments = $state(true);
+  let novelwriterNotes = $state(true);
   let scrivenerMode = $state<ScrivenerExportMode>("create_new");
   let scrivenerPath = $state("");
   let scrivenerBackup = $state(true);
@@ -211,7 +215,11 @@
   });
 
   const canExport = $derived(
-    (exportFormat === "markdown" && outputPath.length > 0) ||
+    (exportFormat === "novelwriter" &&
+      novelwriterPath.length > 0 &&
+      scope === "project" &&
+      currentProject.value?.project_type !== "screenplay") ||
+      (exportFormat === "markdown" && outputPath.length > 0) ||
       (exportFormat === "longform" && outputPath.length > 0) ||
       (exportFormat === "docx" && docxFilePath.length > 0) ||
       (exportFormat === "epub" &&
@@ -287,6 +295,22 @@
     if (path) {
       treatmentFilePath = path;
       error = null;
+    }
+  }
+
+  async function selectNovelWriterPath() {
+    try {
+      const path = await open({
+        directory: true,
+        multiple: false,
+        title: "Choose an empty novelWriter destination folder",
+      });
+      if (path) {
+        novelwriterPath = path;
+        error = null;
+      }
+    } catch (e) {
+      error = String(e);
     }
   }
 
@@ -400,6 +424,17 @@
 
         result = await invoke<ExportResult>("generate_treatment", {
           projectId: currentProject.value.id,
+          options,
+        });
+      } else if (exportFormat === "novelwriter") {
+        const options: NovelWriterExportOptions = {
+          include_beat_comments: novelwriterBeatComments,
+          include_notes: novelwriterNotes,
+          create_snapshot: createSnapshot,
+        };
+        result = await invoke<ExportResult>("export_to_novelwriter", {
+          projectId: currentProject.value.id,
+          outputPath: novelwriterPath,
           options,
         });
       } else if (exportFormat === "scrivener") {
@@ -531,6 +566,27 @@
       <fieldset>
         <legend class="block text-press-ui font-medium text-press-muted mb-3">Export Format</legend>
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {#if scope === "project" && currentProject.value?.project_type !== "screenplay"}
+            <label
+              class="relative flex flex-col items-center p-4 rounded-lg border-2 cursor-pointer transition-all {exportFormat ===
+              'novelwriter'
+                ? 'border-press-accent bg-press-accent-wash'
+                : 'border-press-border bg-press-sunken'}"
+            >
+              <input
+                type="radio"
+                name="format"
+                data-testid="export-format-novelwriter"
+                value="novelwriter"
+                bind:group={exportFormat}
+                class="sr-only"
+              />
+              <BookOpen class="w-8 h-8 mb-2 text-press-muted" />
+              <span class="text-press-ui font-medium text-press-text">novelWriter</span>
+              <span class="text-press-eyebrow text-press-muted">Project folder</span>
+            </label>
+          {/if}
+
           <label
             class="relative flex flex-col items-center p-4 rounded-lg border-2 cursor-pointer transition-all {exportFormat ===
             'docx'
@@ -1263,6 +1319,65 @@
             </Tooltip>
           </div>
         </div>
+      {:else if exportFormat === "novelwriter"}
+        <div class="space-y-4">
+          <p class="text-press-small text-press-muted">
+            Export a complete project for novelWriter 26.2 or newer. Choose an empty folder.
+          </p>
+          <label class="flex items-center gap-3 text-press-ui text-press-text"
+            ><input
+              type="checkbox"
+              data-testid="novelwriter-beat-comments"
+              bind:checked={novelwriterBeatComments}
+            /> Include beat comments</label
+          >
+          <p class="text-press-small text-press-muted">
+            Turning off beat comments disables beat-level sync. Page-mode prose syncs as a whole
+            scene.
+          </p>
+          <label class="flex items-center gap-3 text-press-ui text-press-text"
+            ><input
+              type="checkbox"
+              data-testid="novelwriter-notes"
+              bind:checked={novelwriterNotes}
+            /> Include characters, locations and notes</label
+          >
+          <label for="novelwriter-destination" class="block text-press-ui text-press-muted"
+            >Destination folder</label
+          >
+          <div class="flex gap-2">
+            <input
+              id="novelwriter-destination"
+              readonly
+              value={novelwriterPath}
+              placeholder="Choose an empty folder"
+              class="flex-1 min-w-0 px-3 py-2 bg-press-sunken border border-press-border rounded-lg text-press-base text-press-text"
+            />
+            <button
+              type="button"
+              onclick={selectNovelWriterPath}
+              aria-label="Choose novelWriter destination folder"
+              class="p-2 border border-press-border rounded-lg"
+              ><FolderOpen class="w-5 h-5" /></button
+            >
+          </div>
+          <details class="text-press-small text-press-muted">
+            <summary>Round-trip limitations</summary>
+            <p>
+              Export omits underline, planning status, scene type, tags, discovery notes, snapshots
+              and custom fields. Scene status is limited to Draft, Revised and Final.
+            </p>
+            <p>
+              Import flattens H4 sections and does not preserve shortcodes, footnotes, alignment,
+              indent codes, importance, ignored text, templates, additional novel roots or POV,
+              focus, mention and story references.
+            </p>
+            <p>
+              Sync covers chapters, scenes, beats and prose. Notes, reference links and project
+              metadata are not synced. Existing source connections are preserved when exporting.
+            </p>
+          </details>
+        </div>
       {:else if exportFormat === "scrivener"}
         <!-- Scrivener Export Options -->
         <fieldset>
@@ -1673,6 +1788,7 @@
       </button>
       <button
         type="button"
+        data-testid="export-confirm"
         onclick={handleExport}
         class="px-5 py-2 text-press-ui font-medium bg-press-accent text-press-on-accent rounded-lg hover:bg-press-accent-text transition-colors disabled:cursor-not-allowed flex items-center gap-2"
         disabled={!canExport || exporting}

--- a/src/lib/components/NovelWriter.test.ts
+++ b/src/lib/components/NovelWriter.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import ExportDialog from "./ExportDialog.svelte";
+import SyncDialog from "./SyncDialog.svelte";
+import Sidebar from "./Sidebar.svelte";
+import Onboarding from "./Onboarding.svelte";
+import { currentProject } from "../stores/project.svelte";
+import { ui } from "../stores/ui.svelte";
+import { runImport } from "../utils/import";
+import { COMMAND_DEFS } from "../commands";
+import type { Project, SyncPreview } from "../types";
+
+vi.hoisted(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => values.get(k) ?? null,
+    setItem: (k: string, v: string) => values.set(k, v),
+    removeItem: (k: string) => values.delete(k),
+    clear: () => values.clear(),
+  });
+});
+
+const project: Project = {
+  id: "project-1",
+  name: "A story",
+  source_type: "NovelWriter",
+  source_path: "/source",
+  created_at: "2026-09-05",
+  modified_at: "2026-09-05",
+  author_pen_name: null,
+  genre: null,
+  description: null,
+  word_target: null,
+  reference_types: ["characters", "locations"],
+  project_type: "novel",
+  target_page_count: null,
+};
+const result = {
+  output_path: "/export",
+  files_created: 4,
+  chapters_exported: 1,
+  scenes_exported: 2,
+};
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(open).mockReset();
+  localStorage.clear();
+  currentProject.setProject(null);
+  currentProject.setProject({ ...project });
+  vi.mocked(invoke).mockImplementation(async (cmd) =>
+    cmd === "get_project_word_count" ? 2000 : cmd === "export_to_novelwriter" ? result : []
+  );
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  currentProject.setProject(null);
+});
+
+describe("novelWriter export", () => {
+  function dialog() {
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
+    render(ExportDialog, {
+      scope: "project",
+      scopeId: null,
+      scopeTitle: "Project",
+      onClose,
+      onSuccess,
+    });
+    return { onClose, onSuccess };
+  }
+  it("defaults beat comments and notes on, requires a folder, and sends options", async () => {
+    const { onSuccess } = dialog();
+    await fireEvent.click(screen.getByRole("radio", { name: /novelWriter/ }));
+    expect((screen.getByLabelText("Include beat comments") as HTMLInputElement).checked).toBe(true);
+    expect(
+      (screen.getByLabelText("Include characters, locations and notes") as HTMLInputElement).checked
+    ).toBe(true);
+    expect(screen.getByText(/Turning off beat comments disables beat-level sync/)).toBeTruthy();
+    const exportButton = screen.getByTestId("export-confirm") as HTMLButtonElement;
+    expect(exportButton.disabled).toBe(true);
+    vi.mocked(open).mockResolvedValue("/export");
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Choose novelWriter destination folder" })
+    );
+    expect(open).toHaveBeenCalledWith(expect.objectContaining({ directory: true }));
+    await fireEvent.click(screen.getByLabelText("Include characters, locations and notes"));
+    await fireEvent.click(exportButton);
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("export_to_novelwriter", {
+        projectId: project.id,
+        outputPath: "/export",
+        options: { include_beat_comments: true, include_notes: false, create_snapshot: false },
+      })
+    );
+    expect(onSuccess).toHaveBeenCalledWith(result);
+  });
+  it("keeps the dialog open when export fails", async () => {
+    const { onClose, onSuccess } = dialog();
+    await fireEvent.click(screen.getByRole("radio", { name: /novelWriter/ }));
+    vi.mocked(open).mockResolvedValue("/occupied");
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Choose novelWriter destination folder" })
+    );
+    vi.mocked(invoke).mockRejectedValue("Choose an empty destination folder");
+    await fireEvent.click(screen.getByTestId("export-confirm"));
+    expect(await screen.findByText("Choose an empty destination folder")).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+  it("hides novelWriter for screenplay projects", () => {
+    currentProject.setProject({ ...project, project_type: "screenplay" });
+    dialog();
+    expect(screen.queryByRole("radio", { name: /novelWriter/ })).toBeNull();
+  });
+});
+
+describe("novelWriter import", () => {
+  it("uses the directory picker and surfaces failures", async () => {
+    vi.mocked(open).mockResolvedValue("/source");
+    vi.mocked(invoke).mockResolvedValue(project);
+    expect(await runImport("novelwriter")).toEqual(project);
+    expect(open).toHaveBeenCalledWith({ multiple: false, directory: true });
+    expect(invoke).toHaveBeenCalledWith("import_novelwriter", { path: "/source" });
+    const showError = vi.spyOn(ui, "showError");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(invoke).mockRejectedValue("nwProject.nwx missing");
+    expect(await runImport("novelwriter")).toBeNull();
+    expect(showError).toHaveBeenCalledWith(expect.stringContaining("nwProject.nwx missing"));
+    vi.mocked(open).mockResolvedValue(null);
+    expect(await runImport("novelwriter")).toBeNull();
+  });
+  it("offers guided preview/import and a menu command", async () => {
+    ui.goToStep("import");
+    vi.mocked(open).mockResolvedValue("/source");
+    vi.mocked(invoke).mockImplementation(async (cmd) =>
+      cmd === "preview_import"
+        ? {
+            project_name: "Guided novel",
+            chapter_count: 1,
+            scene_count: 2,
+            beat_count: 3,
+            character_count: 1,
+            location_count: 1,
+          }
+        : project
+    );
+    render(Onboarding);
+    await fireEvent.click(screen.getByRole("button", { name: /novelWriter/ }));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("preview_import", {
+        path: "/source",
+        format: "novelwriter",
+      })
+    );
+    expect(await screen.findByText(/Guided novel/)).toBeTruthy();
+    await fireEvent.click(screen.getByTestId("guided-import-confirm"));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("import_novelwriter", { path: "/source" })
+    );
+    expect(COMMAND_DEFS.some((c) => c.id === "import_novelwriter")).toBe(true);
+  });
+});
+
+describe("prose sync UI", () => {
+  it("shows full before/after prose and selects it independently", async () => {
+    const syncPreview: SyncPreview = {
+      additions: [],
+      changes: [
+        {
+          id: "prose-1",
+          item_type: "scene",
+          field: "prose",
+          item_title: "Arrival",
+          current_value: "Before\n\n" + "Long paragraph. ".repeat(40),
+          new_value: "After\n\nA new paragraph.",
+          db_id: "scene-1",
+        },
+        {
+          id: "title-1",
+          item_type: "scene",
+          field: "title",
+          item_title: "Arrival",
+          current_value: "Arrival",
+          new_value: "Departure",
+          db_id: "scene-1",
+        },
+      ],
+    };
+    render(SyncDialog, {
+      projectId: project.id,
+      syncPreview,
+      onClose: vi.fn(),
+      onSyncComplete: vi.fn(),
+    });
+    expect(screen.getByTestId("sync-prose-diff").textContent).toContain(
+      syncPreview.changes[0].current_value
+    );
+    await fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    await fireEvent.click(screen.getByTestId("sync-confirm"));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("apply_sync", {
+        projectId: project.id,
+        acceptedChangeIds: ["prose-1"],
+        acceptedAdditionIds: [],
+      })
+    );
+  });
+  it.each([
+    "Scrivener",
+    "Blank",
+    "NovelWriter",
+    "Plottr",
+    "YWriter",
+    "Markdown",
+    "Longform",
+  ] as const)("gates sidebar sync for %s", async (source_type) => {
+    currentProject.setProject({ ...project, source_type });
+    render(Sidebar);
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    expect(screen.queryByTestId("sync-button") !== null).toBe(
+      !["Scrivener", "Blank"].includes(source_type)
+    );
+  });
+});
+
+// Reference categories introduced by novelWriter must work throughout the UI.
+import ProjectSettingsDialog from "./ProjectSettingsDialog.svelte";
+import ReferenceEditDialog from "./ReferenceEditDialog.svelte";
+import ReferenceClassificationDialog from "./ReferenceClassificationDialog.svelte";
+import ScenePanel from "./ScenePanel.svelte";
+import { REFERENCE_TYPE_OPTIONS } from "../referenceTypes";
+import { mockScenes, mockChapters } from "../../dev/mock-data";
+
+describe("timeline and custom references", () => {
+  it("loads both categories in classification and submits a character reclassification", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+      if (cmd === "get_characters") return [{ id: "jane", name: "Jane", description: null }];
+      if (cmd === "get_references") {
+        const type = (args as { referenceType: string }).referenceType;
+        if (["timelines", "custom"].includes(type))
+          return [{ id: type, name: `Loaded ${type}`, description: null }];
+      }
+      return cmd === "reclassify_references" ? project : [];
+    });
+    render(ReferenceClassificationDialog, {
+      projectId: project.id,
+      onClose: vi.fn(),
+      onComplete: vi.fn(),
+    });
+    await screen.findByText("Loaded timelines");
+    expect(screen.getByText("Loaded custom")).toBeTruthy();
+    const select = screen.getByText("Jane").closest("tr")!.querySelector("select")!;
+    await fireEvent.change(select, { target: { value: "timelines" } });
+    await fireEvent.click(screen.getByText("Apply changes"));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("reclassify_references", {
+        projectId: project.id,
+        changes: [{ reference_id: "jane", new_type: "timelines" }],
+      })
+    );
+  });
+
+  it("offers custom field definitions for both types in project settings", async () => {
+    currentProject.setProject({ ...project, reference_types: ["timelines", "custom"] });
+    render(ProjectSettingsDialog, { onClose: vi.fn(), onSave: vi.fn() });
+    await waitFor(() => {
+      for (const entityType of ["timeline", "custom"])
+        expect(invoke).toHaveBeenCalledWith("get_field_definitions", {
+          projectId: project.id,
+          entityType,
+        });
+    });
+  });
+
+  it.each(["timelines", "custom"])("loads %s fields when editing a reference", async (type) => {
+    const option = REFERENCE_TYPE_OPTIONS.find((option) => option.id === type)!;
+    render(ReferenceEditDialog, {
+      projectId: project.id,
+      referenceType: option,
+      onClose: vi.fn(),
+      onSave: vi.fn(),
+    });
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("get_field_definitions", {
+        projectId: project.id,
+        entityType: type === "timelines" ? "timeline" : "custom",
+      })
+    );
+  });
+
+  it("shows linked timeline and custom notes in the scene panel", async () => {
+    currentProject.setCurrentChapter(mockChapters[0]);
+    currentProject.setCurrentScene({
+      ...mockScenes[0],
+      planning_status: "fixed",
+      editor_mode: "beat",
+    });
+    vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+      const type = (args as { referenceType?: string } | undefined)?.referenceType;
+      if (cmd === "get_scene_reference_items" && ["timelines", "custom"].includes(type ?? ""))
+        return [{ id: type, name: `Linked ${type}` }];
+      return [];
+    });
+    render(ScenePanel);
+    await screen.findByText("Linked timelines");
+    expect(screen.getByText("Linked custom")).toBeTruthy();
+  });
+});

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { IMPORT_FORMATS, type ImportType } from "../importFormats";
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-dialog";
   import {
@@ -35,7 +36,7 @@
   let { onImportComplete, onImportLongform }: Props = $props();
 
   // Guided import wizard state (within import step)
-  type GuidedFormat = "plottr" | "markdown" | "ywriter" | "longform" | "scrivener";
+  type GuidedFormat = Exclude<ImportType, "longformVault">;
   let guidedPreview = $state<ImportPreview | null>(null);
   let guidedPath = $state<string | null>(null);
   let guidedFormat = $state<GuidedFormat | null>(null);
@@ -65,29 +66,18 @@
     }
   }
 
-  const FORMAT_CONFIG: Record<
-    GuidedFormat,
-    { name: string; extensions: string[]; directory?: boolean }
-  > = {
-    plottr: { name: "Plottr", extensions: ["pltr"] },
-    markdown: { name: "Markdown", extensions: ["md", "markdown"] },
-    ywriter: { name: "yWriter 7", extensions: ["yw7"] },
-    longform: { name: "Longform Index", extensions: ["md", "markdown"] },
-    scrivener: { name: "Scrivener 3", extensions: ["scriv"] },
-  };
-
   async function startGuidedImport(format: GuidedFormat) {
     guidedError = null;
     guidedPreview = null;
     guidedPath = null;
     guidedFormat = format;
-    const config = FORMAT_CONFIG[format];
+    const config = IMPORT_FORMATS[format];
     const path =
       format === "scrivener"
         ? await pickScrivenerProjectPath()
         : await open({
             multiple: false,
-            filters: [{ name: config.name, extensions: config.extensions }],
+            ...(config.directory ? {} : { filters: config.filters }),
             directory: config.directory ?? false,
           });
     if (path) {
@@ -134,24 +124,7 @@
 
     ui.startImport();
     try {
-      let project: Project;
-      switch (format) {
-        case "plottr":
-          project = await invoke<Project>("import_plottr", { path });
-          break;
-        case "markdown":
-          project = await invoke<Project>("import_markdown", { path });
-          break;
-        case "ywriter":
-          project = await invoke<Project>("import_ywriter", { path });
-          break;
-        case "longform":
-          project = await invoke<Project>("import_longform", { path });
-          break;
-        case "scrivener":
-          project = await invoke<Project>("import_scrivener", { path });
-          break;
-      }
+      const project = await invoke<Project>(IMPORT_FORMATS[format].command, { path });
       currentProject.setProject(project);
       ui.completeOnboarding();
       ui.setView("editor");
@@ -767,6 +740,7 @@
                     Choose different file
                   </button>
                   <button
+                    data-testid="guided-import-confirm"
                     onclick={confirmGuidedImport}
                     class="px-6 py-2 bg-press-accent hover:bg-press-accent-text text-press-on-accent font-medium rounded-lg transition-colors"
                   >
@@ -817,6 +791,15 @@
                   <Kanban class="w-10 h-10 text-press-accent-text mb-2" />
                   <span class="text-press-text font-medium text-press-ui">Plottr</span>
                   <span class="text-press-muted text-press-eyebrow">.pltr</span>
+                </button>
+
+                <button
+                  onclick={() => startGuidedImport("novelwriter")}
+                  class="flex flex-col items-center p-4 bg-press-sunken rounded-lg hover:bg-press-sunken transition-colors cursor-pointer border border-transparent hover:border-press-accent"
+                >
+                  <Scroll class="w-10 h-10 text-press-accent-text mb-2" />
+                  <span class="text-press-text font-medium text-press-ui">novelWriter</span>
+                  <span class="text-press-muted text-press-eyebrow">Project folder</span>
                 </button>
 
                 <button

--- a/src/lib/components/ProjectSettingsDialog.svelte
+++ b/src/lib/components/ProjectSettingsDialog.svelte
@@ -8,10 +8,11 @@
   - Word target
 -->
 <script lang="ts">
+  import { REFERENCE_FIELD_TYPES, REFERENCE_TYPE_OPTIONS } from "../referenceTypes";
   import { invoke } from "@tauri-apps/api/core";
   import { X, Loader2, BookOpen } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
-  import type { Project, FieldEntityType } from "../types";
+  import type { Project } from "../types";
   import { normalizeReferenceTypes, DEFAULT_REFERENCE_TYPES } from "../referenceTypes";
   import FieldDefinitionManager from "./FieldDefinitionManager.svelte";
   import TagManager from "./TagManager.svelte";
@@ -210,13 +211,7 @@
         {@const enabledTypes = normalizeReferenceTypes(
           currentProject.value.reference_types ?? DEFAULT_REFERENCE_TYPES
         )}
-        {@const entityTypeMap = {
-          characters: { entity: "character" as FieldEntityType, label: "Character" },
-          locations: { entity: "location" as FieldEntityType, label: "Location" },
-          items: { entity: "item" as FieldEntityType, label: "Item" },
-          objectives: { entity: "objective" as FieldEntityType, label: "Objective" },
-          organizations: { entity: "organization" as FieldEntityType, label: "Organization" },
-        }}
+
         <div class="border-t border-press-border pt-4">
           <h3 class="text-press-ui font-medium text-press-text mb-3">Custom Fields</h3>
           <p class="text-press-eyebrow text-press-muted mb-3">
@@ -225,11 +220,11 @@
           </p>
           <div class="space-y-4">
             {#each enabledTypes as refType}
-              {@const mapping = entityTypeMap[refType as keyof typeof entityTypeMap]}
+              {@const mapping = REFERENCE_TYPE_OPTIONS.find((option) => option.id === refType)}
               {#if mapping}
                 <FieldDefinitionManager
                   projectId={currentProject.value.id}
-                  entityType={mapping.entity}
+                  entityType={REFERENCE_FIELD_TYPES[refType]}
                   entityLabel={mapping.label}
                 />
               {/if}

--- a/src/lib/components/ReferenceClassificationDialog.svelte
+++ b/src/lib/components/ReferenceClassificationDialog.svelte
@@ -42,62 +42,28 @@
     loading = true;
     error = null;
     try {
-      const [characters, locations, items, objectives, organizations] = await Promise.all([
-        invoke<Character[]>("get_characters", { projectId }).then((rows) =>
-          rows.map((row) => ({
+      const groups = await Promise.all(
+        REFERENCE_TYPE_OPTIONS.map(async ({ id }) => {
+          const command =
+            id === "characters"
+              ? "get_characters"
+              : id === "locations"
+                ? "get_locations"
+                : "get_references";
+          const rows = await invoke<Array<Character | Location | ReferenceItem>>(command, {
+            projectId,
+            ...(command === "get_references" ? { referenceType: id } : {}),
+          });
+          return rows.map((row) => ({
             id: row.id,
             name: row.name,
             description: row.description,
-            reference_type: "characters" as ReferenceTypeId,
-            original_type: "characters" as ReferenceTypeId,
-          }))
-        ),
-        invoke<Location[]>("get_locations", { projectId }).then((rows) =>
-          rows.map((row) => ({
-            id: row.id,
-            name: row.name,
-            description: row.description,
-            reference_type: "locations" as ReferenceTypeId,
-            original_type: "locations" as ReferenceTypeId,
-          }))
-        ),
-        invoke<ReferenceItem[]>("get_references", { projectId, referenceType: "items" }).then(
-          (rows) =>
-            rows.map((row) => ({
-              id: row.id,
-              name: row.name,
-              description: row.description,
-              reference_type: "items" as ReferenceTypeId,
-              original_type: "items" as ReferenceTypeId,
-            }))
-        ),
-        invoke<ReferenceItem[]>("get_references", {
-          projectId,
-          referenceType: "objectives",
-        }).then((rows) =>
-          rows.map((row) => ({
-            id: row.id,
-            name: row.name,
-            description: row.description,
-            reference_type: "objectives" as ReferenceTypeId,
-            original_type: "objectives" as ReferenceTypeId,
-          }))
-        ),
-        invoke<ReferenceItem[]>("get_references", {
-          projectId,
-          referenceType: "organizations",
-        }).then((rows) =>
-          rows.map((row) => ({
-            id: row.id,
-            name: row.name,
-            description: row.description,
-            reference_type: "organizations" as ReferenceTypeId,
-            original_type: "organizations" as ReferenceTypeId,
-          }))
-        ),
-      ]);
-
-      references = [...characters, ...locations, ...items, ...objectives, ...organizations];
+            reference_type: id,
+            original_type: id,
+          }));
+        })
+      );
+      references = groups.flat();
       return references.length === 0;
     } catch (e) {
       console.error("Failed to load reference classifications:", e);

--- a/src/lib/components/ReferenceEditDialog.svelte
+++ b/src/lib/components/ReferenceEditDialog.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { REFERENCE_FIELD_TYPES } from "../referenceTypes";
   import { invoke } from "@tauri-apps/api/core";
   import { Loader2, Plus, Trash2, X } from "lucide-svelte";
-  import type { ReferenceItem, FieldDefinition, FieldValue, FieldEntityType } from "../types";
+  import type { ReferenceItem, FieldDefinition, FieldValue } from "../types";
   import type { ReferenceTypeOption } from "../referenceTypes";
   import FieldRenderer from "./FieldRenderer.svelte";
   import Tooltip from "./Tooltip.svelte";
@@ -27,13 +28,7 @@
 
   type AttributeRow = { id: string; key: string; value: string };
 
-  const entityTypeMap: Record<string, FieldEntityType> = {
-    characters: "character",
-    locations: "location",
-    items: "item",
-    objectives: "objective",
-    organizations: "organization",
-  };
+  const entityTypeMap = REFERENCE_FIELD_TYPES;
 
   let name = $state("");
   let description = $state("");

--- a/src/lib/components/ReferencesPanel.svelte
+++ b/src/lib/components/ReferencesPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { REFERENCE_FIELD_TYPES } from "../referenceTypes";
   import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
@@ -162,13 +163,7 @@
       }
 
       // Load field definitions for each entity type
-      const entityTypeMap: Record<string, string> = {
-        characters: "character",
-        locations: "location",
-        items: "item",
-        objectives: "objective",
-        organizations: "organization",
-      };
+      const entityTypeMap = REFERENCE_FIELD_TYPES;
       const defsMap: Record<string, FieldDefinition[]> = {};
       for (const type of enabledTypes) {
         const entityType = entityTypeMap[type] ?? type;

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -97,7 +97,7 @@
   ];
 
   const sceneReferenceOptions = REFERENCE_TYPE_OPTIONS.filter(
-    (option) => option.id === "items" || option.id === "objectives" || option.id === "organizations"
+    (option) => option.id !== "characters" && option.id !== "locations"
   );
 
   let sceneReferenceItems = $state<Record<ReferenceTypeId, ReferenceItem[]>>(
@@ -976,9 +976,7 @@
                   {/each}
                 </div>
               {:else if !sceneReferenceLoading}
-                <div class="text-press-ui text-press-muted">
-                  No linked items, objectives, or organizations.
-                </div>
+                <div class="text-press-ui text-press-muted">No linked reference notes.</div>
               {/if}
             {/if}
           </section>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -8,6 +8,7 @@
   - Sync button for reimporting
 -->
 <script lang="ts">
+  import { supportsSync } from "../importFormats";
   import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
@@ -1282,7 +1283,7 @@
               <Settings class="w-4 h-4" />
             </button>
           </Tooltip>
-          {#if currentProject.value.source_path}
+          {#if currentProject.value.source_path && supportsSync(currentProject.value.source_type)}
             <Tooltip text="Sync from source" position="bottom">
               <button
                 data-testid="sync-button"

--- a/src/lib/components/SyncDialog.svelte
+++ b/src/lib/components/SyncDialog.svelte
@@ -21,6 +21,7 @@
   let { projectId, syncPreview, onClose, onSyncComplete }: Props = $props();
 
   let syncing = $state(false);
+  let error = $state<string | null>(null);
   let selectedChanges = new SvelteSet<string>();
   let selectedAdditions = new SvelteSet<string>();
 
@@ -73,6 +74,7 @@
 
   async function applySync() {
     syncing = true;
+    error = null;
     try {
       const summary = await invoke<ReimportSummary>("apply_sync", {
         projectId,
@@ -82,6 +84,7 @@
       onSyncComplete(summary);
     } catch (e) {
       console.error("Failed to apply sync:", e);
+      error = String(e);
     } finally {
       syncing = false;
     }
@@ -259,6 +262,8 @@
                 >
                   <input
                     type="checkbox"
+                    data-testid="sync-change-checkbox"
+                    data-change-id={change.id}
                     checked={selectedChanges.has(change.id)}
                     onchange={() => toggleChange(change.id)}
                     class="mt-0.5 w-5 h-5 rounded border-2 border-press-border bg-transparent text-press-accent-text focus:ring-press-focus focus:ring-offset-0 cursor-pointer"
@@ -273,18 +278,35 @@
                       <span class="text-press-text font-medium truncate">{change.item_title}</span>
                       <span class="text-press-muted text-press-eyebrow">({change.field})</span>
                     </div>
-                    <div class="text-press-ui space-y-1 font-mono">
-                      <div class="flex gap-2 text-press-error">
-                        <span class="flex-shrink-0">-</span>
-                        <span class="line-through text-press-disabled-text truncate"
-                          >{change.current_value || "(empty)"}</span
-                        >
+                    {#if change.field === "prose"}
+                      <div class="space-y-3" data-testid="sync-prose-diff">
+                        <p class="text-press-small text-press-muted">
+                          Accepting replaces the prose shown below. Scene replacements without beat
+                          comments keep planning beats and put the incoming text in the first beat.
+                        </p>
+                        <div>
+                          <p class="text-press-small text-press-muted">Current prose</p>
+                          <div class="prose-review">{change.current_value || "(empty)"}</div>
+                        </div>
+                        <div>
+                          <p class="text-press-small text-press-muted">Incoming prose</p>
+                          <div class="prose-review">{change.new_value || "(empty)"}</div>
+                        </div>
                       </div>
-                      <div class="flex gap-2 text-press-success">
-                        <span class="flex-shrink-0">+</span>
-                        <span class="truncate">{change.new_value || "(empty)"}</span>
+                    {:else}
+                      <div class="text-press-ui space-y-1 font-mono">
+                        <div class="flex gap-2 text-press-error">
+                          <span class="flex-shrink-0">-</span>
+                          <span class="line-through text-press-disabled-text truncate"
+                            >{change.current_value || "(empty)"}</span
+                          >
+                        </div>
+                        <div class="flex gap-2 text-press-success">
+                          <span class="flex-shrink-0">+</span>
+                          <span class="truncate">{change.new_value || "(empty)"}</span>
+                        </div>
                       </div>
-                    </div>
+                    {/if}
                   </div>
                 </label>
               {/each}
@@ -293,6 +315,8 @@
         </div>
       </div>
     {/if}
+
+    {#if error}<p role="alert" class="px-8 text-press-error">Sync failed: {error}</p>{/if}
 
     <!-- Footer -->
     <div
@@ -329,3 +353,14 @@
     </div>
   </div>
 </div>
+
+<style>
+  .prose-review {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: var(--font-body);
+    font-size: var(--text-body);
+    color: var(--color-text);
+    max-width: var(--measure);
+  }
+</style>

--- a/src/lib/components/SyncSummaryDialog.svelte
+++ b/src/lib/components/SyncSummaryDialog.svelte
@@ -20,7 +20,8 @@
       summary.scenes_added > 0 ||
       summary.scenes_updated > 0 ||
       summary.beats_added > 0 ||
-      summary.beats_updated > 0
+      summary.beats_updated > 0 ||
+      summary.prose_updated > 0
   );
 </script>
 
@@ -48,6 +49,9 @@
         {#if summary.beats_added > 0 || summary.beats_updated > 0}
           <p>Beats: {summary.beats_added} added, {summary.beats_updated} updated</p>
         {/if}
+        {#if summary.prose_updated}<p class="text-press-ui text-press-text">
+            {summary.prose_updated} prose item{summary.prose_updated !== 1 ? "s" : ""} updated
+          </p>{/if}
         {#if summary.prose_preserved > 0}
           <p class="text-press-muted italic">
             {summary.prose_preserved} prose item{summary.prose_preserved !== 1 ? "s" : ""} preserved

--- a/src/lib/importFormats.test.ts
+++ b/src/lib/importFormats.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMPORT_COMMANDS,
+  IMPORT_FORMATS,
+  importTypeForCommand,
+  isImportType,
+  supportsSync,
+} from "./importFormats";
+import { invoke as mockInvoke } from "../dev/mock-tauri";
+import type { Project } from "./types";
+
+describe("import format registry", () => {
+  it("keeps picker, commands, source types, and dev imports aligned", async () => {
+    for (const [type, config] of Object.entries(IMPORT_FORMATS)) {
+      expect(isImportType(type)).toBe(true);
+      expect(IMPORT_COMMANDS[type as keyof typeof IMPORT_COMMANDS]).toBe(config.command);
+      expect(importTypeForCommand(config.command)).toBe(
+        type === "longformVault" ? "longform" : type
+      );
+      const project = await mockInvoke<Project>(config.command, { path: "/fixture" });
+      expect(project.source_type).toBe(config.sourceType);
+      expect(project.source_path).toBe("/fixture");
+      expect(supportsSync(config.sourceType)).toBe(config.sync);
+    }
+    expect(isImportType("__proto__")).toBe(false);
+    expect(isImportType("missing")).toBe(false);
+    expect(importTypeForCommand("delete_project")).toBeUndefined();
+    expect(supportsSync("Blank")).toBe(false);
+  });
+});

--- a/src/lib/importFormats.ts
+++ b/src/lib/importFormats.ts
@@ -1,0 +1,92 @@
+import type { SourceType } from "./types";
+
+interface ImportFormat {
+  command: string;
+  sourceType: SourceType;
+  filters?: { name: string; extensions: string[] }[];
+  directory?: boolean;
+  label: string;
+  references: boolean;
+  sync: boolean;
+}
+
+const formats = {
+  plottr: {
+    command: "import_plottr",
+    sourceType: "Plottr",
+    filters: [{ name: "Plottr", extensions: ["pltr"] }],
+    label: "Plottr file",
+    references: true,
+    sync: true,
+  },
+  markdown: {
+    command: "import_markdown",
+    sourceType: "Markdown",
+    filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
+    label: "Markdown file",
+    references: false,
+    sync: true,
+  },
+  ywriter: {
+    command: "import_ywriter",
+    sourceType: "YWriter",
+    filters: [{ name: "yWriter 7", extensions: ["yw7"] }],
+    label: "yWriter file",
+    references: true,
+    sync: true,
+  },
+  longform: {
+    command: "import_longform",
+    sourceType: "Longform",
+    filters: [{ name: "Longform Index", extensions: ["md", "markdown"] }],
+    label: "Longform index",
+    references: true,
+    sync: true,
+  },
+  longformVault: {
+    command: "import_longform",
+    sourceType: "Longform",
+    directory: true,
+    label: "Longform vault",
+    references: true,
+    sync: true,
+  },
+  novelwriter: {
+    command: "import_novelwriter",
+    sourceType: "NovelWriter",
+    directory: true,
+    label: "novelWriter project",
+    references: true,
+    sync: true,
+  },
+  scrivener: {
+    command: "import_scrivener",
+    sourceType: "Scrivener",
+    filters: [{ name: "Scrivener Project", extensions: ["scriv"] }],
+    label: "Scrivener project",
+    references: false,
+    sync: false,
+  },
+} satisfies Record<string, ImportFormat>;
+
+export type ImportType = keyof typeof formats;
+export const IMPORT_FORMATS: Record<ImportType, ImportFormat> = formats;
+export const IMPORT_COMMANDS = Object.fromEntries(
+  Object.entries(formats).map(([key, config]) => [key, config.command])
+) as Record<ImportType, string>;
+
+export function isImportType(value: string): value is ImportType {
+  return Object.prototype.hasOwnProperty.call(IMPORT_FORMATS, value);
+}
+
+export function importTypeForCommand(command: string): ImportType | undefined {
+  return (Object.keys(IMPORT_FORMATS) as ImportType[]).find(
+    (type) => IMPORT_FORMATS[type].command === command
+  );
+}
+
+export function supportsSync(sourceType: SourceType): boolean {
+  return Object.values(IMPORT_FORMATS).some(
+    (format) => format.sourceType === sourceType && format.sync
+  );
+}

--- a/src/lib/referenceTypes.ts
+++ b/src/lib/referenceTypes.ts
@@ -1,5 +1,5 @@
 import { Building2, MapPin, Package, Target, User } from "lucide-svelte";
-import type { ReferenceTypeId } from "./types";
+import type { FieldEntityType, ReferenceTypeId } from "./types";
 
 export interface ReferenceTypeOption {
   id: ReferenceTypeId;
@@ -51,6 +51,22 @@ export const REFERENCE_TYPE_OPTIONS: ReferenceTypeOption[] = [
     bgClass: "bg-press-tag-purple/20",
     isDefault: false,
   },
+  {
+    id: "timelines",
+    label: "Timelines",
+    icon: Target,
+    accentClass: "text-press-tag-blue",
+    bgClass: "bg-press-tag-blue/20",
+    isDefault: false,
+  },
+  {
+    id: "custom",
+    label: "Notes",
+    icon: Package,
+    accentClass: "text-press-tag-green",
+    bgClass: "bg-press-tag-green/20",
+    isDefault: false,
+  },
 ];
 
 export const DEFAULT_REFERENCE_TYPES: ReferenceTypeId[] = REFERENCE_TYPE_OPTIONS.filter(
@@ -75,3 +91,13 @@ export function normalizeReferenceTypes(types?: string[] | null): ReferenceTypeI
 
   return result;
 }
+
+export const REFERENCE_FIELD_TYPES: Record<ReferenceTypeId, FieldEntityType> = {
+  characters: "character",
+  locations: "location",
+  items: "item",
+  objectives: "objective",
+  organizations: "organization",
+  timelines: "timeline",
+  custom: "custom",
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,7 +8,14 @@
  */
 
 /** Supported outline import formats */
-export type SourceType = "Plottr" | "Markdown" | "YWriter" | "Scrivener" | "Longform" | "Blank";
+export type SourceType =
+  | "Plottr"
+  | "Markdown"
+  | "YWriter"
+  | "Scrivener"
+  | "Longform"
+  | "NovelWriter"
+  | "Blank";
 
 /** Project type: novel (default) or screenplay */
 export type ProjectType = "novel" | "screenplay";
@@ -214,7 +221,14 @@ export interface ReferenceSuggestion {
 }
 
 /** Supported reference types for the References panel */
-export type ReferenceTypeId = "characters" | "locations" | "items" | "objectives" | "organizations";
+export type ReferenceTypeId =
+  | "characters"
+  | "locations"
+  | "items"
+  | "objectives"
+  | "organizations"
+  | "timelines"
+  | "custom";
 
 /** Supported field types for custom fields */
 export type FieldType = "text" | "number" | "date" | "select" | "multiselect" | "checkbox" | "url";
@@ -226,7 +240,9 @@ export type FieldEntityType =
   | "scene"
   | "item"
   | "objective"
-  | "organization";
+  | "organization"
+  | "timeline"
+  | "custom";
 
 /** Project-level definition for a custom field */
 export interface FieldDefinition {
@@ -310,7 +326,7 @@ export interface SyncAddition {
 export interface SyncChange {
   id: string;
   item_type: "chapter" | "scene" | "beat";
-  field: "title" | "synopsis" | "content";
+  field: "title" | "synopsis" | "content" | "prose";
   item_title: string;
   current_value: string;
   new_value: string;
@@ -334,6 +350,7 @@ export interface ReimportSummary {
   beats_updated: number;
   /** Count of prose blocks that were preserved (not overwritten) */
   prose_preserved: number;
+  prose_updated: number;
 }
 
 // =============================================================================
@@ -574,4 +591,10 @@ export interface StoryTemplate {
   structure: TemplatePart[];
   bundled: boolean;
   created_at?: string | null;
+}
+
+export interface NovelWriterExportOptions {
+  include_beat_comments: boolean;
+  include_notes: boolean;
+  create_snapshot: boolean;
 }

--- a/src/lib/utils/import.ts
+++ b/src/lib/utils/import.ts
@@ -4,52 +4,9 @@ import { platform } from "@tauri-apps/plugin-os";
 import { ui } from "$lib/stores/ui.svelte";
 import type { Project } from "$lib/types";
 
-interface FileFilter {
-  name: string;
-  extensions: string[];
-}
-
-interface ImportOptions {
-  command: string;
-  filters?: FileFilter[];
-  directory?: boolean;
-  label: string;
-}
-
-const IMPORT_CONFIGS: Record<string, ImportOptions> = {
-  plottr: {
-    command: "import_plottr",
-    filters: [{ name: "Plottr", extensions: ["pltr"] }],
-    label: "Plottr file",
-  },
-  markdown: {
-    command: "import_markdown",
-    filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
-    label: "Markdown file",
-  },
-  ywriter: {
-    command: "import_ywriter",
-    filters: [{ name: "yWriter 7", extensions: ["yw7"] }],
-    label: "yWriter file",
-  },
-  longform: {
-    command: "import_longform",
-    filters: [{ name: "Longform Index", extensions: ["md", "markdown"] }],
-    label: "Longform index",
-  },
-  longformVault: {
-    command: "import_longform",
-    directory: true,
-    label: "Longform vault",
-  },
-  scrivener: {
-    command: "import_scrivener",
-    filters: [{ name: "Scrivener Project", extensions: ["scriv"] }],
-    label: "Scrivener project",
-  },
-};
-
-export type ImportType = keyof typeof IMPORT_CONFIGS;
+import { IMPORT_FORMATS } from "../importFormats";
+import type { ImportType } from "../importFormats";
+export type { ImportType } from "../importFormats";
 
 /**
  * Opens a file dialog, invokes the backend import command, and returns the
@@ -71,7 +28,7 @@ export async function pickScrivenerProjectPath(): Promise<string | null> {
   const path = await open({
     multiple: false,
     title: isMacos ? undefined : "Select Scrivener project folder (.scriv)",
-    ...(isMacos ? { filters: IMPORT_CONFIGS.scrivener.filters } : { directory: true }),
+    ...(isMacos ? { filters: IMPORT_FORMATS.scrivener.filters } : { directory: true }),
   });
   if (!path) return null;
   if (!isMacos) {
@@ -85,7 +42,7 @@ export async function pickScrivenerProjectPath(): Promise<string | null> {
 }
 
 export async function runImport(type: ImportType): Promise<Project | null> {
-  const config = IMPORT_CONFIGS[type];
+  const config = IMPORT_FORMATS[type];
   if (!config) throw new Error(`Unknown import type: ${type}`);
 
   const path =

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,13 +17,16 @@ const app = mount(App, {
   target: document.getElementById("app")!,
 });
 
+import { IMPORT_COMMANDS, isImportType, type ImportType } from "./lib/importFormats";
+
 // Expose Tauri invoke and store helpers for E2E testing
 // This allows WebDriver tests to call Tauri commands and update stores directly
 declare global {
   interface Window {
     __KINDLING_TEST__?: {
       invoke: typeof invoke;
-      importProject: (path: string) => Promise<Project>;
+      importCommands: typeof IMPORT_COMMANDS;
+      importProject: (path: string, format?: ImportType) => Promise<Project>;
       disableGuidance: () => void;
     };
   }
@@ -32,13 +35,16 @@ declare global {
 // Helper to import a project and update the frontend state
 // For E2E testing, this also loads chapters directly rather than relying on $effect
 async function importProject(
-  path: string
+  path: string,
+  format: ImportType = "plottr"
 ): Promise<
   Project & { _debug?: { chapterCount: number; storeChapterCount: number; hasProject: boolean } }
 > {
   ui.startImport();
   try {
-    const project = await invoke<Project>("import_plottr", { path });
+    const command = isImportType(format) ? IMPORT_COMMANDS[format] : undefined;
+    if (!command) throw new Error(`Unsupported test import format: ${format}`);
+    const project = await invoke<Project>(command, { path });
     currentProject.setProject(project);
 
     // Load and set chapters directly for E2E testing
@@ -74,6 +80,7 @@ async function importProject(
 // Always expose for E2E testing - the test helper checks for this
 window.__KINDLING_TEST__ = {
   invoke,
+  importCommands: IMPORT_COMMANDS,
   importProject,
   disableGuidance: () => ui.setGuidanceEnabled(false),
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 export default defineConfig({
   plugins: [svelte({ hot: !process.env.VITEST })],
   resolve: {
+    alias: { $lib: new URL("./src/lib", import.meta.url).pathname },
     conditions: ["browser"],
   },
   test: {


### PR DESCRIPTION
## Summary

Add a novelWriter round-trip workflow: export a Kindling novel, edit it in novelWriter, then import it or selectively accept source changes through Sync. Prose changes are unselected by default and respect locked chapters and scenes.

- Export manuscript structure, beat comments, formatted prose, reference notes and scene links; preserve existing connections to other source formats.
- Add import/onboarding and export options, plus beat-level and whole-scene prose review.
- Preserve imported text containing bare delimiters, keep split beats local during Sync, and retain scene links when reclassifying references. Timeline and custom notes also survive Longform export/import/export/import.
- Share HTML parsing and frontend import registries, and add user documentation, native E2E coverage and visual QA scenarios.

## Related Issues

Closes #261

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally — automated unit checks pass; native E2E remains pending
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Screenshots/Recordings

Visual QA scenarios `13-import-formats` and `14-novelwriter-round-trip` cover import, export options, prose selection, dark theme and narrow layouts. Native screenshots/baselines have not yet been captured.

## Testing Instructions

Automated validation completed:

- 392 Rust tests with all features; clippy with warnings denied; Rust formatting.
- 177 frontend tests with coverage gate (99.68% statements, 100% functions).
- 10 visual QA harness tests; ESLint, Prettier, Svelte type checking and generated design-system checks. Svelte reports six existing warnings and no errors.
- IPC registration verified: 125 command functions and 125 registrations.

Manual acceptance:

1. Export a novel to an empty folder and open it in novelWriter 26.2+. Check the outline, emphasis, note tags and reference links.
2. Import that folder into Kindling, edit its source prose, then accept one Sync change and decline another. Verify the editor and locked content.
3. Run `e2e/specs/novelwriter.spec.js` on a supported WebDriver platform and visual QA scenarios 13 and 14.

## Additional Notes

The writer emits project format 1.6 for `.md` documents with TOML headers; the reader accepts 1.4–1.6. Paragraph handling follows novelWriter's blank-line convention. Notes, reference links and project metadata are imported but are not synchronized.

No database schema or generated Press styles changed. SHA-1 uses the existing locked `sha1 0.10.6` crate; the lockfile adds only the direct dependency edge and changes no package versions.

