### PR TITLE
feat(demo): add reproducible sample and development fixtures

### DIFF
--- a/qa/demo/README.md
+++ b/qa/demo/README.md
@@ -1,23 +1,58 @@
-# Demo seed — documentation and website screenshots
+# Demo fixtures — documentation and website screenshots
 
-A committed, reproducible project used for every screenshot in `docs/assets/` and
-on the website. Deliberately separate from `qa/visual/`, which has the opposite
-requirements.
+The user-facing **Sample Project** creates **The Letter** from the committed
+fixture in `src-tauri/src/commands/sample_project.rs`: three chapters, nine scenes,
+typed reference fields, hierarchical tags and an active-protagonist filter.
+This is the preferred source for new documentation and website screenshots.
 
-|                    | `qa/visual/` (QA baseline)                    | `qa/demo/` (this)                        |
-| ------------------ | --------------------------------------------- | ---------------------------------------- |
-| Content            | minimal, boring, deterministic                | rich enough to photograph                |
-| Source             | `test-data/simple-story.pltr`, imported       | `seed.json`, applied to the database     |
-| Lifecycle          | imported at run start, deleted at run end     | persists until reseeded                  |
-| Data dir           | `qa/visual/data`                              | `qa/demo/data`                           |
-| Cost of changing it | invalidates the baselines in `qa/visual/baselines/` | free                               |
+## Create the current fixtures
 
-Keep them apart. A QA run imports its fixture on top of whatever is already
-there, so demo content in the QA data dir would put a second project in every
-sidebar baseline, and `q.cleanupFixtures()` would not remove it — cleanup only
-deletes ids the harness itself imported.
+Start the debug app with an empty scratch data directory:
 
-## Use it
+```bash
+KINDLING_DATA_DIR="$(mktemp -d /tmp/kindling-demo.XXXXXX)" npm run tauri dev
+```
+
+Click **Sample Project**. For screenplay and sync screenshots, also run this in
+the app's developer console (or through the local MCP `execute_js` command):
+
+```js
+await window.__KINDLING_TEST__.invoke("create_demo_fixture");
+```
+
+The command adds **The Letter — Screenplay** and **The Letter — Source Outline**.
+Return to **All Projects** to open them. It is compiled and registered only in
+debug builds. Every invocation creates new projects with independent IDs; use an
+empty data directory for a clean screenshot run.
+
+The outline project initially has an empty sync preview. Its `source_path` points
+to a `demo-outline-<uuid>.md` file beside the active database. Append a scene to
+that file and click **Sync** to photograph the diff:
+
+```markdown
+## Beneath the Tower
+
+- Eleanor turns the key
+```
+
+From the sibling `kindling-splash` repository, capture without installing images:
+
+```bash
+npm run shots -- --keep
+```
+
+Keep screenshot data separate from `qa/visual/data`, whose minimal imported
+fixtures drive the visual regression baselines. Theme, onboarding and panel widths
+are local preferences; the fixture commands do not set them. Create a real
+snapshot in the app if a screenshot needs one.
+
+## Older SQL seed
+
+`seed.json` and `seed.mjs` remain available to reproduce the older screenshot
+content. They do not contain the current typed fields, tags or nine-scene spine.
+The instructions below apply to that older seed only.
+
+### Use the older seed
 
 ```bash
 npm run tauri:demo
@@ -38,7 +73,7 @@ edited copy.
 Two flags: `--print` writes the SQL to stdout instead of applying it, and
 `--db <path>` targets a database somewhere else.
 
-## Editing the content
+### Editing the older content
 
 Edit `seed.json` and reseed. Every id is a UUIDv5 derived from the `key` fields, so
 the same manifest always produces the same database — a copy-edit shows up as a
@@ -58,7 +93,7 @@ Run the tests after editing:
 npm run test:demo-seed
 ```
 
-## What the seed deliberately does not cover
+### What the older seed does not cover
 
 - **Snapshots.** A `snapshots` row points at a real archive on disk with a real
   `file_size`. Faking the row would give a demo where restore fails, which is worse
@@ -71,7 +106,7 @@ npm run test:demo-seed
   `localStorage`, not the database. Set them in the app; the seed will not touch
   them.
 
-## Why the script writes SQL directly
+### Why the older script writes SQL directly
 
 It bypasses the Tauri commands, which is a real trade-off: nothing stops the
 manifest from encoding a state the app itself could not produce. Two things hold

--- a/src-tauri/src/commands/demo_fixture.rs
+++ b/src-tauri/src/commands/demo_fixture.rs
@@ -1,0 +1,145 @@
+//! Additional screenshot projects. This entire module is absent in release builds.
+
+use std::io::Write;
+use std::path::Path;
+
+use rusqlite::Connection;
+use tauri::State;
+use uuid::Uuid;
+
+use super::AppState;
+use crate::db;
+use crate::models::{Beat, Chapter, EditorMode, Project, Scene, SourceType};
+use crate::parsers::parse_markdown_outline;
+
+const OUTLINE: &str = "---\ntitle: The Letter — Source Outline\n---\n\n# The Letter\n\n## On the Cliff\n\n- Eleanor reads the sealed letter\n- Thomas arrives with a warning\n\n## The Seventh Step\n\n- A hidden key opens nothing in the lighthouse\n";
+
+/// Adds a screenplay and a syncable outline alongside the user-facing sample.
+/// The Markdown source lives beside the active database, including when QA uses
+/// KINDLING_DATA_DIR. Each invocation owns a new file and never overwrites one.
+#[cfg(debug_assertions)]
+#[tauri::command]
+pub async fn create_demo_fixture(state: State<'_, AppState>) -> Result<Vec<Project>, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let data_dir = conn
+        .path()
+        .and_then(|p| Path::new(p).parent())
+        .ok_or("The demo fixture requires an on-disk app database")?;
+    seed_demo_fixture(&conn, data_dir)
+}
+
+fn seed_demo_fixture(conn: &Connection, data_dir: &Path) -> Result<Vec<Project>, String> {
+    let source_path = data_dir.join(format!("demo-outline-{}.md", Uuid::new_v4()));
+    let mut source = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&source_path)
+        .map_err(|e| e.to_string())?;
+    let result = (|| {
+        source
+            .write_all(OUTLINE.as_bytes())
+            .map_err(|e| e.to_string())?;
+        let parsed = parse_markdown_outline(&source_path).map_err(|e| e.to_string())?;
+        let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+        let mut screenplay =
+            Project::new("The Letter — Screenplay".into(), SourceType::Blank, None);
+        screenplay.project_type = "screenplay".into();
+        screenplay.target_page_count = Some(120);
+        screenplay.author_pen_name = Some("E. M. Hale".into());
+        screenplay.genre = Some("Gothic Mystery".into());
+        db::insert_project(&tx, &screenplay).map_err(|e| e.to_string())?;
+        let act = Chapter::new(screenplay.id, "Act I — Setup".into(), 0).with_is_part(true);
+        db::insert_chapter(&tx, &act).map_err(|e| e.to_string())?;
+        let sequence = Chapter::new(screenplay.id, "The Letter".into(), 1);
+        db::insert_chapter(&tx, &sequence).map_err(|e| e.to_string())?;
+        for (position, (title, synopsis, prose)) in [
+            ("EXT. KESTREL POINT - DUSK", "Eleanor reads a letter that threatens everything she knows.",
+             "<p>Wind tears across the cliff. ELEANOR BLACKWOOD, 18, unfolds a letter beside the lighthouse.</p><p>ELEANOR</p><p>What could possibly be worth all this deception?</p><p>The lighthouse door opens. Thomas steps into the wind.</p>"),
+            ("INT. LIGHTHOUSE STAIRWELL - NIGHT", "Thomas watches as Eleanor lifts the seventh step.",
+             "<p>A lamp throws their shadows up the spiral stair. Eleanor works her knife under the stone.</p><p>THOMAS</p><p>He'll hear us.</p><p>ELEANOR</p><p>Then let him explain what we find.</p><p>The step lifts. An iron key lies in a fold of oilcloth.</p>"),
+        ].iter().enumerate() {
+            let scene = Scene {
+                editor_mode: EditorMode::Page,
+                prose: Some((*prose).into()),
+                ..Scene::new(sequence.id, (*title).into(), Some((*synopsis).into()), position as i32)
+            };
+            db::insert_scene(&tx, &scene).map_err(|e| e.to_string())?;
+            db::insert_beat(&tx, &Beat::new(scene.id, (*synopsis).into(), 0)).map_err(|e| e.to_string())?;
+        }
+        // Import through the real parser to retain the source IDs sync compares.
+        db::insert_project(&tx, &parsed.project).map_err(|e| e.to_string())?;
+        for chapter in &parsed.chapters {
+            db::insert_chapter(&tx, chapter).map_err(|e| e.to_string())?;
+        }
+        for scene in &parsed.scenes {
+            db::insert_scene(&tx, scene).map_err(|e| e.to_string())?;
+        }
+        for beat in &parsed.beats {
+            db::insert_beat(&tx, beat).map_err(|e| e.to_string())?;
+        }
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(vec![screenplay, parsed.project])
+    })();
+    drop(source);
+    if result.is_err() {
+        // The transaction rolls back on error; remove only our own new file.
+        let _ = std::fs::remove_file(source_path);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::sync::get_sync_preview_with_connection;
+    use super::*;
+
+    #[test]
+    fn screenplay_and_source_outline_are_ready_for_screenshots_and_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).unwrap();
+        let conn = state.db.lock().unwrap();
+        let projects = seed_demo_fixture(&conn, dir.path()).unwrap();
+        assert_eq!(projects.len(), 2);
+        let screenplay = db::get_project(&conn, &projects[0].id).unwrap().unwrap();
+        assert_eq!(screenplay.project_type, "screenplay");
+        let scenes = db::get_all_project_scenes(&conn, &screenplay.id).unwrap();
+        assert!(scenes.len() >= 2);
+        assert!(scenes
+            .iter()
+            .all(|s| s.title.starts_with("INT.") || s.title.starts_with("EXT.")));
+        assert!(scenes.iter().all(|s| s.prose.is_some()));
+        let source = db::get_project(&conn, &projects[1].id).unwrap().unwrap();
+        assert_eq!(source.source_type, SourceType::Markdown);
+        let path = Path::new(source.source_path.as_ref().unwrap());
+        assert_eq!(path.parent(), Some(dir.path()));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), OUTLINE);
+        let preview = get_sync_preview_with_connection(&conn, source.id).unwrap();
+        assert!(preview.additions.is_empty());
+        assert!(preview.changes.is_empty());
+        let edited = format!("{OUTLINE}\n## Beneath the Tower\n\n- Eleanor turns the key\n");
+        std::fs::write(path, &edited).unwrap();
+        let preview = get_sync_preview_with_connection(&conn, source.id).unwrap();
+        assert!(preview
+            .additions
+            .iter()
+            .any(|a| a.title == "Beneath the Tower"));
+        let second = seed_demo_fixture(&conn, dir.path()).unwrap();
+        assert_ne!(second[1].source_path, source.source_path);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), edited);
+    }
+
+    #[test]
+    fn failure_rolls_back_projects_and_removes_the_new_source_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        conn.execute_batch("CREATE TRIGGER reject_outline BEFORE INSERT ON projects WHEN NEW.source_type = 'markdown' BEGIN SELECT RAISE(ABORT, 'test failure'); END;").unwrap();
+        assert!(seed_demo_fixture(&conn, dir.path()).is_err());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM projects", [], |r| r.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,8 @@
 mod archive;
 mod blank_project;
 mod crud;
+#[cfg(debug_assertions)]
+mod demo_fixture;
 mod detect;
 mod export;
 pub mod feedback;
@@ -38,6 +40,8 @@ mod templates;
 pub use archive::*;
 pub use blank_project::*;
 pub use crud::*;
+#[cfg(debug_assertions)]
+pub use demo_fixture::*;
 pub use detect::*;
 pub use export::*;
 pub use feedback::*;

--- a/src-tauri/src/commands/sample_project.rs
+++ b/src-tauri/src/commands/sample_project.rs
@@ -1,214 +1,671 @@
-//! Sample Project Command
-//!
-//! Creates a minimal sample project for first-time users to explore Kindling
-//! without importing their own outline.
-
-use std::collections::HashMap;
-use tauri::State;
-use uuid::Uuid;
-
-use crate::db;
-use crate::models::{
-    Beat, Chapter, Character, EditorMode, Location, PlanningStatus, Project, ReferenceItem, Scene,
-    SceneStatus, SceneType, SourceType,
-};
+//! Reproducible first-time-user sample, shared with documentation screenshots.
 
 use super::AppState;
+use crate::db;
+use crate::models::{
+    Beat, Chapter, Character, EditorMode, FieldDefinition, Location, PlanningStatus, Project,
+    ReferenceItem, SavedFilter, Scene, SceneStatus, SceneType, SourceType, Tag,
+};
+use rusqlite::Connection;
+use std::collections::HashMap;
+use tauri::State;
 
-/// Build and insert a sample project into the database.
-/// Returns the created project for the frontend to load.
 #[tauri::command]
 pub async fn create_sample_project(state: State<'_, AppState>) -> Result<Project, String> {
     let conn = state.db.lock().map_err(|e| e.to_string())?;
+    seed_sample_project(&conn).map_err(|e| e.to_string())
+}
 
-    let now = chrono::Utc::now().to_rfc3339();
-    let project_id = Uuid::new_v4();
+/// Keep the complete fixture atomic, including fields, tags and scene links.
+fn seed_sample_project(conn: &Connection) -> rusqlite::Result<Project> {
+    let tx = conn.unchecked_transaction()?;
+    let mut project = Project::new("The Letter".into(), SourceType::Blank, None);
+    project.author_pen_name = Some("E. M. Hale".into());
+    project.genre = Some("Gothic Mystery".into());
+    project.word_target = Some(90000);
+    project.reference_types.push("items".into());
+    project.description = Some("A lighthouse keeper's daughter learns that the man who raised her is not her father, and that the tower he tends was built to hide something.".into());
+    db::insert_project(&tx, &project)?;
 
-    let project = Project {
-        id: project_id,
-        name: "Sample Project".to_string(),
-        source_type: SourceType::Markdown,
-        source_path: None,
-        created_at: now.clone(),
-        modified_at: now,
-        author_pen_name: None,
-        genre: Some("Fiction".to_string()),
-        description: Some("A sample project to explore Kindling. Try the sidebar, scene panel, beats, and references.".to_string()),
-        word_target: None,
-        reference_types: Project::default_reference_types(),
-        project_type: Project::default_project_type(),
-        target_page_count: None,
+    let eleanor = Character {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Eleanor Blackwood".into(), description: Some("Eighteen, raised at Kestrel Point since she was two. Reads the sea better than she reads people. Carries a pocket knife her father gave her and has just learned he is not her father.".into()),
+        attributes: HashMap::new(), source_id: None,
     };
-
-    let chapter_id = Uuid::new_v4();
-    let chapter = Chapter {
-        id: chapter_id,
-        project_id,
-        title: "Chapter 1: The Beginning".to_string(),
-        position: 0,
-        source_id: None,
-        archived: false,
-        locked: false,
-        is_part: false,
-        synopsis: None,
-        planning_status: PlanningStatus::Fixed,
+    db::insert_character(&tx, &eleanor)?;
+    let silas = Character {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Silas Blackwood".into(), description: Some("Keeper of Kestrel Point for sixteen years. Precise, kind, and entirely unwilling to answer a direct question. Whatever he is protecting, he has protected it longer than Eleanor has been alive.".into()),
+        attributes: HashMap::new(), source_id: None,
     };
+    db::insert_character(&tx, &silas)?;
+    let thomas = Character {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Thomas Ward".into(), description: Some("The relief keeper from Wrackham, two years older than Eleanor and a poor liar. He knows part of it. He does not know he knows.".into()),
+        attributes: HashMap::new(), source_id: None,
+    };
+    db::insert_character(&tx, &thomas)?;
+    let margaret = Character {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Margaret Wren".into(), description: Some("M.W. Signed the letter. Nobody in Wrackham will say the name aloud, and the parish register has had a page cut out of it.".into()),
+        attributes: HashMap::new(), source_id: None,
+    };
+    db::insert_character(&tx, &margaret)?;
+    let lighthouse = Location {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Kestrel Point".into(), description: Some("Ninety-one feet of grey stone on a headland that the Admiralty chart still marks as unsurveyed. Eighty-eight steps to the lamp room. The seventh one is loose.".into()),
+        attributes: HashMap::new(), source_id: None,
+    };
+    db::insert_location(&tx, &lighthouse)?;
+    let cliff = Location {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "The Cliff Path".into(), description: Some("A quarter mile of chalk and gorse between the light and the town, with a forty-foot drop on the seaward side and no rail.".into()),
+        attributes: HashMap::new(), source_id: None,
+    };
+    db::insert_location(&tx, &cliff)?;
+    let harbour = Location {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "Wrackham Harbour".into(), description: Some("Six fishing boats, one chandlery, one church with a damaged register. Everyone here remembers Margaret Wren and no one will say so.".into()),
+        attributes: HashMap::new(), source_id: None,
+    };
+    db::insert_location(&tx, &harbour)?;
+    let sealed_letter = ReferenceItem {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "The Sealed Letter".into(), description: Some("Cream laid paper, elegant hand, no postmark. Left inside Eleanor's copy of Bowditch. Signed M.W.".into()),
+        attributes: HashMap::new(), source_id: None,
+        reference_type: "items".into(),
+    };
+    db::insert_reference_item(&tx, &sealed_letter)?;
+    let seventh_step_key = ReferenceItem {
+        id: uuid::Uuid::new_v4(), project_id: project.id,
+        name: "The Key Beneath the Seventh Step".into(), description: Some("Iron, four inches, too large for any door in the lighthouse. It does not fit the lamp room, the oil store, or the keeper's quarters.".into()),
+        attributes: HashMap::new(), source_id: None,
+        reference_type: "items".into(),
+    };
+    db::insert_reference_item(&tx, &seventh_step_key)?;
 
-    let scene1_id = Uuid::new_v4();
-    let scene2_id = Uuid::new_v4();
-    let scene3_id = Uuid::new_v4();
-
-    let scenes = vec![
-        Scene {
-            id: scene1_id,
-            chapter_id,
-            title: "The Call to Adventure".to_string(),
-            synopsis: Some(
-                "Our hero receives an unexpected invitation that will change everything."
-                    .to_string(),
-            ),
-            prose: None,
-            position: 0,
-            source_id: None,
-            archived: false,
-            locked: false,
-            scene_type: SceneType::Normal,
-            scene_status: SceneStatus::Draft,
-            planning_status: PlanningStatus::Fixed,
-            editor_mode: EditorMode::Beat,
-        },
-        Scene {
-            id: scene2_id,
-            chapter_id,
-            title: "Meeting the Mentor".to_string(),
-            synopsis: Some("A wise figure appears with guidance and a crucial object.".to_string()),
-            prose: None,
-            position: 1,
-            source_id: None,
-            archived: false,
-            locked: false,
-            scene_type: SceneType::Normal,
-            scene_status: SceneStatus::Draft,
-            planning_status: PlanningStatus::Fixed,
-            editor_mode: EditorMode::Beat,
-        },
-        Scene {
-            id: scene3_id,
-            chapter_id,
-            title: "Crossing the Threshold".to_string(),
-            synopsis: Some(
-                "The hero commits to the journey and leaves the ordinary world behind.".to_string(),
-            ),
-            prose: None,
-            position: 2,
-            source_id: None,
-            archived: false,
-            locked: false,
-            scene_type: SceneType::Normal,
-            scene_status: SceneStatus::Draft,
-            planning_status: PlanningStatus::Fixed,
-            editor_mode: EditorMode::Beat,
-        },
+    // Stored spelling follows the fixture contract; the UI also accepts its older
+    // `multiselect` spelling so existing projects continue to work.
+    let field_specs = [
+        (
+            "Role",
+            "select",
+            Some(r#"["protagonist","antagonist","supporting"]"#),
+        ),
+        ("Age", "number", None),
+        ("Wants", "text", None),
+        (
+            "Traits",
+            "multi_select",
+            Some(r#"["observant","resolute","loyal","secretive","resourceful"]"#),
+        ),
     ];
-
-    let beat1_1 = Beat {
-        id: Uuid::new_v4(),
-        scene_id: scene1_id,
-        content: "The letter arrives".to_string(),
-        prose: Some("The morning post brought something unexpected: a thick envelope with a wax seal. Inside, an invitation to the annual gathering at the old estate—a place they'd heard stories about but never visited.".to_string()),
-        position: 0,
-        source_id: None,
-    };
-    let beat1_2 = Beat {
-        id: Uuid::new_v4(),
-        scene_id: scene1_id,
-        content: "The decision".to_string(),
-        prose: Some("They could ignore it. Life was comfortable enough. But something in the invitation called to them—a curiosity they hadn't felt in years.".to_string()),
-        position: 1,
-        source_id: None,
-    };
-    let beat2_1 = Beat {
-        id: Uuid::new_v4(),
-        scene_id: scene2_id,
-        content: "The stranger at the gate".to_string(),
-        prose: Some("An elderly figure waited at the estate gates, leaning on a carved staff. Their eyes held a knowing look, as if they'd been expecting this visitor all along.".to_string()),
-        position: 0,
-        source_id: None,
-    };
-    let beat2_2 = Beat {
-        id: Uuid::new_v4(),
-        scene_id: scene2_id,
-        content: "The gift".to_string(),
-        prose: Some("From a worn satchel, the mentor produced a small compass. \"This will help when the path grows unclear,\" they said. \"Trust it.\"".to_string()),
-        position: 1,
-        source_id: None,
-    };
-    let beat3_1 = Beat {
-        id: Uuid::new_v4(),
-        scene_id: scene3_id,
-        content: "Looking back".to_string(),
-        prose: Some("The familiar rooftops faded behind them. Part of them wanted to turn back—to return to the life they knew. But the compass in their pocket hummed with warmth, and they kept walking.".to_string()),
-        position: 0,
-        source_id: None,
-    };
-
-    let character_id = Uuid::new_v4();
-    let character = Character {
-        id: character_id,
-        project_id,
-        name: "The Hero".to_string(),
-        description: Some("Our protagonist, on the cusp of a great adventure.".to_string()),
-        attributes: HashMap::from([("Role".to_string(), "Protagonist".to_string())]),
-        source_id: None,
-    };
-
-    let location_id = Uuid::new_v4();
-    let location = Location {
-        id: location_id,
-        project_id,
-        name: "The Old Estate".to_string(),
-        description: Some("A mysterious manor at the edge of town, rarely visited.".to_string()),
-        attributes: HashMap::new(),
-        source_id: None,
-    };
-
-    // Reference item (e.g., objective or custom type)
-    let ref_item_id = Uuid::new_v4();
-    let reference_item = ReferenceItem {
-        id: ref_item_id,
-        project_id,
-        reference_type: "characters".to_string(),
-        name: "The Mentor".to_string(),
-        description: Some("A wise guide who appears at key moments.".to_string()),
-        attributes: HashMap::new(),
-        source_id: None,
-    };
-
-    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
-
-    db::insert_project(&tx, &project).map_err(|e| e.to_string())?;
-    db::insert_chapter(&tx, &chapter).map_err(|e| e.to_string())?;
-
-    for scene in &scenes {
-        db::insert_scene(&tx, scene).map_err(|e| e.to_string())?;
+    let character_values = [
+        (
+            &eleanor,
+            [
+                "protagonist",
+                "18",
+                "The truth about her parents",
+                r#"["observant","resolute"]"#,
+            ],
+        ),
+        (
+            &thomas,
+            [
+                "supporting",
+                "20",
+                "To be trusted with something that matters",
+                r#"["loyal","resourceful"]"#,
+            ],
+        ),
+        (
+            &margaret,
+            [
+                "supporting",
+                "43",
+                "To bring Eleanor safely home",
+                r#"["resourceful","secretive"]"#,
+            ],
+        ),
+        (
+            &silas,
+            [
+                "antagonist",
+                "54",
+                "For Eleanor to stop asking",
+                r#"["loyal","secretive"]"#,
+            ],
+        ),
+    ];
+    for (position, (name, kind, options)) in field_specs.iter().enumerate() {
+        let mut def = FieldDefinition::new(
+            project.id,
+            "character".into(),
+            (*name).into(),
+            (*kind).into(),
+            position as i32,
+        );
+        def.options = options.map(str::to_string);
+        db::create_field_definition(&tx, &def)?;
+        for (character, values) in &character_values {
+            db::set_field_value(&tx, &def.id, &character.id, Some(values[position]))?;
+        }
     }
 
-    for beat in &[beat1_1, beat1_2, beat2_1, beat2_2, beat3_1] {
-        db::insert_beat(&tx, beat).map_err(|e| e.to_string())?;
+    let role = Tag::new(project.id, "role".into(), Some("#D97706".into()), None, 0);
+    let status = Tag::new(project.id, "status".into(), None, None, 1);
+    db::create_tag(&tx, &role)?;
+    db::create_tag(&tx, &status)?;
+    let protagonist = Tag::new(
+        project.id,
+        "protagonist".into(),
+        Some("#D97706".into()),
+        Some(role.id),
+        0,
+    );
+    let antagonist = Tag::new(project.id, "antagonist".into(), None, Some(role.id), 1);
+    let supporting = Tag::new(project.id, "supporting".into(), None, Some(role.id), 2);
+    let active = Tag::new(
+        project.id,
+        "active".into(),
+        Some("#15803D".into()),
+        Some(status.id),
+        0,
+    );
+    let deceased = Tag::new(project.id, "deceased".into(), None, Some(status.id), 1);
+    let unknown = Tag::new(project.id, "unknown".into(), None, Some(status.id), 2);
+    for tag in [
+        &protagonist,
+        &antagonist,
+        &supporting,
+        &active,
+        &deceased,
+        &unknown,
+    ] {
+        db::create_tag(&tx, tag)?;
     }
+    for (character, role_tag, status_tag) in [
+        (&eleanor, &protagonist, &active),
+        (&thomas, &supporting, &active),
+        (&margaret, &supporting, &unknown),
+        (&silas, &antagonist, &active),
+    ] {
+        db::tag_entity(&tx, &role_tag.id, "character", &character.id)?;
+        db::tag_entity(&tx, &status_tag.id, "character", &character.id)?;
+    }
+    db::save_filter(
+        &tx,
+        &SavedFilter::new(
+            project.id,
+            "Active protagonists".into(),
+            "character".into(),
+            serde_json::json!({"tags": [protagonist.id, active.id], "operator": "AND"}).to_string(),
+            0,
+        ),
+    )?;
 
-    db::insert_character(&tx, &character).map_err(|e| e.to_string())?;
-    db::insert_location(&tx, &location).map_err(|e| e.to_string())?;
-    db::insert_reference_item(&tx, &reference_item).map_err(|e| e.to_string())?;
-
-    db::add_scene_character_ref(&tx, &scene1_id, &character_id).map_err(|e| e.to_string())?;
-    db::add_scene_character_ref(&tx, &scene2_id, &character_id).map_err(|e| e.to_string())?;
-    db::add_scene_character_ref(&tx, &scene3_id, &character_id).map_err(|e| e.to_string())?;
-    db::add_scene_location_ref(&tx, &scene2_id, &location_id).map_err(|e| e.to_string())?;
-    db::add_scene_location_ref(&tx, &scene3_id, &location_id).map_err(|e| e.to_string())?;
-    db::add_scene_reference_item_ref(&tx, &scene2_id, &ref_item_id).map_err(|e| e.to_string())?;
-
-    tx.commit().map_err(|e| e.to_string())?;
-
+    let chapter = Chapter {
+        synopsis: Some("Eleanor reads the letter, confronts Thomas, and finds the key.".into()),
+        ..Chapter::new(project.id, "The Letter".into(), 0)
+    };
+    db::insert_chapter(&tx, &chapter)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(chapter.id, "On the Cliff".into(), Some("Eleanor discovers a mysterious letter revealing her father may not be who he claims.".into()), 0)
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(&tx, &Beat { prose: Some("<p>The lighthouse keeper's daughter stood at the edge of the cliff, her <em>heart pounding</em> against her ribs like a caged bird desperate for freedom. The wind whipped her dark hair across her face, carrying with it the salt-spray of a restless sea.</p><p><strong>Eleanor Blackwood</strong> had always known this day would come. The letter in her pocket—crumpled now from being read a dozen times—confirmed what she'd long suspected: <em>her father was not who he claimed to be.</em></p><p>She pulled the paper out once more, squinting at the elegant handwriting in the fading light:</p><blockquote><p>My dearest Eleanor,</p><p>If you are reading this, I have failed in my duty to protect you. The lighthouse holds secrets older than the stone it stands upon. Find the key beneath the seventh step. Trust no one—especially not the man who calls himself your father.</p><p>Your true guardian,</p><p>M.W.</p></blockquote><p>\"What secrets?\" she whispered to the churning waves below. <em>What could possibly be worth all this deception?</em></p>".into()), ..Beat::new(scene.id, "Eleanor reads the mysterious letter on the cliff".into(), 0) })?;
+    db::insert_beat(&tx, &Beat { prose: Some("<p>The door to the lighthouse creaked open behind her. Eleanor spun around, her hand instinctively reaching for the pocket knife she always carried—a gift from the man she'd called \"Papa\" for eighteen years.</p><p>It was only Thomas, the relief keeper, with his coat buttoned wrong and his hair full of weather. He stopped when he saw her face.</p><p>\"You've found it, then,\" he said.</p><p>Not <em>what's wrong</em>. Not <em>Eleanor, you're white as the lamp glass</em>. He had gone straight to <em>found it</em>, and in the two seconds it took him to understand what he had said, she watched him try to take it back.</p><p>\"Found what, Thomas?\"</p><p>He looked at the sea. Everyone in Wrackham looked at the sea when they wanted to stop talking.</p><p>She unfolded the letter between them. \"M.W. means Margaret Wren, doesn't it? And what has Silas Blackwood been keeping from me?\" Thomas reached for the paper, then let his hand fall.</p>".into()), ..Beat::new(scene.id, "Thomas arrives and Eleanor confronts him".into(), 1) })?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "She counts the stairs on the way up and the number is wrong".into(),
+                2,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &thomas.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &cliff.id)?;
+    db::add_scene_reference_item_ref(&tx, &scene.id, &sealed_letter.id)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(
+            chapter.id,
+            "The Seventh Step".into(),
+            Some(
+                "The step lifts out. What is underneath it does not fit any lock in the building."
+                    .into(),
+            ),
+            1,
+        )
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(&tx, &Beat { prose: Some("<p>It came up without protest. That was the part that frightened her—not the hollow beneath, not the oilcloth bundle, but the clean grey line where the stone had been lifted and set back, lifted and set back, for longer than she had been alive.</p><p>Someone had been coming here. Someone had been coming here the whole time.</p>".into()), ..Beat::new(scene.id, "The seventh step lifts out cleanly, as though it has been lifted often".into(), 0) })?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "The key fits nothing: not the lamp room, not the oil store, not the quarters"
+                    .into(),
+                1,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "Silas calls up the stairwell and she puts the stone back before answering".into(),
+                2,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "She wraps the key in her handkerchief before Silas reaches the landing".into(),
+                3,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "A draught beneath the wall hints at a passage absent from the plans".into(),
+                4,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &lighthouse.id)?;
+    db::add_scene_reference_item_ref(&tx, &scene.id, &seventh_step_key.id)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(chapter.id, "Supper with Silas".into(), Some("Eleanor tests a harmless question and discovers how carefully Silas has rehearsed his answer.".into()), 2)
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(&tx, &Beat { prose: Some("<p>Silas laid three places, though Thomas had already gone. Eleanor watched the empty chair while he told her the staircase had never needed repair.</p>".into()), ..Beat::new(scene.id, "She asks when the seventh step was repaired".into(), 0) })?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &silas.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &lighthouse.id)?;
+    let chapter = Chapter {
+        synopsis: Some(
+            "Wrackham closes ranks. Eleanor learns the name M.W. and what it costs to say it."
+                .into(),
+        ),
+        ..Chapter::new(project.id, "What the Stone Remembers".into(), 1)
+    };
+    db::insert_chapter(&tx, &chapter)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Revised,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(chapter.id, "Low Tide".into(), Some("At low water the foundation course is exposed, and the stones are older than 1798.".into()), 0)
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(&tx, &Beat { prose: Some("<p>The tide went out further than it had all year, and the light stood on something that was not its own foundation.</p><p>Eleanor crouched in the wrack and put her palm flat against the lowest course. Dressed stone, mortared, and weathered into softness—nothing like the hard Portland above it. Whoever built the lighthouse in 1798 had not started from nothing. They had started from whatever this was, and then they had built ninety-one feet of grey stone on top of it.</p>".into()), ..Beat::new(scene.id, "The foundation stones predate the tower by two centuries".into(), 0) })?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "Thomas admits he has seen Silas on the shore at night, counting".into(),
+                1,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &thomas.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &harbour.id)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(
+            chapter.id,
+            "The Damaged Register".into(),
+            Some(
+                "A page has been cut from the parish register. The verger remembers who cut it."
+                    .into(),
+            ),
+            1,
+        )
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "The register is missing the page covering the spring Eleanor arrived".into(),
+                0,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "The cut is clean and recent — a razor, not sixteen years of handling".into(),
+                1,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "The verger gives her the name Margaret Wren and asks her not to come back".into(),
+                2,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &margaret.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &harbour.id)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Final,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Page,
+        prose: Some("<p>Nothing in the room had been allowed to settle. The bed was turned down, the water jug full, the window unlatched. Someone had dusted the sill that morning.</p><p>Eleanor set the letter on the dressing table. The grain of the wood held a pale rectangle exactly its size.</p><p>For sixteen years she had thought herself abandoned. Here was the unbearable evidence of someone waiting.</p>".into()),
+        ..Scene::new(chapter.id, "Margaret's Room".into(), Some("Above the chandlery, Eleanor finds a room that has been kept ready for sixteen years.".into()), 2)
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &margaret.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &harbour.id)?;
+    let chapter = Chapter {
+        synopsis: Some(
+            "Outline only. Silas's logbooks record a second, unexplained set of counts.".into(),
+        ),
+        ..Chapter::new(project.id, "The Keeper's Ledger".into(), 2)
+    };
+    db::insert_chapter(&tx, &chapter)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Fixed,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(chapter.id, "The Ledger".into(), Some("Sixteen years of keeper's logs, and in every one a column of numbers that has nothing to do with the light.".into()), 0)
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "Every log has a second column Silas has never explained".into(),
+                0,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "The numbers are step counts, and they change".into(),
+                1,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "Eleanor realises the tower is being measured, not tended".into(),
+                2,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &silas.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &lighthouse.id)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Notes,
+        planning_status: PlanningStatus::Flexible,
+        editor_mode: EditorMode::Page,
+        prose: Some("<p>Why does the ledger begin sixteen years ago? Check the spring tide against the date in the register. Decide whether Thomas recognises the handwriting before Eleanor does.</p>".into()),
+        ..Scene::new(chapter.id, "Questions for the Keeper".into(), Some("Planning notes: reconcile the changing stair counts with the missing parish page.".into()), 1)
+    };
+    db::insert_scene(&tx, &scene)?;
+    let scene = Scene {
+        scene_status: SceneStatus::Draft,
+        scene_type: SceneType::Normal,
+        planning_status: PlanningStatus::Flexible,
+        editor_mode: EditorMode::Beat,
+        ..Scene::new(
+            chapter.id,
+            "Below the Light".into(),
+            Some("Eleanor and Thomas follow the draught to a door beneath the foundations.".into()),
+            2,
+        )
+    };
+    db::insert_scene(&tx, &scene)?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "At low tide, the key turns in a lock buried beneath the tower".into(),
+                0,
+            )
+        },
+    )?;
+    db::insert_beat(
+        &tx,
+        &Beat {
+            prose: None,
+            ..Beat::new(
+                scene.id,
+                "A lamp is burning on the other side of the door".into(),
+                1,
+            )
+        },
+    )?;
+    db::add_scene_character_ref(&tx, &scene.id, &eleanor.id)?;
+    db::add_scene_character_ref(&tx, &scene.id, &thomas.id)?;
+    db::add_scene_location_ref(&tx, &scene.id, &lighthouse.id)?;
+    db::add_scene_reference_item_ref(&tx, &scene.id, &seventh_step_key.id)?;
+    tx.commit()?;
     Ok(project)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (Connection, Project) {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        db::initialize_schema(&conn).unwrap();
+        let project = seed_sample_project(&conn).unwrap();
+        (conn, project)
+    }
+
+    #[test]
+    fn narrative_has_varied_density_and_preserves_the_novelwriter_opening() {
+        let (conn, project) = fixture();
+        assert_eq!(project.name, "The Letter");
+        assert_eq!(project.author_pen_name.as_deref(), Some("E. M. Hale"));
+        assert_eq!(project.genre.as_deref(), Some("Gothic Mystery"));
+        assert_eq!(project.word_target, Some(90000));
+        let chapters = db::get_chapters(&conn, &project.id).unwrap();
+        assert_eq!(
+            chapters
+                .iter()
+                .map(|c| c.title.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "The Letter",
+                "What the Stone Remembers",
+                "The Keeper's Ledger"
+            ]
+        );
+        let scenes = db::get_all_project_scenes(&conn, &project.id).unwrap();
+        assert!(scenes.len() >= 8);
+        let counts: Vec<_> = scenes
+            .iter()
+            .map(|s| db::get_beats(&conn, &s.id).unwrap().len())
+            .collect();
+        assert_eq!(counts.iter().min(), Some(&0));
+        assert!(counts.iter().max().unwrap() >= &5);
+        assert!(scenes.iter().any(|s| s.scene_type == SceneType::Notes));
+        assert!(scenes.iter().any(|s| s.scene_status == SceneStatus::Final));
+        assert!(scenes
+            .iter()
+            .any(|s| s.planning_status == PlanningStatus::Flexible));
+        assert!(scenes
+            .iter()
+            .any(|s| s.editor_mode == EditorMode::Page && s.prose.is_some()));
+        let first = &db::get_scenes(&conn, &chapters[0].id).unwrap()[0];
+        assert_eq!(first.title, "On the Cliff");
+        assert_eq!(first.scene_type, SceneType::Normal);
+        assert_eq!(first.editor_mode, EditorMode::Beat);
+        let beats = db::get_beats(&conn, &first.id).unwrap();
+        assert_eq!(beats.len(), 3);
+        assert!(beats[0].prose.as_ref().unwrap().contains("<blockquote>"));
+        assert!(beats[0]
+            .prose
+            .as_ref()
+            .unwrap()
+            .contains("lighthouse keeper's daughter"));
+        let prose = beats
+            .iter()
+            .filter_map(|b| b.prose.as_deref())
+            .collect::<String>();
+        let links = db::get_all_scene_character_refs(&conn, &project.id).unwrap();
+        for name in ["Margaret Wren", "Silas Blackwood"] {
+            let character = db::get_characters(&conn, &project.id)
+                .unwrap()
+                .into_iter()
+                .find(|c| c.name == name)
+                .unwrap();
+            assert!(prose.contains(name));
+            assert!(!links
+                .iter()
+                .any(|link| link.scene_id == first.id && link.character_id == character.id));
+        }
+    }
+
+    #[test]
+    fn references_have_typed_fields_and_a_working_hierarchical_filter() {
+        let (conn, project) = fixture();
+        let characters = db::get_characters(&conn, &project.id).unwrap();
+        let locations = db::get_locations(&conn, &project.id).unwrap();
+        let items = db::get_all_reference_items(&conn, &project.id).unwrap();
+        assert!(characters.len() >= 4 && locations.len() >= 3 && items.len() >= 2);
+        assert!(characters.iter().all(|c| c.attributes.is_empty()));
+        assert!(locations.iter().all(|c| c.attributes.is_empty()));
+        assert!(items.iter().all(|c| c.attributes.is_empty()));
+        let definitions = db::get_field_definitions(&conn, &project.id, "character").unwrap();
+        for kind in ["text", "number", "select", "multi_select"] {
+            assert!(definitions.iter().any(|d| d.field_type == kind));
+        }
+        for character in &characters {
+            let values = db::get_field_values(&conn, &character.id).unwrap();
+            assert_eq!(values.len(), 4);
+            for def in &definitions {
+                let value = values
+                    .iter()
+                    .find(|v| v.field_definition_id == def.id)
+                    .unwrap()
+                    .value
+                    .as_deref()
+                    .unwrap();
+                match def.field_type.as_str() {
+                    "number" => {
+                        value.parse::<u32>().unwrap();
+                    }
+                    "select" => {
+                        let options: Vec<String> =
+                            serde_json::from_str(def.options.as_ref().unwrap()).unwrap();
+                        assert!(options.contains(&value.to_string()));
+                    }
+                    "multi_select" => {
+                        let options: Vec<String> =
+                            serde_json::from_str(def.options.as_ref().unwrap()).unwrap();
+                        let selected: Vec<String> = serde_json::from_str(value).unwrap();
+                        assert!(!selected.is_empty());
+                        assert!(selected.iter().all(|v| options.contains(v)));
+                    }
+                    _ => assert!(!value.is_empty()),
+                }
+            }
+        }
+        let tags = db::get_tags(&conn, &project.id).unwrap();
+        let roots: Vec<_> = tags.iter().filter(|t| t.parent_id.is_none()).collect();
+        assert_eq!(roots.len(), 2);
+        for root in roots {
+            assert!(tags.iter().filter(|t| t.parent_id == Some(root.id)).count() >= 2);
+        }
+        assert!(tags.iter().any(|t| t.color.is_some()));
+        assert!(
+            db::get_all_entity_tags_for_project(&conn, &project.id)
+                .unwrap()
+                .len()
+                >= 3
+        );
+        let filters = db::get_saved_filters(&conn, &project.id).unwrap();
+        assert_eq!(filters.len(), 1);
+        let matches = db::filter_entities(
+            &conn,
+            &project.id,
+            &filters[0].entity_type,
+            &filters[0].filter_json,
+        )
+        .unwrap();
+        assert_eq!(
+            matches,
+            vec![
+                characters
+                    .iter()
+                    .find(|c| c.name == "Eleanor Blackwood")
+                    .unwrap()
+                    .id
+            ]
+        );
+        let second = seed_sample_project(&conn).unwrap();
+        assert_ne!(project.id, second.id);
+        assert_eq!(db::get_saved_filters(&conn, &second.id).unwrap().len(), 1);
+    }
 }

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -344,7 +344,7 @@ pub async fn get_sync_preview(
     get_sync_preview_with_connection(&conn, project_uuid)
 }
 
-fn get_sync_preview_with_connection(
+pub(super) fn get_sync_preview_with_connection(
     conn: &Connection,
     project_uuid: Uuid,
 ) -> Result<SyncPreview, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,8 @@ pub fn run() {
             commands::import_novelwriter,
             commands::preview_import,
             commands::create_sample_project,
+            #[cfg(debug_assertions)]
+            commands::create_demo_fixture,
             commands::create_blank_project,
             commands::create_screenplay_project,
             commands::get_page_count_estimate,

--- a/src/lib/components/FieldDefinitionManager.svelte
+++ b/src/lib/components/FieldDefinitionManager.svelte
@@ -67,7 +67,10 @@
 
   function openEditForm(def: FieldDefinition) {
     editMode = "edit";
-    editingDef = { ...def };
+    editingDef = {
+      ...def,
+      field_type: def.field_type === "multi_select" ? "multiselect" : def.field_type,
+    };
   }
 
   function cancelEdit() {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -142,7 +142,7 @@
         <option value={option}>{option}</option>
       {/each}
     </select>
-  {:else if definition.field_type === "multiselect"}
+  {:else if definition.field_type === "multiselect" || definition.field_type === "multi_select"}
     <div class="flex flex-wrap gap-2">
       {#each selectOptions as option}
         <label

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -233,7 +233,7 @@
                 <div class="relative">
                   <div class="flex items-center gap-2 p-2 rounded bg-press-surface">
                     <ChevronDown class="w-4 h-4 text-press-muted" />
-                    <span class="text-press-text font-medium">Chapter 1: The Beginning</span>
+                    <span class="text-press-text font-medium">The Letter</span>
                   </div>
                   <!-- Label -->
                   <div

--- a/src/lib/components/ReferenceEditDialog.svelte
+++ b/src/lib/components/ReferenceEditDialog.svelte
@@ -252,7 +252,7 @@
 
       <div class="space-y-2">
         <div class="flex items-center justify-between">
-          <span class="text-press-ui text-press-muted">Additional Attributes</span>
+          <span class="text-press-ui text-press-muted">Legacy Attributes</span>
           <button
             type="button"
             onclick={addAttributeRow}

--- a/src/lib/components/ReferencesPanel.svelte
+++ b/src/lib/components/ReferencesPanel.svelte
@@ -822,6 +822,7 @@
 <aside
   class="bg-press-surface border-l border-press-border flex flex-col h-full relative"
   class:w-0={ui.referencesPanelCollapsed}
+  class:min-w-0={ui.referencesPanelCollapsed}
   class:overflow-hidden={ui.referencesPanelCollapsed}
   class:opacity-0={ui.referencesPanelCollapsed}
   class:border-l-0={ui.referencesPanelCollapsed}
@@ -1024,7 +1025,6 @@
       <div class="space-y-2">
         {#each activeItems as reference, index (reference.id)}
           {@const isExpanded = expandedIds.has(reference.id)}
-          {@const attributes = formatAttributes(reference.attributes)}
           {@const notes = getNotes(reference.attributes)}
           {@const isLinked = currentProject.currentScene ? linkedIds.has(reference.id) : false}
           {@const canDrag = !currentProject.currentScene || isLinked}
@@ -1108,6 +1108,17 @@
               {@const hasFieldValues = refFieldDefs.some(
                 (d) => refFieldValues[d.id] != null && refFieldValues[d.id] !== ""
               )}
+              {@const attributes = formatAttributes(reference.attributes)
+                .filter(
+                  ([key]) =>
+                    !refFieldDefs.some(
+                      (def) =>
+                        def.name.trim().toLowerCase() === key.trim().toLowerCase() &&
+                        refFieldValues[def.id] != null &&
+                        refFieldValues[def.id] !== ""
+                    )
+                )
+                .sort(([a], [b]) => a.localeCompare(b))}
               <div class="px-3 pb-3 border-t border-press-border">
                 {#if reference.description}
                   <div
@@ -1136,7 +1147,7 @@
                           <span class="text-press-text wrap-break-word">
                             {#if def.field_type === "checkbox"}
                               {fv === "true" ? "Yes" : "No"}
-                            {:else if def.field_type === "multiselect"}
+                            {:else if def.field_type === "multiselect" || def.field_type === "multi_select"}
                               {(() => {
                                 try {
                                   return (JSON.parse(fv) as string[]).join(", ");

--- a/src/lib/components/ReferencesPanel.test.ts
+++ b/src/lib/components/ReferencesPanel.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { currentProject } from "../stores/project.svelte";
+import { ui } from "../stores/ui.svelte";
+import { REFERENCE_TYPE_OPTIONS } from "../referenceTypes";
+import type { FieldDefinition, FieldValue, Project, ReferenceItem } from "../types";
+import ReferencesPanel from "./ReferencesPanel.svelte";
+import ReferenceEditDialog from "./ReferenceEditDialog.svelte";
+import FieldRenderer from "./FieldRenderer.svelte";
+import Onboarding from "./Onboarding.svelte";
+import sampleSource from "../../../src-tauri/src/commands/sample_project.rs?raw";
+
+vi.hoisted(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+  });
+});
+
+const project: Project = {
+  id: "project",
+  name: "The Letter",
+  source_type: "Blank",
+  source_path: null,
+  created_at: "",
+  modified_at: "",
+  author_pen_name: "E. M. Hale",
+  genre: "Gothic Mystery",
+  description: null,
+  word_target: 90000,
+  reference_types: ["characters"],
+  project_type: "novel",
+  target_page_count: null,
+};
+const reference: ReferenceItem = {
+  id: "eleanor",
+  project_id: project.id,
+  name: "Eleanor Blackwood",
+  reference_type: "characters",
+  description: null,
+  attributes: { Role: "Legacy role", Age: "17", Keepsake: "Pocket knife" },
+  source_id: null,
+};
+const definitions: FieldDefinition[] = [
+  {
+    id: "role",
+    project_id: project.id,
+    entity_type: "character",
+    name: "Role",
+    field_type: "text",
+    options: null,
+    default_value: null,
+    position: 0,
+    required: false,
+    visible: true,
+    created_at: "",
+  },
+  {
+    id: "age",
+    project_id: project.id,
+    entity_type: "character",
+    name: "Age",
+    field_type: "number",
+    options: null,
+    default_value: null,
+    position: 1,
+    required: false,
+    visible: true,
+    created_at: "",
+  },
+];
+const values: FieldValue[] = [
+  { id: "v1", field_definition_id: "role", entity_id: reference.id, value: "protagonist" },
+  { id: "v2", field_definition_id: "age", entity_id: reference.id, value: "18" },
+];
+function mockFields(defs = definitions, fieldValues = values) {
+  vi.mocked(invoke).mockImplementation(async (command) => {
+    if (command === "get_references") return [reference];
+    if (command === "get_field_definitions") return defs;
+    if (command === "get_field_values_bulk" || command === "get_field_values") return fieldValues;
+    return [];
+  });
+}
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  currentProject.setProject(project);
+  currentProject.setCurrentScene(null);
+  ui.referencesPanelCollapsed = false;
+  mockFields();
+});
+afterEach(() => {
+  cleanup();
+  currentProject.setProject(null);
+  ui.referencesPanelCollapsed = false;
+});
+
+async function expandReference() {
+  await fireEvent.click(await screen.findByRole("button", { name: reference.name }));
+}
+
+describe("reference fixture rendering", () => {
+  it("renders overlapping labels once, preferring typed values and preserving other legacy values", async () => {
+    render(ReferencesPanel);
+    await expandReference();
+    await screen.findByText("protagonist");
+    expect(screen.getAllByText("Role:")).toHaveLength(1);
+    expect(screen.getAllByText("Age:")).toHaveLength(1);
+    expect(screen.queryByText("Legacy role")).toBeNull();
+    expect(screen.getByText("18")).toBeTruthy();
+    expect(screen.getByText("Keepsake:")).toBeTruthy();
+  });
+  it("preserves legacy-only projects without field definitions", async () => {
+    mockFields([], []);
+    render(ReferencesPanel);
+    await expandReference();
+    expect(await screen.findByText("Legacy role")).toBeTruthy();
+    expect(screen.getAllByText("Role:")).toHaveLength(1);
+    expect(screen.getByText("17")).toBeTruthy();
+  });
+  it("keeps a legacy value when the matching typed field is empty", async () => {
+    mockFields(definitions, []);
+    render(ReferencesPanel);
+    await expandReference();
+    expect(await screen.findByText("Legacy role")).toBeTruthy();
+    expect(screen.getAllByText("Role:")).toHaveLength(1);
+  });
+  it("returns the collapsed panel's minimum width and restores its pixel width on expansion", async () => {
+    const { container } = render(ReferencesPanel);
+    const aside = container.querySelector("aside")!;
+    expect(aside.style.width).toBe(`${ui.referencesPanelWidth}px`);
+    expect(aside.classList.contains("min-w-0")).toBe(false);
+    ui.referencesPanelCollapsed = true;
+    await tick();
+    expect(aside.classList.contains("w-0")).toBe(true);
+    expect(aside.classList.contains("min-w-0")).toBe(true);
+    expect(aside.getAttribute("style") ?? "").not.toContain("width:");
+    ui.referencesPanelCollapsed = false;
+    await tick();
+    expect(aside.style.width).toBe(`${ui.referencesPanelWidth}px`);
+    expect(aside.classList.contains("min-w-0")).toBe(false);
+  });
+  it("keeps typed and legacy values editable in distinctly labelled sections", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(ReferenceEditDialog, {
+      referenceType: REFERENCE_TYPE_OPTIONS.find((t) => t.id === "characters")!,
+      reference,
+      projectId: project.id,
+      onSave,
+      onClose: vi.fn(),
+    });
+    const typedHeading = await screen.findByText("Custom Fields");
+    const legacyHeading = screen.getByText("Legacy Attributes");
+    expect(typedHeading.parentElement?.querySelector("input")?.value).toBe("protagonist");
+    expect(legacyHeading.parentElement?.parentElement?.querySelector("input")?.value).toBe("Role");
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: reference.attributes,
+          fieldValues: { role: "protagonist", age: "18" },
+        })
+      )
+    );
+  });
+  it.each(["multi_select", "multiselect"] as const)(
+    "edits %s Traits as a multi-select",
+    async (field_type) => {
+      const onChange = vi.fn();
+      render(FieldRenderer, {
+        definition: {
+          ...definitions[0],
+          name: "Traits",
+          field_type,
+          options: '["observant","loyal"]',
+        },
+        value: '["observant"]',
+        onChange,
+      });
+      await fireEvent.click(screen.getByText("loyal"));
+      expect(onChange).toHaveBeenCalledWith('["observant","loyal"]');
+    }
+  );
+  it("aligns the onboarding sidebar with a seeded chapter", () => {
+    ui.startOnboarding();
+    ui.goToStep("tour-sidebar");
+    render(Onboarding);
+    expect(screen.queryByText("Chapter 1: The Beginning")).toBeNull();
+    expect(screen.getByText("The Letter")).toBeTruthy();
+    expect(sampleSource).toMatch(/Chapter::new\(project.id, "The Letter"/);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -231,7 +231,15 @@ export type ReferenceTypeId =
   | "custom";
 
 /** Supported field types for custom fields */
-export type FieldType = "text" | "number" | "date" | "select" | "multiselect" | "checkbox" | "url";
+export type FieldType =
+  | "text"
+  | "number"
+  | "date"
+  | "select"
+  | "multiselect"
+  | "multi_select"
+  | "checkbox"
+  | "url";
 
 /** Entity types that support custom fields */
 export type FieldEntityType =


### PR DESCRIPTION
## Summary

The sample project was too sparse to demonstrate documented features, and reference cards repeated legacy fields beside typed values. This replaces the sample with the reproducible **The Letter** fixture and fixes reference rendering and collapsed-panel layout.

- Seed three chapters and nine scenes, spanning zero to five beats, Notes/Final/Flexible states and Page mode. Preserve the first scene, **On the Cliff**, in Beat mode with three beats and the published opening prose.
- Add four characters, three locations, two items, four typed character fields, hierarchical tags and an active-protagonist saved filter. Margaret Wren and Silas Blackwood remain unlinked but detectable in the opening prose.
- Add `create_demo_fixture` for a screenplay and a Markdown source-backed project; both the command and registration are gated by `debug_assertions`. Files are created beside the active database without overwriting existing outlines.
- Prefer typed values over duplicate legacy labels, retain legacy editing under its own heading, restore editor width when references collapse, and align onboarding. Accept `multi_select` alongside the existing `multiselect` spelling.
- Document clean fixture creation in `qa/demo/README.md`.

## Related Issues

Implements the Demo Fixture Content v1 PRD, WU-01 through WU-08.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally — the exact WebDriver suite still requires a supported environment; see validation below
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Validation

- `cargo test --all-features`: 403 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `npm test`: 268 passed, including eight new frontend regressions.
- `npm run check`: zero errors, six existing warnings.
- `npm run lint`: passed.
- `cargo fmt --all` and `npm run format`: run.
- `cargo check --release --all-features`: passed with the development command excluded.
- Clean scratch database plus both fixture commands: all seven sibling `kindling-splash` screenshot targets passed `npm run shots -- --keep`, including luminance, ratio and minimum-width checks.
- Live collapse check: references shrank from 332px to 0px; the editor grew from 588px to 920px. Visually verified.
- Native-app test bridge: novelWriter export → import → empty sync preview → source prose edit → UI diff → UI acceptance → accepted prose visible in the final beat editor passed. Smart detection surfaced both intended unlinked characters.

The unchanged `e2e/specs/novelwriter.spec.js` could not run through WebDriver locally: a WebdriverIO runner dependency is missing, macOS lacks a WKWebView driver, and the Docker daemon is unavailable. Run that exact suite on Linux/Windows before merging; the native bridge smoke above is supplementary evidence.

## Screenshots/Recordings

All seven screenshot targets were captured from the clean fixture with `--keep`; no website assets were installed. Reproduction steps are in `qa/demo/README.md`.

## Testing Instructions

1. Start a debug build with a fresh `KINDLING_DATA_DIR`, then click **Sample Project**. Inspect the scenes, references, custom fields, tags and saved filter.
2. Collapse references and confirm the editor receives its width. Expand Eleanor's card and confirm each field appears once.
3. Invoke `create_demo_fixture` using the documented developer-console command. Open the screenplay; then open the source outline, append a scene heading to its `source_path`, and inspect Sync Preview.
4. Run the existing novelWriter WebDriver round-trip on a supported platform.

## Additional Notes

No schema, brand-token, lockfile, DOCX-formatting or existing novelWriter E2E changes. No dependencies added. Implemented and validated without Blacksmith.
