### PR TITLE
fix(import): add novelWriter to home screen

### DIFF
--- a/src/lib/components/NovelWriter.test.ts
+++ b/src/lib/components/NovelWriter.test.ts
@@ -6,6 +6,7 @@ import ExportDialog from "./ExportDialog.svelte";
 import SyncDialog from "./SyncDialog.svelte";
 import Sidebar from "./Sidebar.svelte";
 import Onboarding from "./Onboarding.svelte";
+import StartScreen from "./StartScreen.svelte";
 import { currentProject } from "../stores/project.svelte";
 import { ui } from "../stores/ui.svelte";
 import { runImport } from "../utils/import";
@@ -308,5 +309,24 @@ describe("timeline and custom references", () => {
     render(ScenePanel);
     await screen.findByText("Linked timelines");
     expect(screen.getByText("Linked custom")).toBeTruthy();
+  });
+});
+
+describe("novelWriter home screen import", () => {
+  it("picks a project folder, opens the import and notifies reference classification", async () => {
+    currentProject.setProject(null);
+    ui.setView("start");
+    vi.mocked(open).mockResolvedValue("/source");
+    vi.mocked(invoke).mockResolvedValue(project);
+    const onImportComplete = vi.fn();
+    render(StartScreen, { recentProjects: [], onImportComplete });
+
+    await fireEvent.click(screen.getByRole("button", { name: "novelWriter Project folder" }));
+
+    await waitFor(() => expect(onImportComplete).toHaveBeenCalledWith(project, "novelwriter"));
+    expect(open).toHaveBeenCalledWith({ multiple: false, directory: true });
+    expect(invoke).toHaveBeenCalledWith("import_novelwriter", { path: "/source" });
+    expect(currentProject.value?.id).toBe(project.id);
+    expect(ui.currentView).toBe("editor");
   });
 });

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -56,6 +56,7 @@
   const importYWriter = () => handleImport("ywriter");
   const importLongform = () => handleImport("longform");
   const importScrivener = () => handleImport("scrivener");
+  const importNovelWriter = () => handleImport("novelwriter");
 
   function handleLongformImport() {
     const handler = onImportLongform ?? importLongform;
@@ -201,7 +202,7 @@
         </div>
       {/if}
 
-      <!-- Import Options (2x2 compact) -->
+      <!-- Import Options (two-column grid) -->
       <div data-testid="import-section" class="bg-press-surface rounded-lg p-4">
         <h2 class="text-press-base font-heading font-medium text-press-text mb-3">
           Import an Outline
@@ -246,6 +247,14 @@
             <Scroll class="w-8 h-8 text-press-accent-text mb-1" />
             <span class="text-press-text text-press-ui font-medium">Scrivener</span>
             <span class="text-press-muted text-press-eyebrow">.scriv</span>
+          </button>
+          <button
+            onclick={importNovelWriter}
+            class="flex flex-col items-center p-4 bg-press-sunken rounded-lg hover:bg-press-sunken transition-colors cursor-pointer"
+          >
+            <Scroll class="w-8 h-8 text-press-accent-text mb-1" />
+            <span class="text-press-text text-press-ui font-medium">novelWriter</span>
+            <span class="text-press-muted text-press-eyebrow">Project folder</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The home screen omitted novelWriter from **Import an Outline**. Add a novelWriter tile beside Scrivener, with a **Project folder** caption, using the existing folder picker, import, and reference classification flow.

Includes a regression test covering the button, picker configuration, IPC command, project activation, and import-completion callback.

## Related Issues

Follow-up to #267. Relates to #261.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing frontend tests pass locally
- [x] I have updated documentation as needed (no documentation change needed)
- [x] I have added relevant labels to this PR

## Testing Instructions

1. Open the home screen and locate **novelWriter** beside **Scrivener** in **Import an Outline**.
2. Click it and select a novelWriter project folder containing `nwProject.nwx`.
3. Confirm the project opens and the reference classification flow is available when applicable.

## Additional Notes

Manual verification confirmed by the requester. Local pre-push checks cover Prettier, ESLint, svelte-check, Rust formatting, Clippy, and the full Vitest suite. Svelte-check reports zero errors and six existing warnings.
