### PR TITLE
fix(editor): preserve editing focus and save drafts before exit

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,6 +30,7 @@
   import { COMMAND_DEFS } from "./lib/commands";
   import { currentProject } from "./lib/stores/project.svelte";
   import { session } from "./lib/stores/session.svelte";
+  import { synopsisSaves } from "./lib/stores/synopsisSaves.svelte";
   import { ui } from "./lib/stores/ui.svelte";
   import type { ProseDocument } from "./lib/utils/proseSearch";
   import type { Project, ExportResult, Chapter, Scene, Beat } from "./lib/types";
@@ -157,16 +158,38 @@
     currentProject.setProject(null);
   }
 
-  async function flushBeforeClose() {
+  let closePending = $state(false);
+  let closeRequest: Promise<boolean> | null = null;
+
+  function flushBeforeClose() {
+    if (closeRequest) return closeRequest;
+    closePending = true;
+    closeRequest = saveBeforeClose().finally(() => {
+      closePending = false;
+      closeRequest = null;
+    });
+    return closeRequest;
+  }
+
+  async function saveBeforeClose() {
+    try {
+      await synopsisSaves.flush();
+    } catch (error) {
+      ui.showError(
+        `Kindling stayed open because your synopsis could not be saved. ${String(error)}`
+      );
+      return false;
+    }
     try {
       await session.flush();
     } catch (error) {
       console.error("Failed to save writing position before closing:", error);
     }
+    return true;
   }
 
   async function quit() {
-    await flushBeforeClose();
+    if (!(await flushBeforeClose())) return;
     try {
       await exit(0);
     } catch (error) {
@@ -176,11 +199,25 @@
 
   onMount(() => {
     // Tauri awaits this handler before destroying the window.
-    const unlisten = getCurrentWindow().onCloseRequested(flushBeforeClose);
+    const unlisten = getCurrentWindow().onCloseRequested(async (event) => {
+      if (!(await flushBeforeClose())) event.preventDefault();
+    });
     return () => {
       void unlisten.then((stop) => stop());
     };
   });
+
+  let retryingSynopses = $state(false);
+  async function retrySynopses() {
+    retryingSynopses = true;
+    try {
+      await synopsisSaves.flush();
+    } catch {
+      // The banner and per-scene errors remain visible until saving succeeds.
+    } finally {
+      retryingSynopses = false;
+    }
+  }
 
   // Check for updates on launch (delayed so it doesn't block startup)
   onMount(() => {
@@ -377,7 +414,29 @@
 
 <UpdateBanner />
 
-<main class="flex h-screen w-screen overflow-hidden bg-press-bg">
+{#if synopsisSaves.failedCount}
+  <div
+    role="alert"
+    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-press-surface border border-press-error p-4 shadow-lg text-press-ui"
+  >
+    <p class="text-press-error">
+      Your synopsis changes have not been saved. Retry saving before closing Kindling.
+    </p>
+    <button
+      onclick={retrySynopses}
+      disabled={retryingSynopses}
+      aria-label="Retry all synopsis saves"
+      class="mt-2 underline text-press-text disabled:opacity-50"
+      >{retryingSynopses ? "Saving..." : "Retry saving"}</button
+    >
+  </div>
+{/if}
+
+<main
+  inert={closePending}
+  aria-busy={closePending}
+  class="flex h-screen w-screen overflow-hidden bg-press-bg"
+>
   {#if currentProject.value}
     <Sidebar />
     <ScenePanel bind:this={scenePanel} />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
   import ExportDialog from "./lib/components/ExportDialog.svelte";
   import ExportSuccessDialog from "./lib/components/ExportSuccessDialog.svelte";
   import ErrorToast from "./lib/components/ErrorToast.svelte";
+  import ConfirmDialog from "./lib/components/ConfirmDialog.svelte";
   import ImportLongformDialog from "./lib/components/ImportLongformDialog.svelte";
   import ReferenceClassificationDialog from "./lib/components/ReferenceClassificationDialog.svelte";
   import QuickStartDialog from "./lib/components/QuickStartDialog.svelte";
@@ -30,7 +31,7 @@
   import { COMMAND_DEFS } from "./lib/commands";
   import { currentProject } from "./lib/stores/project.svelte";
   import { session } from "./lib/stores/session.svelte";
-  import { synopsisSaves } from "./lib/stores/synopsisSaves.svelte";
+  import { synopsisSaves, type SynopsisDraft } from "./lib/stores/synopsisSaves.svelte";
   import { ui } from "./lib/stores/ui.svelte";
   import type { ProseDocument } from "./lib/utils/proseSearch";
   import type { Project, ExportResult, Chapter, Scene, Beat } from "./lib/types";
@@ -160,8 +161,10 @@
 
   let closePending = $state(false);
   let closeRequest: Promise<boolean> | null = null;
+  let discardQuitDrafts = $state.raw<SynopsisDraft[] | null>(null);
 
   function flushBeforeClose() {
+    if (discardQuitDrafts) return Promise.resolve(false);
     if (closeRequest) return closeRequest;
     closePending = true;
     closeRequest = saveBeforeClose().finally(() => {
@@ -174,10 +177,8 @@
   async function saveBeforeClose() {
     try {
       await synopsisSaves.flush();
-    } catch (error) {
-      ui.showError(
-        `Kindling stayed open because your synopsis could not be saved. ${String(error)}`
-      );
+    } catch {
+      discardQuitDrafts = synopsisSaves.snapshot();
       return false;
     }
     try {
@@ -194,6 +195,22 @@
       await exit(0);
     } catch (error) {
       console.error("Failed to quit:", error);
+    }
+  }
+
+  async function quitAndDiscard() {
+    const approved = discardQuitDrafts;
+    if (!approved || closePending) return;
+    closePending = true;
+    try {
+      await synopsisSaves.discardAll(approved);
+      discardQuitDrafts = null;
+      await exit(0);
+    } catch (error) {
+      discardQuitDrafts = null;
+      ui.showError(`Could not quit: ${String(error)}`);
+    } finally {
+      closePending = false;
     }
   }
 
@@ -414,17 +431,28 @@
 
 <UpdateBanner />
 
+{#if discardQuitDrafts}
+  <ConfirmDialog
+    title="Quit without saving synopsis changes?"
+    message="Some synopsis changes could not be saved. Quit and discard these unsaved synopsis changes, or keep editing to retry saving."
+    confirmLabel="Quit and discard"
+    cancelLabel="Keep editing"
+    onConfirm={quitAndDiscard}
+    onCancel={() => {
+      if (!closePending) discardQuitDrafts = null;
+    }}
+  />
+{/if}
+
 {#if synopsisSaves.failedCount}
   <div
     role="alert"
     class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-press-surface border border-press-error p-4 shadow-lg text-press-ui"
   >
-    <p class="text-press-error">
-      Your synopsis changes have not been saved. Retry saving before closing Kindling.
-    </p>
+    <p class="text-press-error">Your synopsis changes have not been saved.</p>
     <button
       onclick={retrySynopses}
-      disabled={retryingSynopses}
+      disabled={retryingSynopses || discardQuitDrafts !== null}
       aria-label="Retry all synopsis saves"
       class="mt-2 underline text-press-text disabled:opacity-50"
       >{retryingSynopses ? "Saving..." : "Retry saving"}</button
@@ -433,7 +461,7 @@
 {/if}
 
 <main
-  inert={closePending}
+  inert={closePending || discardQuitDrafts !== null}
   aria-busy={closePending}
   class="flex h-screen w-screen overflow-hidden bg-press-bg"
 >

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -32,6 +32,7 @@
   import { currentProject } from "./lib/stores/project.svelte";
   import { session } from "./lib/stores/session.svelte";
   import { synopsisSaves, type SynopsisDraft } from "./lib/stores/synopsisSaves.svelte";
+  import { proseSaves, type ProseSave } from "./lib/utils/proseSaves";
   import { ui } from "./lib/stores/ui.svelte";
   import type { ProseDocument } from "./lib/utils/proseSearch";
   import type { Project, ExportResult, Chapter, Scene, Beat } from "./lib/types";
@@ -163,6 +164,7 @@
   let updatePending = $state(false);
   let closeRequest: Promise<boolean> | null = null;
   let discardQuitDrafts = $state.raw<SynopsisDraft[] | null>(null);
+  let discardQuitProse = $state.raw<ProseSave[]>([]);
 
   function flushBeforeClose() {
     if (discardQuitDrafts || updatePending) return Promise.resolve(false);
@@ -175,10 +177,31 @@
     return closeRequest;
   }
 
+  async function flushProseBeforeExit() {
+    // This existing editor hook submits debounced page and beat edits to proseSaves.
+    await scenePanel?.prepareForSearch();
+    await proseSaves.flush();
+    if (proseSaves.draftsForRecovery().length) {
+      throw new Error(
+        "Prose changes could not be saved. Review the unsaved drafts in Find and Replace."
+      );
+    }
+  }
+
   async function saveBeforeClose() {
+    let failed = false;
+    try {
+      await flushProseBeforeExit();
+    } catch {
+      failed = true;
+    }
     try {
       await synopsisSaves.flush();
     } catch {
+      failed = true;
+    }
+    if (failed) {
+      discardQuitProse = proseSaves.draftsForRecovery();
       discardQuitDrafts = synopsisSaves.snapshot();
       return false;
     }
@@ -208,6 +231,9 @@
     if (!approved || closePending) return;
     closePending = true;
     try {
+      await proseSaves.discard(discardQuitProse, () =>
+        scenePanel?.discardProseDraftsForClose(discardQuitProse)
+      );
       await synopsisSaves.discardAll(approved);
       await flushPositionBeforeClose();
       discardQuitDrafts = null;
@@ -438,12 +464,17 @@
 <UpdateBanner
   disabled={closePending || discardQuitDrafts !== null}
   bind:restarting={updatePending}
+  prepare={flushProseBeforeExit}
 />
 
 {#if discardQuitDrafts}
   <ConfirmDialog
-    title="Quit without saving synopsis changes?"
-    message="Some synopsis changes could not be saved. Quit and discard these unsaved synopsis changes, or keep editing to retry saving."
+    title={discardQuitProse.length
+      ? "Quit without saving writing changes?"
+      : "Quit without saving synopsis changes?"}
+    message={discardQuitProse.length
+      ? "Some prose or synopsis changes could not be saved. Quit and discard these unsaved writing changes, or keep editing to retry saving."
+      : "Some synopsis changes could not be saved. Quit and discard these unsaved synopsis changes, or keep editing to retry saving."}
     confirmLabel="Quit and discard"
     cancelLabel="Keep editing"
     onConfirm={quitAndDiscard}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -160,11 +160,12 @@
   }
 
   let closePending = $state(false);
+  let updatePending = $state(false);
   let closeRequest: Promise<boolean> | null = null;
   let discardQuitDrafts = $state.raw<SynopsisDraft[] | null>(null);
 
   function flushBeforeClose() {
-    if (discardQuitDrafts) return Promise.resolve(false);
+    if (discardQuitDrafts || updatePending) return Promise.resolve(false);
     if (closeRequest) return closeRequest;
     closePending = true;
     closeRequest = saveBeforeClose().finally(() => {
@@ -181,12 +182,16 @@
       discardQuitDrafts = synopsisSaves.snapshot();
       return false;
     }
+    await flushPositionBeforeClose();
+    return true;
+  }
+
+  async function flushPositionBeforeClose() {
     try {
       await session.flush();
     } catch (error) {
       console.error("Failed to save writing position before closing:", error);
     }
-    return true;
   }
 
   async function quit() {
@@ -204,6 +209,7 @@
     closePending = true;
     try {
       await synopsisSaves.discardAll(approved);
+      await flushPositionBeforeClose();
       discardQuitDrafts = null;
       await exit(0);
     } catch (error) {
@@ -429,7 +435,10 @@
   {/key}
 {/if}
 
-<UpdateBanner />
+<UpdateBanner
+  disabled={closePending || discardQuitDrafts !== null}
+  bind:restarting={updatePending}
+/>
 
 {#if discardQuitDrafts}
   <ConfirmDialog
@@ -444,10 +453,10 @@
   />
 {/if}
 
-{#if synopsisSaves.failedCount}
+{#if synopsisSaves.failedCount && !discardQuitDrafts}
   <div
     role="alert"
-    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-press-surface border border-press-error p-4 shadow-lg text-press-ui"
+    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-press-toast rounded-lg bg-press-surface border border-press-error p-4 shadow-lg text-press-ui"
   >
     <p class="text-press-error">Your synopsis changes have not been saved.</p>
     <button
@@ -461,8 +470,8 @@
 {/if}
 
 <main
-  inert={closePending || discardQuitDrafts !== null}
-  aria-busy={closePending}
+  inert={closePending || updatePending || discardQuitDrafts !== null}
+  aria-busy={closePending || updatePending}
   class="flex h-screen w-screen overflow-hidden bg-press-bg"
 >
   {#if currentProject.value}

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -4,6 +4,7 @@ import { tick } from "svelte";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { updateState } from "./lib/updater";
 import { exit } from "@tauri-apps/plugin-process";
 import { synopsisSaves } from "./lib/stores/synopsisSaves.svelte";
 import { session } from "./lib/stores/session.svelte";
@@ -50,6 +51,7 @@ beforeEach(() => {
   );
   vi.mocked(listen).mockClear();
   vi.mocked(exit).mockClear();
+  updateState.set(null);
   vi.mocked(getCurrentWindow().onCloseRequested).mockClear();
   currentProject.setProject(mockProject);
   currentProject.setCurrentScene({ ...mockScenes[0], planning_status: "undefined" });
@@ -59,6 +61,7 @@ beforeEach(() => {
 });
 afterEach(async () => {
   cleanup();
+  updateState.set(null);
   vi.mocked(invoke).mockResolvedValue([]);
   await synopsisSaves.flush();
   currentProject.setProject(null);
@@ -422,4 +425,115 @@ it("requires fresh discard confirmation if synopsis drafts change while the quit
   await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
   await vi.advanceTimersByTimeAsync(0);
   expect(exit).toHaveBeenCalledWith(0);
+});
+
+it.each([false, true])(
+  "flushes writing position before quit-and-discard (position save fails: %s)",
+  async (fails) => {
+    vi.useFakeTimers();
+    currentProject.setChapters(mockChapters);
+    render(App);
+    await vi.advanceTimersByTimeAsync(0);
+    synopsisSaves.stage({
+      projectId: mockProject.id,
+      sceneId: mockScenes[0].id,
+      synopsis: "Locked draft",
+    });
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_scene_synopsis") throw "Cannot edit a locked scene";
+      return [];
+    });
+    await menu("quit");
+    await vi.advanceTimersByTimeAsync(0);
+    let finish!: () => void;
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const flush = vi.spyOn(session, "flush").mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      if (fails) throw new Error("disk full");
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
+    await vi.advanceTimersByTimeAsync(0);
+    try {
+      expect(flush).toHaveBeenCalledOnce();
+      expect(exit).not.toHaveBeenCalled();
+    } finally {
+      finish?.();
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exit).toHaveBeenCalledWith(0);
+    if (fails)
+      expect(error).toHaveBeenCalledWith(
+        "Failed to save writing position before closing:",
+        expect.any(Error)
+      );
+  }
+);
+
+it("disables update restart while a quit-discard decision is pending", async () => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  const install = vi.fn().mockResolvedValue(undefined);
+  updateState.set({ ready: true, version: "1.2.1", body: null, update: { install } as never });
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  synopsisSaves.stage({
+    projectId: mockProject.id,
+    sceneId: mockScenes[0].id,
+    synopsis: "Unsaved draft",
+  });
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis") throw "disk full";
+    return [];
+  });
+  await menu("quit");
+  await vi.advanceTimersByTimeAsync(0);
+  const restart = screen.getByRole("button", { name: "Restart" }) as HTMLButtonElement;
+  expect(restart.disabled).toBe(true);
+  expect(screen.queryByText("Your synopsis changes have not been saved.")).toBeNull();
+  await fireEvent.click(restart);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(install).not.toHaveBeenCalled();
+  await fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+  expect(restart.disabled).toBe(false);
+  expect(screen.getByText("Your synopsis changes have not been saved.")).toBeTruthy();
+  await fireEvent.click(restart);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(install).not.toHaveBeenCalled();
+  expect(screen.getByText(/Could not restart to update/)).toBeTruthy();
+});
+
+it("prevents editing and duplicate restart or quit while an update is saving", async () => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  const install = vi.fn().mockResolvedValue(undefined);
+  updateState.set({ ready: true, version: "1.2.1", body: null, update: { install } as never });
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  let finish!: () => void;
+  vi.spyOn(session, "flush").mockImplementation(async () => {
+    await new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+  });
+  const restart = screen.getByRole("button", { name: "Restart" }) as HTMLButtonElement;
+  await fireEvent.click(restart);
+  await vi.advanceTimersByTimeAsync(0);
+  try {
+    expect(restart.disabled).toBe(true);
+    expect(screen.getByRole("main", { hidden: true }).inert).toBe(true);
+    await fireEvent.click(restart);
+    await menu("quit");
+    const preventDefault = vi.fn();
+    const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+    await handler({ preventDefault } as never);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(exit).not.toHaveBeenCalled();
+  } finally {
+    finish?.();
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  expect(install).toHaveBeenCalledOnce();
+  expect(screen.getByRole("main").inert).toBe(false);
 });

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -139,8 +139,15 @@ it.each(["menu", "native"])(
     else await handler({ preventDefault } as never);
     await vi.advanceTimersByTimeAsync(0);
     expect(exit).not.toHaveBeenCalled();
-    expect(screen.getByRole("main").inert).toBe(false);
     if (path === "native") expect(preventDefault).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("dialog", { name: "Quit without saving synopsis changes?" })
+    ).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(screen.getByRole("main").inert).toBe(false);
+    expect(synopsisSaves.getState(mockProject.id, mockScenes[0].id).draft?.synopsis).toBe(
+      "Do not lose this synopsis"
+    );
     expect(screen.getByRole("button", { name: "Retry all synopsis saves" })).toBeTruthy();
     vi.mocked(invoke).mockResolvedValue([]);
     await fireEvent.click(screen.getByRole("button", { name: "Retry all synopsis saves" }));
@@ -291,4 +298,128 @@ it("ignores an old project's search response after switching projects during loa
     expect(invoke).toHaveBeenCalledWith("get_search_documents", { projectId: "another" })
   );
   expect((screen.getByLabelText("Find") as HTMLInputElement).value).toBe("");
+});
+
+it.each([
+  ["menu", "Cannot edit a locked scene"],
+  ["native", "Cannot edit a locked scene"],
+  ["menu", "disk full"],
+  ["native", "disk full"],
+])("allows explicit quit-and-discard via %s after %s", async (path, failure) => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  synopsisSaves.stage({
+    projectId: mockProject.id,
+    sceneId: mockScenes[0].id,
+    synopsis: "Unsavable draft",
+  });
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis") throw failure;
+    return [];
+  });
+  const preventDefault = vi.fn();
+  if (path === "menu") await menu("quit");
+  else {
+    const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+    await handler({ preventDefault } as never);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).not.toHaveBeenCalled();
+  expect(synopsisSaves.failedCount).toBe(1);
+  await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).toHaveBeenCalledWith(0);
+  expect(synopsisSaves.getState(mockProject.id, mockScenes[0].id).draft).toBeUndefined();
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(
+    vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === "save_scene_synopsis")
+  ).toHaveLength(1);
+});
+
+it.each(["menu", "native"])(
+  "does not block %s quit after a scene is deleted during synopsis debounce",
+  async (path) => {
+    vi.useFakeTimers();
+    currentProject.setChapters(mockChapters);
+    render(App);
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+    await fireEvent.input(screen.getByPlaceholderText("Write a brief synopsis for this scene..."), {
+      target: { value: "Deleted with its scene" },
+    });
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_scene_synopsis") throw "Query returned no rows";
+      return [];
+    });
+    await invoke("delete_scene", { sceneId: mockScenes[0].id });
+    currentProject.setCurrentScene(null);
+    await tick();
+    const preventDefault = vi.fn();
+    if (path === "menu") await menu("quit");
+    else {
+      const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+      await handler({ preventDefault } as never);
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    if (path === "menu") expect(exit).toHaveBeenCalledWith(0);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(synopsisSaves.failedCount).toBe(0);
+  }
+);
+
+it("keeps both synopsis error warnings visible while typing continues", async () => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  const textarea = screen.getByPlaceholderText("Write a brief synopsis for this scene...");
+  await fireEvent.input(textarea, { target: { value: "Unsaved" } });
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis") throw "disk full";
+    return [];
+  });
+  await vi.advanceTimersByTimeAsync(1000);
+  for (const value of ["Unsaved changes", "Unsaved changes continue"]) {
+    await fireEvent.input(textarea, { target: { value } });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(screen.getByText(/Synopsis not saved: disk full/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry all synopsis saves" })).toBeTruthy();
+  }
+});
+
+it("requires fresh discard confirmation if synopsis drafts change while the quit dialog is open", async () => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  const draft = {
+    projectId: mockProject.id,
+    sceneId: mockScenes[0].id,
+    synopsis: "Original draft",
+  };
+  synopsisSaves.stage(draft);
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis") throw "disk full";
+    return [];
+  });
+  await menu("quit");
+  await vi.advanceTimersByTimeAsync(0);
+  synopsisSaves.stage({ ...draft, synopsis: "New changes after the dialog opened" });
+  await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).not.toHaveBeenCalled();
+  expect(synopsisSaves.getState(draft.projectId, draft.sceneId).draft?.synopsis).toBe(
+    "New changes after the dialog opened"
+  );
+  expect(screen.getByRole("main").inert).toBe(false);
+  await menu("quit");
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).toHaveBeenCalledWith(0);
 });

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -5,10 +5,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { exit } from "@tauri-apps/plugin-process";
+import { synopsisSaves } from "./lib/stores/synopsisSaves.svelte";
 import { session } from "./lib/stores/session.svelte";
 import { runImport } from "./lib/utils/import";
 import { currentProject } from "./lib/stores/project.svelte";
-import { mockProject, mockScenes } from "./dev/mock-data";
+import { mockProject, mockScenes, mockChapters } from "./dev/mock-data";
 import App from "./App.svelte";
 
 vi.hoisted(() => {
@@ -56,9 +57,12 @@ beforeEach(() => {
     this.setAttribute("open", "");
   };
 });
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  vi.mocked(invoke).mockResolvedValue([]);
+  await synopsisSaves.flush();
   currentProject.setProject(null);
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 async function menu(payload: string) {
@@ -66,6 +70,93 @@ async function menu(payload: string) {
   callback({ event: "menu-event", id: 1, payload });
   await tick();
 }
+
+it.each(["menu", "native"])("flushes a debounced synopsis before %s quit", async (path) => {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  await fireEvent.input(screen.getByPlaceholderText("Write a brief synopsis for this scene..."), {
+    target: { value: "Last words before quitting" },
+  });
+  let finish!: () => void;
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis")
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+    return [];
+  });
+  const preventDefault = vi.fn();
+  let closed = false;
+  let closing: Promise<unknown> | undefined;
+  if (path === "menu") await menu("quit");
+  else {
+    const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+    closing = Promise.resolve(handler({ preventDefault } as never)).then(() => {
+      closed = true;
+    });
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  try {
+    expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+      sceneId: mockScenes[0].id,
+      synopsis: "Last words before quitting",
+    });
+    expect(exit).not.toHaveBeenCalled();
+    expect(closed).toBe(false);
+    expect(screen.getByRole("main", { hidden: true }).inert).toBe(true);
+  } finally {
+    finish?.();
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  await closing;
+  if (path === "menu") expect(exit).toHaveBeenCalledWith(0);
+  else expect(closed).toBe(true);
+  expect(preventDefault).not.toHaveBeenCalled();
+  expect(screen.getByRole("main").inert).toBe(false);
+});
+
+it.each(["menu", "native"])(
+  "blocks %s quit on a failed synopsis save and allows retry",
+  async (path) => {
+    vi.useFakeTimers();
+    currentProject.setChapters(mockChapters);
+    render(App);
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+    await fireEvent.input(screen.getByPlaceholderText("Write a brief synopsis for this scene..."), {
+      target: { value: "Do not lose this synopsis" },
+    });
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_scene_synopsis") throw "disk full";
+      return [];
+    });
+    const preventDefault = vi.fn();
+    const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+    if (path === "menu") await menu("quit");
+    else await handler({ preventDefault } as never);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(exit).not.toHaveBeenCalled();
+    expect(screen.getByRole("main").inert).toBe(false);
+    if (path === "native") expect(preventDefault).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Retry all synopsis saves" })).toBeTruthy();
+    vi.mocked(invoke).mockResolvedValue([]);
+    await fireEvent.click(screen.getByRole("button", { name: "Retry all synopsis saves" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(screen.queryByRole("button", { name: "Retry all synopsis saves" })).toBeNull();
+    if (path === "menu") {
+      await menu("quit");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(exit).toHaveBeenCalledWith(0);
+    } else {
+      preventDefault.mockClear();
+      await handler({ preventDefault } as never);
+      expect(preventDefault).not.toHaveBeenCalled();
+    }
+  }
+);
 
 it("waits for pending position saves before quitting from the menu", async () => {
   let finish!: () => void;

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -5,7 +5,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { updateState } from "./lib/updater";
-import { exit } from "@tauri-apps/plugin-process";
+import type { Editor } from "@tiptap/core";
+import { ui } from "./lib/stores/ui.svelte";
+import { proseSaves } from "./lib/utils/proseSaves";
+import { exit, relaunch } from "@tauri-apps/plugin-process";
 import { synopsisSaves } from "./lib/stores/synopsisSaves.svelte";
 import { session } from "./lib/stores/session.svelte";
 import { runImport } from "./lib/utils/import";
@@ -51,6 +54,7 @@ beforeEach(() => {
   );
   vi.mocked(listen).mockClear();
   vi.mocked(exit).mockClear();
+  vi.mocked(relaunch).mockReset();
   updateState.set(null);
   vi.mocked(getCurrentWindow().onCloseRequested).mockClear();
   currentProject.setProject(mockProject);
@@ -64,6 +68,9 @@ afterEach(async () => {
   updateState.set(null);
   vi.mocked(invoke).mockResolvedValue([]);
   await synopsisSaves.flush();
+  await proseSaves.flush(mockProject.id);
+  await proseSaves.discard(proseSaves.draftsForRecovery(mockProject.id));
+  ui.setExpandedBeat(null);
   currentProject.setProject(null);
   vi.useRealTimers();
   vi.restoreAllMocks();
@@ -536,4 +543,144 @@ it("prevents editing and duplicate restart or quit while an update is saving", a
   await vi.advanceTimersByTimeAsync(0);
   expect(install).toHaveBeenCalledOnce();
   expect(screen.getByRole("main").inert).toBe(false);
+});
+
+async function editProse(mode: "beat" | "page") {
+  vi.useFakeTimers();
+  currentProject.setChapters(mockChapters);
+  currentProject.setCurrentChapter(mockChapters[0]);
+  currentProject.setCurrentScene({
+    ...mockScenes[0],
+    planning_status: "fixed",
+    editor_mode: mode,
+    prose: "<p>Saved page</p>",
+  });
+  currentProject.setBeats([
+    {
+      id: "exit-beat",
+      scene_id: mockScenes[0].id,
+      content: "Beat",
+      prose: "<p>Saved beat</p>",
+      position: 0,
+    },
+  ]);
+  render(App);
+  await tick();
+  if (mode === "beat") ui.setExpandedBeat("exit-beat");
+  await vi.advanceTimersByTimeAsync(0);
+  const editor = (document.querySelector(".tiptap") as HTMLElement & { editor: Editor }).editor;
+  editor.commands.setContent("<p>Final words before exit</p>");
+}
+
+it.each([
+  ["beat", "menu"],
+  ["page", "menu"],
+  ["beat", "native"],
+  ["page", "native"],
+  ["beat", "update"],
+  ["page", "update"],
+] as const)("flushes debounced prose in %s mode before %s exit", async (mode, path) => {
+  const install = vi.fn().mockResolvedValue(undefined);
+  if (path === "update")
+    updateState.set({ ready: true, version: "1.2.1", body: null, update: { install } as never });
+  await editProse(mode);
+  let finish!: () => void;
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_beat_prose" || cmd === "save_scene_page_prose")
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+    return [];
+  });
+  let closing: Promise<unknown> | undefined;
+  let closed = false;
+  const preventDefault = vi.fn();
+  if (path === "menu") await menu("quit");
+  else if (path === "update")
+    await fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+  else {
+    const handler = vi.mocked(getCurrentWindow().onCloseRequested).mock.calls[0][0];
+    closing = Promise.resolve(handler({ preventDefault } as never)).then(() => {
+      closed = true;
+    });
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  try {
+    expect(invoke).toHaveBeenCalledWith(
+      mode === "beat" ? "save_beat_prose" : "save_scene_page_prose",
+      {
+        [mode === "beat" ? "beatId" : "sceneId"]: mode === "beat" ? "exit-beat" : mockScenes[0].id,
+        prose: "<p>Final words before exit</p>",
+      }
+    );
+    expect(exit).not.toHaveBeenCalled();
+    expect(install).not.toHaveBeenCalled();
+    expect(closed).toBe(false);
+  } finally {
+    finish?.();
+  }
+  await vi.advanceTimersByTimeAsync(0);
+  await closing;
+  if (path === "menu") expect(exit).toHaveBeenCalledWith(0);
+  if (path === "update") expect(install).toHaveBeenCalledOnce();
+  if (path === "native") expect(closed).toBe(true);
+  expect(preventDefault).not.toHaveBeenCalled();
+});
+
+it.each([
+  ["beat", "disk full"],
+  ["page", "disk full"],
+  ["beat", "Cannot edit beats in a locked scene"],
+  ["page", "Cannot edit a locked scene"],
+] as const)("allows explicit discard when %s prose cannot save: %s", async (mode, error) => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  await editProse(mode);
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_beat_prose" || cmd === "save_scene_page_prose") throw error;
+    return [];
+  });
+  await menu("quit");
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).not.toHaveBeenCalled();
+  expect(screen.getByRole("dialog", { name: "Quit without saving writing changes?" })).toBeTruthy();
+  expect(proseSaves.draftsForRecovery(mockProject.id)[0].prose).toBe(
+    "<p>Final words before exit</p>"
+  );
+  await fireEvent.click(screen.getByRole("button", { name: "Quit and discard" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(exit).toHaveBeenCalledWith(0);
+  expect(proseSaves.draftsForRecovery(mockProject.id)).toEqual([]);
+  const calls = vi.mocked(invoke).mock.calls.length;
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(
+    vi
+      .mocked(invoke)
+      .mock.calls.slice(calls)
+      .some(([cmd]) => cmd === "save_beat_prose" || cmd === "save_scene_page_prose")
+  ).toBe(false);
+});
+
+it.each(["install", "relaunch"])("shows an actionable update error when %s fails", async (step) => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  currentProject.setChapters(mockChapters);
+  const install = vi.fn().mockResolvedValue(undefined);
+  if (step === "install") install.mockRejectedValue(new Error("Installer failed"));
+  else vi.mocked(relaunch).mockRejectedValue(new Error("Relaunch failed"));
+  updateState.set({ ready: true, version: "1.2.1", body: null, update: { install } as never });
+  render(App);
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(
+    screen.getByText(
+      new RegExp(
+        `Could not restart to update.*${step === "install" ? "Installer" : "Relaunch"} failed`
+      )
+    )
+  ).toBeTruthy();
+  expect(screen.queryByText(/Retry saving your synopsis first/)).toBeNull();
+  expect((screen.getByRole("button", { name: "Restart" }) as HTMLButtonElement).disabled).toBe(
+    false
+  );
 });

--- a/src/lib/components/BeatView.svelte
+++ b/src/lib/components/BeatView.svelte
@@ -572,7 +572,7 @@
   </div>
   {#if beats.length > 0}
     <div class="space-y-4">
-      {#each beats as beat, index}
+      {#each beats as beat, index (beat.id)}
         {@const isExpanded = ui.expandedBeatId === beat.id}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <article

--- a/src/lib/components/BeatView.test.ts
+++ b/src/lib/components/BeatView.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import BeatView from "./BeatView.svelte";
+import { currentProject } from "../stores/project.svelte";
+import { ui } from "../stores/ui.svelte";
+
+vi.hoisted(() => {
+  vi.stubGlobal("localStorage", { getItem: () => null, setItem: () => {}, removeItem: () => {} });
+});
+
+afterEach(() => {
+  cleanup();
+  currentProject.setProject(null);
+  ui.setExpandedBeat(null);
+  vi.restoreAllMocks();
+});
+
+it("updates the beat title and scroll target on scene switch without needing a hover", async () => {
+  const first = {
+    id: "first-beat",
+    scene_id: "first-scene",
+    content: "First scene's beat",
+    prose: null,
+    position: 0,
+  };
+  const second = {
+    ...first,
+    id: "second-beat",
+    scene_id: "second-scene",
+    content: "Second scene's beat",
+  };
+  const view = render(BeatView, { beats: [first] });
+  await view.rerender({ beats: [second] });
+  expect(screen.queryByText(first.content)).toBeNull();
+  expect(screen.getByTestId("beat-header").textContent).toContain(second.content);
+  const row = screen.getByTestId("beat-item");
+  const scroll = vi.fn();
+  row.scrollIntoView = scroll;
+  await fireEvent.click(screen.getByTestId("beat-header"));
+  expect(scroll).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  expect(ui.expandedBeatId).toBe(second.id);
+});

--- a/src/lib/components/EditorAutosave.test.ts
+++ b/src/lib/components/EditorAutosave.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import type { Editor } from "@tiptap/core";
+import { invoke } from "@tauri-apps/api/core";
+import ScenePanel from "./ScenePanel.svelte";
+import { currentProject } from "../stores/project.svelte";
+import { ui } from "../stores/ui.svelte";
+import { mockProject, mockScenes, mockChapters } from "../../dev/mock-data";
+
+vi.hoisted(() => {
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear(),
+  });
+});
+
+const scene = { ...mockScenes[0], planning_status: "fixed" as const, editor_mode: "beat" as const };
+const destination = { ...scene, id: "destination", synopsis: "Destination synopsis" };
+const placeholder = "Write a brief synopsis for this scene...";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockResolvedValue([]);
+  currentProject.setProject(mockProject);
+  currentProject.setCurrentChapter(mockChapters[0]);
+  currentProject.setScenes([scene, destination]);
+  currentProject.setCurrentScene(scene);
+});
+
+afterEach(async () => {
+  cleanup();
+  await vi.advanceTimersByTimeAsync(2000);
+  currentProject.setProject(null);
+  ui.setExpandedBeat(null);
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function editSynopsis(text = "Updated synopsis") {
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  const textarea = screen.getByPlaceholderText(placeholder) as HTMLTextAreaElement;
+  textarea.focus();
+  await fireEvent.input(textarea, { target: { value: text } });
+  return textarea;
+}
+
+// Discord report, Quizzical, July 13–14, 2026: autosave interrupts synopsis/beat editing.
+it("keeps the synopsis open and focused through repeated autosaves", async () => {
+  render(ScenePanel);
+  const textarea = await editSynopsis();
+  textarea.setSelectionRange(4, 4);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+    sceneId: scene.id,
+    synopsis: "Updated synopsis",
+  });
+  expect(screen.queryByPlaceholderText(placeholder)).toBe(textarea);
+  expect(document.activeElement).toBe(textarea);
+  expect(textarea.selectionStart).toBe(4);
+  await fireEvent.input(textarea, { target: { value: "Updated synopsis continued" } });
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(screen.queryByPlaceholderText(placeholder)).toBe(textarea);
+  expect(currentProject.currentScene?.synopsis).toBe("Updated synopsis continued");
+});
+
+it.each([0, 1000])("saves to the original scene when navigating after %i ms", async (delay) => {
+  render(ScenePanel);
+  await vi.advanceTimersByTimeAsync(0);
+  let finish!: () => void;
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis")
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+    return [];
+  });
+  await editSynopsis();
+  await vi.advanceTimersByTimeAsync(delay);
+  currentProject.setCurrentScene(destination);
+  await tick();
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(screen.queryByPlaceholderText(placeholder)).toBeNull();
+  expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+    sceneId: scene.id,
+    synopsis: "Updated synopsis",
+  });
+  finish();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(currentProject.currentScene?.synopsis).toBe(destination.synopsis);
+  expect(currentProject.scenes.find((item) => item.id === scene.id)?.synopsis).toBe(
+    "Updated synopsis"
+  );
+});
+
+it("flushes the synopsis on Escape so reopening keeps the latest text", async () => {
+  render(ScenePanel);
+  await editSynopsis();
+  await fireEvent.keyDown(window, { key: "Escape" });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(screen.queryByPlaceholderText(placeholder)).toBeNull();
+  expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+    sceneId: scene.id,
+    synopsis: "Updated synopsis",
+  });
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  expect((screen.getByPlaceholderText(placeholder) as HTMLTextAreaElement).value).toBe(
+    "Updated synopsis"
+  );
+});
+
+it("flushes a pending synopsis when the scene panel unmounts", async () => {
+  const view = render(ScenePanel);
+  await editSynopsis();
+  view.unmount();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+    sceneId: scene.id,
+    synopsis: "Updated synopsis",
+  });
+});
+
+it("serializes synopsis saves and reopens the newest draft while an older save is pending", async () => {
+  render(ScenePanel);
+  await vi.advanceTimersByTimeAsync(0);
+  let finish!: () => void;
+  let persisted = scene.synopsis;
+  vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+    if (cmd === "save_scene_synopsis") {
+      if (!finish)
+        await new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+      persisted = (args as { synopsis: string }).synopsis;
+    }
+    return [];
+  });
+  const textarea = await editSynopsis("First draft");
+  await vi.advanceTimersByTimeAsync(1000);
+  await fireEvent.input(textarea, { target: { value: "Latest draft" } });
+  await fireEvent.keyDown(window, { key: "Escape" });
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  const reopened = screen.getByPlaceholderText(placeholder) as HTMLTextAreaElement;
+  expect(reopened.value).toBe("Latest draft");
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(
+    vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === "save_scene_synopsis")
+  ).toHaveLength(1);
+  finish();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(persisted).toBe("Latest draft");
+  expect(currentProject.currentScene?.synopsis).toBe("Latest draft");
+  expect(screen.queryByPlaceholderText(placeholder)).toBe(reopened);
+});
+
+it("keeps synopsis editing usable after a save failure", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  render(ScenePanel);
+  await vi.advanceTimersByTimeAsync(0);
+  vi.mocked(invoke).mockRejectedValueOnce("Disk full");
+  const textarea = await editSynopsis();
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(screen.queryByPlaceholderText(placeholder)).toBe(textarea);
+  expect(document.activeElement).toBe(textarea);
+  await fireEvent.input(textarea, { target: { value: "Continued after failure" } });
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(invoke).toHaveBeenLastCalledWith("save_scene_synopsis", {
+    sceneId: scene.id,
+    synopsis: "Continued after failure",
+  });
+  expect(screen.queryByText("Saving...")).toBeNull();
+});
+
+it.each([false, true])(
+  "preserves the beat cursor when autosave finishes (newer edit: %s)",
+  async (newerEdit) => {
+    const beat = {
+      id: "beat",
+      scene_id: scene.id,
+      content: "Greeting",
+      prose: "<p>First paragraph</p><p>Last paragraph</p>",
+      position: 0,
+    };
+    currentProject.setBeats([beat]);
+    const { component } = render(ScenePanel);
+    await tick();
+    ui.setExpandedBeat(beat.id);
+    await vi.advanceTimersByTimeAsync(0);
+    const element = document.querySelector(".tiptap") as HTMLElement & { editor: Editor };
+    const editor = element.editor;
+    editor.view.focus();
+    editor.commands.setTextSelection(4);
+    editor.commands.insertContent("X");
+    let finish!: () => void;
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_beat_prose" && !finish)
+        await new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+      return [];
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    if (newerEdit) editor.commands.insertContent("Y");
+    const expectedText = editor.getHTML();
+    const expectedCursor = editor.state.selection.head;
+    finish();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(editor.state.selection.head).toBe(expectedCursor);
+    expect(editor.getHTML()).toBe(expectedText);
+    expect(document.activeElement).toBe(element);
+    await component.prepareForSearch();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(editor.state.selection.head).toBe(expectedCursor);
+    expect(editor.getHTML()).toBe(expectedText);
+    expect(currentProject.beats[0].prose).toBe(expectedText);
+  }
+);

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -100,6 +100,9 @@
     };
   }
   let synopsisSaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  type SynopsisDraft = { projectId: string; sceneId: string; synopsis: string | null };
+  let pendingSynopsis: SynopsisDraft | null = null;
+  let synopsisSaveQueue: Promise<void> = Promise.resolve();
 
   // Synopsis editing state
   let editingSynopsis = $state(false);
@@ -289,6 +292,7 @@
       }
       beatViewRef?.handleEscape();
       if (editingSynopsis) {
+        flushSynopsisSave();
         editingSynopsis = false;
       }
       if (addingDiscoveryNote) {
@@ -308,34 +312,67 @@
     editingSynopsis = true;
   }
 
-  async function saveSynopsis() {
-    if (!currentProject.currentScene) return;
-    synopsisSaving = true;
+  function isCurrentSynopsis(draft: SynopsisDraft) {
+    return (
+      currentProject.value?.id === draft.projectId &&
+      currentProject.currentScene?.id === draft.sceneId
+    );
+  }
+
+  async function saveSynopsis(draft: SynopsisDraft) {
+    if (isCurrentSynopsis(draft)) synopsisSaving = true;
     try {
-      const synopsis = synopsisText.trim() || null;
       await invoke("save_scene_synopsis", {
-        sceneId: currentProject.currentScene.id,
-        synopsis,
+        sceneId: draft.sceneId,
+        synopsis: draft.synopsis,
       });
-      currentProject.updateSceneSynopsis(currentProject.currentScene.id, synopsis);
-      editingSynopsis = false;
     } catch (e) {
       console.error("Failed to save synopsis:", e);
     } finally {
-      synopsisSaving = false;
+      if (isCurrentSynopsis(draft)) synopsisSaving = false;
     }
+  }
+
+  function flushSynopsisSave() {
+    if (synopsisSaveTimeout) clearTimeout(synopsisSaveTimeout);
+    synopsisSaveTimeout = null;
+    const draft = pendingSynopsis;
+    pendingSynopsis = null;
+    // Serialize writes so a slow save cannot overwrite a newer draft on disk.
+    if (draft) synopsisSaveQueue = synopsisSaveQueue.then(() => saveSynopsis(draft));
   }
 
   function handleSynopsisInput(value: string) {
     synopsisText = value;
+    const sceneId = currentProject.currentScene?.id;
+    const projectId = currentProject.value?.id;
+    if (!sceneId || !projectId) return;
+    pendingSynopsis = { projectId, sceneId, synopsis: value.trim() || null };
+    // Keep the working copy current when closing/reopening before a save completes.
+    currentProject.updateSceneSynopsis(sceneId, pendingSynopsis.synopsis);
     // Debounce auto-save
     if (synopsisSaveTimeout) {
       clearTimeout(synopsisSaveTimeout);
     }
-    synopsisSaveTimeout = setTimeout(() => {
-      saveSynopsis();
-    }, 1000);
+    synopsisSaveTimeout = setTimeout(flushSynopsisSave, 1000);
   }
+
+  let synopsisProjectId: string | undefined;
+  let synopsisSceneId: string | undefined;
+  $effect(() => {
+    // Only navigation should close the editor; autosave updates the same scene object.
+    const projectId = currentProject.value?.id;
+    const sceneId = currentProject.currentScene?.id;
+    if (projectId === synopsisProjectId && sceneId === synopsisSceneId) return;
+    synopsisProjectId = projectId;
+    synopsisSceneId = sceneId;
+    untrack(() => {
+      flushSynopsisSave();
+      editingSynopsis = false;
+      synopsisSaving = false;
+      synopsisText = "";
+    });
+  });
 
   let lastSceneId: string | null = null;
   let completedViewport: typeof session.viewport = null;
@@ -701,6 +738,7 @@
   });
 
   onDestroy(() => {
+    flushSynopsisSave();
     beatViewRef?.flushOnSceneChange();
     if (pageProseSaveTimeout) {
       clearTimeout(pageProseSaveTimeout);

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -19,6 +19,7 @@
   import { onDestroy, onMount, untrack } from "svelte";
   import { trackScrollPosition } from "../utils/scrollPosition";
   import { session } from "../stores/session.svelte";
+  import { synopsisSaves } from "../stores/synopsisSaves.svelte";
   import { REFERENCE_TYPE_OPTIONS } from "../referenceTypes";
   import { currentProject } from "../stores/project.svelte";
   import { ui } from "../stores/ui.svelte";
@@ -99,15 +100,16 @@
       },
     };
   }
-  let synopsisSaveTimeout: ReturnType<typeof setTimeout> | null = null;
-  type SynopsisDraft = { projectId: string; sceneId: string; synopsis: string | null };
-  let pendingSynopsis: SynopsisDraft | null = null;
-  let synopsisSaveQueue: Promise<void> = Promise.resolve();
 
   // Synopsis editing state
   let editingSynopsis = $state(false);
   let synopsisText = $state("");
-  let synopsisSaving = $state(false);
+  const synopsisSave = $derived(
+    synopsisSaves.getState(currentProject.value?.id, currentProject.currentScene?.id)
+  );
+  const synopsis = $derived(
+    synopsisSave.draft ? synopsisSave.draft.synopsis : currentProject.currentScene?.synopsis
+  );
   let metadataSaving = $state(false);
   let metadataError = $state<string | null>(null);
   let sceneTagIds = $state<string[]>([]);
@@ -308,38 +310,14 @@
 
   // Synopsis functions
   function startEditingSynopsis() {
-    synopsisText = currentProject.currentScene?.synopsis || "";
+    synopsisText = synopsis || "";
     editingSynopsis = true;
   }
 
-  function isCurrentSynopsis(draft: SynopsisDraft) {
-    return (
-      currentProject.value?.id === draft.projectId &&
-      currentProject.currentScene?.id === draft.sceneId
-    );
-  }
-
-  async function saveSynopsis(draft: SynopsisDraft) {
-    if (isCurrentSynopsis(draft)) synopsisSaving = true;
-    try {
-      await invoke("save_scene_synopsis", {
-        sceneId: draft.sceneId,
-        synopsis: draft.synopsis,
-      });
-    } catch (e) {
-      console.error("Failed to save synopsis:", e);
-    } finally {
-      if (isCurrentSynopsis(draft)) synopsisSaving = false;
-    }
-  }
-
   function flushSynopsisSave() {
-    if (synopsisSaveTimeout) clearTimeout(synopsisSaveTimeout);
-    synopsisSaveTimeout = null;
-    const draft = pendingSynopsis;
-    pendingSynopsis = null;
-    // Serialize writes so a slow save cannot overwrite a newer draft on disk.
-    if (draft) synopsisSaveQueue = synopsisSaveQueue.then(() => saveSynopsis(draft));
+    if (synopsisProjectId && synopsisSceneId) {
+      void synopsisSaves.flush(synopsisProjectId, synopsisSceneId).catch(() => {});
+    }
   }
 
   function handleSynopsisInput(value: string) {
@@ -347,14 +325,7 @@
     const sceneId = currentProject.currentScene?.id;
     const projectId = currentProject.value?.id;
     if (!sceneId || !projectId) return;
-    pendingSynopsis = { projectId, sceneId, synopsis: value.trim() || null };
-    // Keep the working copy current when closing/reopening before a save completes.
-    currentProject.updateSceneSynopsis(sceneId, pendingSynopsis.synopsis);
-    // Debounce auto-save
-    if (synopsisSaveTimeout) {
-      clearTimeout(synopsisSaveTimeout);
-    }
-    synopsisSaveTimeout = setTimeout(flushSynopsisSave, 1000);
+    synopsisSaves.stage({ projectId, sceneId, synopsis: value.trim() || null });
   }
 
   let synopsisProjectId: string | undefined;
@@ -364,14 +335,13 @@
     const projectId = currentProject.value?.id;
     const sceneId = currentProject.currentScene?.id;
     if (projectId === synopsisProjectId && sceneId === synopsisSceneId) return;
-    synopsisProjectId = projectId;
-    synopsisSceneId = sceneId;
     untrack(() => {
       flushSynopsisSave();
       editingSynopsis = false;
-      synopsisSaving = false;
       synopsisText = "";
     });
+    synopsisProjectId = projectId;
+    synopsisSceneId = sceneId;
   });
 
   let lastSceneId: string | null = null;
@@ -1062,7 +1032,7 @@
             <h2 class="text-press-ui font-semibold text-press-text uppercase tracking-wide">
               Synopsis
             </h2>
-            {#if scene.synopsis && !editingSynopsis && !isLocked}
+            {#if synopsis && !editingSynopsis && !isLocked}
               <Tooltip text="Edit synopsis" position="left">
                 <button
                   onclick={startEditingSynopsis}
@@ -1082,7 +1052,7 @@
                 bind:value={synopsisText}
                 oninput={(e) => handleSynopsisInput(e.currentTarget.value)}
               ></textarea>
-              {#if synopsisSaving}
+              {#if synopsisSave.saving}
                 <div class="absolute bottom-3 right-3 flex items-center gap-1.5 text-press-muted">
                   <Loader2 class="w-3.5 h-3.5 animate-spin" />
                   <span class="text-press-eyebrow">Saving...</span>
@@ -1092,10 +1062,10 @@
             <p class="text-press-muted text-press-eyebrow mt-2">
               Press Escape to close. Changes are saved automatically.
             </p>
-          {:else if scene.synopsis}
+          {:else if synopsis}
             <div class="bg-press-surface rounded-lg p-4 border-l-2 border-press-accent">
               <p class="text-press-text font-prose italic">
-                {scene.synopsis}
+                {synopsis}
               </p>
             </div>
           {:else if !isLocked}
@@ -1113,6 +1083,19 @@
               <Lock class="w-4 h-4" />
               <span class="text-press-ui">Scene is locked</span>
             </div>
+          {/if}
+          {#if synopsisSave.error}
+            <div role="alert" class="mt-2 text-press-ui text-press-error">
+              <p>Synopsis not saved: {synopsisSave.error}. Your draft is kept for retry.</p>
+              <button
+                onclick={flushSynopsisSave}
+                disabled={synopsisSave.saving}
+                class="underline mt-1 disabled:opacity-50"
+                aria-label="Retry synopsis save">Retry saving</button
+              >
+            </div>
+          {:else if synopsisSave.draft && !synopsisSave.saving}
+            <p role="status" class="mt-2 text-press-eyebrow text-press-muted">Unsaved changes</p>
           {/if}
         </section>
 

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -618,6 +618,23 @@
     pageProseSaveStatus = "idle";
   }
 
+  // Called atomically with queue discard when the user approves quitting without saving.
+  export function discardProseDraftsForClose(drafts: ProseSave[]) {
+    beatViewRef?.discardFailedDrafts(drafts);
+    if (
+      drafts.some(
+        (draft) =>
+          draft.kind === "page" &&
+          draft.projectId === pageProseProjectId &&
+          draft.id === lastPageViewSceneId &&
+          draft.prose === pageProseContent
+      )
+    ) {
+      if (pageProseSaveTimeout) clearTimeout(pageProseSaveTimeout);
+      pageProseSaveTimeout = null;
+    }
+  }
+
   export async function discardFailedSaves(drafts: ProseSave[]) {
     const projectId = currentProject.value?.id;
     const scene = currentProject.currentScene;

--- a/src/lib/components/SynopsisAutosave.test.ts
+++ b/src/lib/components/SynopsisAutosave.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
-import type { Editor } from "@tiptap/core";
 import { invoke } from "@tauri-apps/api/core";
 import ScenePanel from "./ScenePanel.svelte";
 import { currentProject } from "../stores/project.svelte";
+import { synopsisSaves } from "../stores/synopsisSaves.svelte";
 import { ui } from "../stores/ui.svelte";
 import { mockProject, mockScenes, mockChapters } from "../../dev/mock-data";
 
@@ -34,6 +34,8 @@ beforeEach(() => {
 
 afterEach(async () => {
   cleanup();
+  vi.mocked(invoke).mockResolvedValue([]);
+  await synopsisSaves.flush();
   await vi.advanceTimersByTimeAsync(2000);
   currentProject.setProject(null);
   ui.setExpandedBeat(null);
@@ -49,7 +51,7 @@ async function editSynopsis(text = "Updated synopsis") {
   return textarea;
 }
 
-// Discord report, Quizzical, July 13–14, 2026: autosave interrupts synopsis/beat editing.
+// Discord report, Quizzical, July 13–14, 2026: autosave closes synopsis editing.
 it("keeps the synopsis open and focused through repeated autosaves", async () => {
   render(ScenePanel);
   const textarea = await editSynopsis();
@@ -175,47 +177,54 @@ it("keeps synopsis editing usable after a save failure", async () => {
   expect(screen.queryByText("Saving...")).toBeNull();
 });
 
-it.each([false, true])(
-  "preserves the beat cursor when autosave finishes (newer edit: %s)",
-  async (newerEdit) => {
-    const beat = {
-      id: "beat",
-      scene_id: scene.id,
-      content: "Greeting",
-      prose: "<p>First paragraph</p><p>Last paragraph</p>",
-      position: 0,
-    };
-    currentProject.setBeats([beat]);
-    const { component } = render(ScenePanel);
-    await tick();
-    ui.setExpandedBeat(beat.id);
+it.each(["database is locked", "disk full", "Cannot edit a locked scene"])(
+  "retains a failed synopsis and offers an explicit retry after %s",
+  async (failure) => {
+    render(ScenePanel);
     await vi.advanceTimersByTimeAsync(0);
-    const element = document.querySelector(".tiptap") as HTMLElement & { editor: Editor };
-    const editor = element.editor;
-    editor.view.focus();
-    editor.commands.setTextSelection(4);
-    editor.commands.insertContent("X");
-    let finish!: () => void;
     vi.mocked(invoke).mockImplementation(async (cmd) => {
-      if (cmd === "save_beat_prose" && !finish)
-        await new Promise<void>((resolve) => {
-          finish = resolve;
-        });
+      if (cmd === "save_scene_synopsis") throw failure;
       return [];
     });
-    await vi.advanceTimersByTimeAsync(500);
-    if (newerEdit) editor.commands.insertContent("Y");
-    const expectedText = editor.getHTML();
-    const expectedCursor = editor.state.selection.head;
-    finish();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(editor.state.selection.head).toBe(expectedCursor);
-    expect(editor.getHTML()).toBe(expectedText);
-    expect(document.activeElement).toBe(element);
-    await component.prepareForSearch();
+    const textarea = await editSynopsis("Recover this draft");
     await vi.advanceTimersByTimeAsync(1000);
-    expect(editor.state.selection.head).toBe(expectedCursor);
-    expect(editor.getHTML()).toBe(expectedText);
-    expect(currentProject.beats[0].prose).toBe(expectedText);
+    expect(screen.getByRole("alert").textContent).toContain("not saved");
+    expect(screen.getByRole("alert").textContent).toContain(failure);
+    expect(document.activeElement).toBe(textarea);
+    expect(currentProject.currentScene?.synopsis).toBe(scene.synopsis);
+    vi.mocked(invoke).mockResolvedValue([]);
+    await fireEvent.click(screen.getByRole("button", { name: "Retry synopsis save" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(currentProject.currentScene?.synopsis).toBe("Recover this draft");
+    expect(screen.getByPlaceholderText(placeholder)).toBe(textarea);
   }
 );
+
+it("recovers a failed synopsis after leaving the project and remounting the scene panel", async () => {
+  const view = render(ScenePanel);
+  await vi.advanceTimersByTimeAsync(0);
+  vi.mocked(invoke).mockImplementation(async (cmd) => {
+    if (cmd === "save_scene_synopsis") throw "disk full";
+    return [];
+  });
+  await editSynopsis("Still recoverable");
+  await vi.advanceTimersByTimeAsync(1000);
+  view.unmount();
+  currentProject.setProject(null);
+  await vi.advanceTimersByTimeAsync(0);
+  currentProject.setProject(mockProject);
+  currentProject.setCurrentChapter(mockChapters[0]);
+  currentProject.setScenes([scene]);
+  currentProject.setCurrentScene(scene);
+  render(ScenePanel);
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+  expect((screen.getByPlaceholderText(placeholder) as HTMLTextAreaElement).value).toBe(
+    "Still recoverable"
+  );
+  vi.mocked(invoke).mockResolvedValue([]);
+  await fireEvent.click(screen.getByRole("button", { name: "Retry synopsis save" }));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(currentProject.currentScene?.synopsis).toBe("Still recoverable");
+});

--- a/src/lib/components/UpdateBanner.svelte
+++ b/src/lib/components/UpdateBanner.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { updateState, installAndRelaunch, dismissUpdate, type UpdateState } from "../updater";
   import { X } from "lucide-svelte";
+  import { ui } from "../stores/ui.svelte";
+
+  let {
+    disabled = false,
+    restarting = $bindable(false),
+  }: { disabled?: boolean; restarting?: boolean } = $props();
 
   let state = $state<UpdateState | null>(null);
 
@@ -10,6 +16,20 @@
     });
     return unsub;
   });
+
+  async function restart() {
+    if (!state || disabled || restarting) return;
+    restarting = true;
+    try {
+      await installAndRelaunch(state);
+    } catch (error) {
+      ui.showError(
+        `Could not restart to update: ${String(error)}. Retry saving your synopsis first.`
+      );
+    } finally {
+      restarting = false;
+    }
+  }
 </script>
 
 {#if state}
@@ -21,14 +41,16 @@
     </span>
     <div class="flex items-center gap-2">
       <button
-        onclick={() => state && installAndRelaunch(state)}
-        class="rounded px-3 py-1 font-medium border border-press-on-accent hover:bg-press-accent-text transition-colors"
+        onclick={restart}
+        disabled={disabled || restarting}
+        class="rounded px-3 py-1 font-medium border border-press-on-accent hover:bg-press-accent-text transition-colors disabled:bg-press-disabled-bg disabled:text-press-disabled-text disabled:border-press-disabled-border"
       >
         Restart
       </button>
       <button
         onclick={dismissUpdate}
-        class="p-1 rounded hover:bg-press-accent-text transition-colors"
+        disabled={disabled || restarting}
+        class="p-1 rounded hover:bg-press-accent-text transition-colors disabled:bg-press-disabled-bg disabled:text-press-disabled-text"
         aria-label="Dismiss"
       >
         <X class="w-4 h-4" />

--- a/src/lib/components/UpdateBanner.svelte
+++ b/src/lib/components/UpdateBanner.svelte
@@ -6,7 +6,8 @@
   let {
     disabled = false,
     restarting = $bindable(false),
-  }: { disabled?: boolean; restarting?: boolean } = $props();
+    prepare,
+  }: { disabled?: boolean; restarting?: boolean; prepare?: () => Promise<void> } = $props();
 
   let state = $state<UpdateState | null>(null);
 
@@ -21,11 +22,10 @@
     if (!state || disabled || restarting) return;
     restarting = true;
     try {
+      await prepare?.();
       await installAndRelaunch(state);
     } catch (error) {
-      ui.showError(
-        `Could not restart to update: ${String(error)}. Retry saving your synopsis first.`
-      );
+      ui.showError(`Could not restart to update: ${String(error)}`);
     } finally {
       restarting = false;
     }

--- a/src/lib/stores/project.svelte.test.ts
+++ b/src/lib/stores/project.svelte.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { currentProject } from "./project.svelte";
+import { mockScenes } from "../../dev/mock-data";
 import type {
   Chapter,
   EditorMode,
@@ -417,6 +418,23 @@ describe("currentProject store", () => {
     currentProject.setCurrentScene(null);
 
     expect(currentProject.currentScene).toBeNull();
+    expect(currentProject.beats).toEqual([]);
+  });
+
+  it("clears the previous scene's beats while the next scene is loading", () => {
+    const scene = mockScenes[0];
+    const beat = {
+      id: "old-beat",
+      scene_id: scene.id,
+      content: "Old title",
+      prose: null,
+      position: 0,
+    };
+    currentProject.setCurrentScene(scene);
+    currentProject.setBeats([beat]);
+    currentProject.setCurrentScene({ ...scene, title: "Renamed scene" });
+    expect(currentProject.beats).toEqual([beat]);
+    currentProject.setCurrentScene({ ...scene, id: "next-scene" });
     expect(currentProject.beats).toEqual([]);
   });
 

--- a/src/lib/stores/project.svelte.ts
+++ b/src/lib/stores/project.svelte.ts
@@ -118,10 +118,10 @@ class ProjectStore {
 
   setCurrentScene(scene: Scene | null) {
     if (scene) session.selectScene(scene);
-    this.currentScene = scene;
-    if (!scene) {
+    if (!scene || this.currentScene?.id !== scene.id) {
       this.beats = [];
     }
+    this.currentScene = scene;
   }
 
   setBeats(beats: Beat[]) {

--- a/src/lib/stores/synopsisSaves.svelte.test.ts
+++ b/src/lib/stores/synopsisSaves.svelte.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { SynopsisSaveQueue } from "./synopsisSaves.svelte";
+
+const draft = { projectId: "project", sceneId: "scene", synopsis: "Draft" };
+let saves: SynopsisSaveQueue;
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  saves = new SynopsisSaveQueue();
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+it.each(["database is locked", "disk full", "Cannot edit a locked scene"])(
+  "retains %s failures and retries without further typing",
+  async (error) => {
+    vi.mocked(invoke).mockRejectedValue(error);
+    saves.stage(draft);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(saves.getState(draft.projectId, draft.sceneId)).toEqual({ draft, error, saving: false });
+    await expect(saves.flush()).rejects.toThrow(error);
+    expect(saves.failedCount).toBe(1);
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    await saves.flush();
+    expect(saves.getState(draft.projectId, draft.sceneId).draft).toBeUndefined();
+    expect(saves.failedCount).toBe(0);
+  }
+);
+
+it.each([false, true])(
+  "drains newer edits made during a save (older save fails: %s)",
+  async (rejectOld) => {
+    let finish!: () => void;
+    vi.mocked(invoke).mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      if (rejectOld) throw "disk full";
+    });
+    saves.stage(draft);
+    const writing = saves.flush();
+    await vi.advanceTimersByTimeAsync(0);
+    saves.stage({ ...draft, synopsis: "Newer draft" });
+    const closing = saves.flush();
+    finish();
+    await Promise.all([writing, closing]);
+    expect(invoke).toHaveBeenLastCalledWith("save_scene_synopsis", {
+      sceneId: draft.sceneId,
+      synopsis: "Newer draft",
+    });
+    expect(saves.getState(draft.projectId, draft.sceneId).draft).toBeUndefined();
+    expect(saves.failedCount).toBe(0);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(invoke).toHaveBeenCalledTimes(2);
+  }
+);
+
+it("retains an old project's failure without blocking another project's save", async () => {
+  const other = { ...draft, projectId: "other-project", sceneId: "other-scene" };
+  vi.mocked(invoke).mockImplementation(async (_cmd, args) => {
+    if ((args as { sceneId: string }).sceneId === draft.sceneId) throw "locked scene";
+  });
+  saves.stage(draft);
+  saves.stage(other);
+  await expect(saves.flush()).rejects.toThrow("locked scene");
+  expect(saves.getState(other.projectId, other.sceneId).draft).toBeUndefined();
+  expect(saves.getState(draft.projectId, draft.sceneId).draft).toEqual(draft);
+  await expect(saves.flush(other.projectId, other.sceneId)).resolves.toBeUndefined();
+});
+
+it("keeps clearing a synopsis as a recoverable null draft", async () => {
+  vi.mocked(invoke).mockRejectedValueOnce(new Error("database is locked"));
+  saves.stage({ ...draft, synopsis: null });
+  await expect(saves.flush()).rejects.toThrow("database is locked");
+  expect(saves.getState(draft.projectId, draft.sceneId).draft?.synopsis).toBeNull();
+  await saves.flush();
+  expect(invoke).toHaveBeenLastCalledWith("save_scene_synopsis", {
+    sceneId: draft.sceneId,
+    synopsis: null,
+  });
+});

--- a/src/lib/stores/synopsisSaves.svelte.test.ts
+++ b/src/lib/stores/synopsisSaves.svelte.test.ts
@@ -84,3 +84,83 @@ it("keeps clearing a synopsis as a recoverable null draft", async () => {
     synopsis: null,
   });
 });
+
+it("keeps a save error visible through continued typing until the newest draft is saved", async () => {
+  vi.mocked(invoke).mockRejectedValue("disk full");
+  saves.stage(draft);
+  await vi.advanceTimersByTimeAsync(1000);
+  for (const synopsis of ["Still", "Still typing", "Still typing more"]) {
+    saves.stage({ ...draft, synopsis });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saves.failedCount).toBe(1);
+    expect(saves.getState(draft.projectId, draft.sceneId).error).toBe("disk full");
+  }
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  await saves.flush();
+  expect(saves.failedCount).toBe(0);
+  expect(invoke).toHaveBeenLastCalledWith("save_scene_synopsis", {
+    sceneId: draft.sceneId,
+    synopsis: "Still typing more",
+  });
+});
+
+it.each(["Query returned no rows", new Error("Query returned no rows")])(
+  "retires a deleted scene's draft after the backend returns %s",
+  async (error) => {
+    vi.mocked(invoke).mockRejectedValue(error);
+    saves.stage(draft);
+    await expect(saves.flush()).resolves.toBeUndefined();
+    expect(saves.getState(draft.projectId, draft.sceneId).draft).toBeUndefined();
+    expect(saves.failedCount).toBe(0);
+    await saves.flush();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  }
+);
+
+it("rejects stale discard approval without losing newer edits, then cancels their debounce on approval", async () => {
+  vi.mocked(invoke).mockRejectedValue("Cannot edit a locked scene");
+  saves.stage(draft);
+  await expect(saves.flush()).rejects.toThrow("Cannot edit a locked scene");
+  const approved = saves.snapshot();
+  const newer = { ...draft, synopsis: "Newer unsaved changes" };
+  saves.stage(newer);
+  await expect(saves.discardAll(approved)).rejects.toThrow("Synopsis drafts changed");
+  expect(saves.getState(draft.projectId, draft.sceneId).draft).toBe(newer);
+  expect(saves.failedCount).toBe(1);
+  await saves.discardAll(saves.snapshot());
+  expect(saves.snapshot()).toEqual([]);
+  expect(saves.failedCount).toBe(0);
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(invoke).toHaveBeenCalledTimes(1);
+});
+
+it("waits for an in-flight write before discarding and never resubmits the discarded draft", async () => {
+  let finish!: () => void;
+  vi.mocked(invoke).mockImplementationOnce(async () => {
+    await new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    throw "disk full";
+  });
+  saves.stage(draft);
+  const writing = saves.flush().catch(() => {});
+  await vi.advanceTimersByTimeAsync(0);
+  let discarded = false;
+  const discarding = saves.discardAll(saves.snapshot()).then(() => {
+    discarded = true;
+  });
+  try {
+    await vi.advanceTimersByTimeAsync(0);
+    expect(discarded).toBe(false);
+  } finally {
+    finish();
+  }
+  await Promise.all([writing, discarding]);
+  expect(discarded).toBe(true);
+  expect(saves.snapshot()).toEqual([]);
+  expect(saves.failedCount).toBe(0);
+  await saves.flush();
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(invoke).toHaveBeenCalledTimes(1);
+});

--- a/src/lib/stores/synopsisSaves.svelte.ts
+++ b/src/lib/stores/synopsisSaves.svelte.ts
@@ -4,7 +4,7 @@ import { currentProject } from "./project.svelte";
 
 export type SynopsisDraft = { projectId: string; sceneId: string; synopsis: string | null };
 
-/** Drafts outlive scene panels. Only successful writes retire them. */
+/** Drafts outlive scene panels until saved, explicitly discarded, or their scene is deleted. */
 export class SynopsisSaveQueue {
   private drafts = new SvelteMap<string, SynopsisDraft>();
   private errors = new SvelteMap<string, string>();
@@ -32,7 +32,6 @@ export class SynopsisSaveQueue {
   stage(draft: SynopsisDraft) {
     const key = this.key(draft.projectId, draft.sceneId);
     this.drafts.set(key, draft);
-    this.errors.delete(key);
     this.clearTimer(key);
     this.timers.set(
       key,
@@ -47,6 +46,29 @@ export class SynopsisSaveQueue {
     const timer = this.timers.get(key);
     if (timer) clearTimeout(timer);
     this.timers.delete(key);
+  }
+
+  snapshot(): SynopsisDraft[] {
+    return [...this.drafts.values()];
+  }
+
+  /** Discard only the work the user approved, after outstanding writes have settled. */
+  discardAll(expected: SynopsisDraft[]): Promise<void> {
+    const discarding = this.queue.then(() => {
+      const approved = new SvelteSet(expected);
+      if ([...this.drafts.values()].some((draft) => !approved.has(draft))) {
+        throw new Error("Synopsis drafts changed. Review the latest changes before discarding.");
+      }
+      for (const key of this.drafts.keys()) this.retire(key);
+    });
+    this.queue = discarding.catch(() => {});
+    return discarding;
+  }
+
+  private retire(key: string) {
+    this.clearTimer(key);
+    this.drafts.delete(key);
+    this.errors.delete(key);
   }
 
   /** Drain the latest edits, including edits made during a write; retry failures once per call. */
@@ -70,12 +92,15 @@ export class SynopsisSaveQueue {
             currentProject.updateSceneSynopsis(draft.sceneId, draft.synopsis);
           }
           if (this.drafts.get(key) === draft) {
-            this.drafts.delete(key);
-            this.errors.delete(key);
+            this.retire(key);
           }
         } catch (error) {
           if (this.drafts.get(key) === draft) {
-            this.errors.set(key, error instanceof Error ? error.message : String(error));
+            const message = error instanceof Error ? error.message : String(error);
+            // save_scene_synopsis's lock lookup returns this exact SQLite error for
+            // a deleted scene (or parent chapter). There is no longer a target to save.
+            if (message === "Query returned no rows") this.retire(key);
+            else this.errors.set(key, message);
           }
         } finally {
           this.saving.delete(key);

--- a/src/lib/stores/synopsisSaves.svelte.ts
+++ b/src/lib/stores/synopsisSaves.svelte.ts
@@ -1,0 +1,96 @@
+import { invoke } from "@tauri-apps/api/core";
+import { SvelteMap, SvelteSet } from "svelte/reactivity";
+import { currentProject } from "./project.svelte";
+
+export type SynopsisDraft = { projectId: string; sceneId: string; synopsis: string | null };
+
+/** Drafts outlive scene panels. Only successful writes retire them. */
+export class SynopsisSaveQueue {
+  private drafts = new SvelteMap<string, SynopsisDraft>();
+  private errors = new SvelteMap<string, string>();
+  private saving = new SvelteSet<string>();
+  private timers = new SvelteMap<string, ReturnType<typeof setTimeout>>();
+  private queue: Promise<void> = Promise.resolve();
+
+  private key(projectId: string, sceneId: string) {
+    return JSON.stringify([projectId, sceneId]);
+  }
+
+  get failedCount() {
+    return this.errors.size;
+  }
+
+  getState(projectId: string | undefined, sceneId: string | undefined) {
+    const key = this.key(projectId ?? "", sceneId ?? "");
+    return {
+      draft: this.drafts.get(key),
+      error: this.errors.get(key),
+      saving: this.saving.has(key),
+    };
+  }
+
+  stage(draft: SynopsisDraft) {
+    const key = this.key(draft.projectId, draft.sceneId);
+    this.drafts.set(key, draft);
+    this.errors.delete(key);
+    this.clearTimer(key);
+    this.timers.set(
+      key,
+      setTimeout(() => {
+        // Errors remain visible and retryable; never discard a rejected draft.
+        void this.flush(draft.projectId, draft.sceneId).catch(() => {});
+      }, 1000)
+    );
+  }
+
+  private clearTimer(key: string) {
+    const timer = this.timers.get(key);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(key);
+  }
+
+  /** Drain the latest edits, including edits made during a write; retry failures once per call. */
+  flush(projectId?: string, sceneId?: string): Promise<void> {
+    const matches = (draft: SynopsisDraft) =>
+      (projectId === undefined || draft.projectId === projectId) &&
+      (sceneId === undefined || draft.sceneId === sceneId);
+    const writing = this.queue.then(async () => {
+      const attempted = new SvelteSet<SynopsisDraft>();
+      let next: [string, SynopsisDraft] | undefined;
+      while (
+        (next = [...this.drafts].find(([, draft]) => matches(draft) && !attempted.has(draft)))
+      ) {
+        const [key, draft] = next;
+        attempted.add(draft);
+        this.clearTimer(key);
+        this.saving.add(key);
+        try {
+          await invoke("save_scene_synopsis", { sceneId: draft.sceneId, synopsis: draft.synopsis });
+          if (currentProject.value?.id === draft.projectId) {
+            currentProject.updateSceneSynopsis(draft.sceneId, draft.synopsis);
+          }
+          if (this.drafts.get(key) === draft) {
+            this.drafts.delete(key);
+            this.errors.delete(key);
+          }
+        } catch (error) {
+          if (this.drafts.get(key) === draft) {
+            this.errors.set(key, error instanceof Error ? error.message : String(error));
+          }
+        } finally {
+          this.saving.delete(key);
+        }
+      }
+      const failures = [...this.drafts].filter(([, draft]) => matches(draft));
+      if (failures.length) {
+        throw new Error(
+          `Synopsis not saved: ${failures.map(([key]) => this.errors.get(key)).join("; ")}`
+        );
+      }
+    });
+    this.queue = writing.catch(() => {});
+    return writing;
+  }
+}
+
+export const synopsisSaves = new SynopsisSaveQueue();

--- a/src/lib/stores/synopsisSaves.svelte.ts
+++ b/src/lib/stores/synopsisSaves.svelte.ts
@@ -99,6 +99,8 @@ export class SynopsisSaveQueue {
             const message = error instanceof Error ? error.message : String(error);
             // save_scene_synopsis's lock lookup returns this exact SQLite error for
             // a deleted scene (or parent chapter). There is no longer a target to save.
+            // This depends on rusqlite's display text; use a typed IPC error when
+            // next changing the Rust command's error contract.
             if (message === "Query returned no rows") this.retire(key);
             else this.errors.set(key, message);
           }

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -190,14 +190,14 @@ describe("updater", () => {
           if (installFails) throw installError;
         });
 
-        await expect(
-          installAndRelaunch({
-            ready: true,
-            version: "1.2.0",
-            body: null,
-            update: { install } as never,
-          })
-        ).resolves.toBeUndefined();
+        const installing = installAndRelaunch({
+          ready: true,
+          version: "1.2.0",
+          body: null,
+          update: { install } as never,
+        });
+        if (installFails) await expect(installing).rejects.toBe(installError);
+        else await expect(installing).resolves.toBeUndefined();
 
         expect(install).toHaveBeenCalledOnce();
         if (installFails) {
@@ -245,12 +245,14 @@ describe("updater", () => {
         expect(flushed).toHaveBeenCalledOnce();
         throw new Error("install failed");
       });
-      await installAndRelaunch({
-        ready: true,
-        version: "1.2.0",
-        body: null,
-        update: { install } as never,
-      });
+      await expect(
+        installAndRelaunch({
+          ready: true,
+          version: "1.2.0",
+          body: null,
+          update: { install } as never,
+        })
+      ).rejects.toThrow("install failed");
       expect(install).toHaveBeenCalledOnce();
       expect(relaunchMock).not.toHaveBeenCalled();
     });
@@ -284,7 +286,7 @@ describe("updater", () => {
       expect(relaunchMock).not.toHaveBeenCalled();
     });
 
-    it("handles install failure gracefully", async () => {
+    it("propagates install failure to the banner", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const mockUpdate = {
         install: vi.fn().mockRejectedValue(new Error("Install failed")),
@@ -296,7 +298,7 @@ describe("updater", () => {
         update: mockUpdate as never,
       };
 
-      await installAndRelaunch(state);
+      await expect(installAndRelaunch(state)).rejects.toThrow("Install failed");
 
       expect(errorSpy).toHaveBeenCalledWith("Failed to install update:", expect.any(Error));
       errorSpy.mockRestore();

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { get } from "svelte/store";
+import { invoke } from "@tauri-apps/api/core";
+import { synopsisSaves } from "./stores/synopsisSaves.svelte";
 import { session } from "./stores/session.svelte";
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
@@ -19,9 +21,15 @@ const checkMock = vi.mocked(check);
 const relaunchMock = vi.mocked(relaunch);
 
 describe("updater", () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    await synopsisSaves.flush();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(invoke).mockResolvedValue(undefined);
     updateState.set(null);
   });
 
@@ -108,6 +116,64 @@ describe("updater", () => {
   });
 
   describe("installAndRelaunch", () => {
+    it("saves a debounced synopsis before entering the installer", async () => {
+      vi.useFakeTimers();
+      synopsisSaves.stage({
+        projectId: "project",
+        sceneId: "scene",
+        synopsis: "Last synopsis edit",
+      });
+      let finish!: () => void;
+      vi.mocked(invoke).mockImplementation(async (cmd) => {
+        if (cmd === "save_scene_synopsis")
+          await new Promise<void>((resolve) => {
+            finish = resolve;
+          });
+      });
+      const install = vi.fn().mockResolvedValue(undefined);
+      const installing = installAndRelaunch({
+        ready: true,
+        version: "1.2.0",
+        body: null,
+        update: { install } as never,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      try {
+        expect(invoke).toHaveBeenCalledWith("save_scene_synopsis", {
+          sceneId: "scene",
+          synopsis: "Last synopsis edit",
+        });
+        expect(install).not.toHaveBeenCalled();
+        expect(relaunchMock).not.toHaveBeenCalled();
+      } finally {
+        finish?.();
+      }
+      await installing;
+      expect(install).toHaveBeenCalledOnce();
+      expect(relaunchMock).toHaveBeenCalledOnce();
+    });
+
+    it.each([false, true])(
+      "blocks installation until a failed synopsis can be saved (already retained: %s)",
+      async (retained) => {
+        vi.useFakeTimers();
+        const draft = { projectId: "project", sceneId: "scene", synopsis: "Do not lose this" };
+        synopsisSaves.stage(draft);
+        vi.mocked(invoke).mockRejectedValue("disk full");
+        if (retained) await expect(synopsisSaves.flush()).rejects.toThrow("disk full");
+        const install = vi.fn().mockResolvedValue(undefined);
+        const state = { ready: true, version: "1.2.0", body: null, update: { install } as never };
+        await expect(installAndRelaunch(state)).rejects.toThrow("disk full");
+        expect(install).not.toHaveBeenCalled();
+        expect(relaunchMock).not.toHaveBeenCalled();
+        expect(synopsisSaves.getState("project", "scene").draft).toEqual(draft);
+        vi.mocked(invoke).mockResolvedValue(undefined);
+        await installAndRelaunch(state);
+        expect(install).toHaveBeenCalledOnce();
+        expect(relaunchMock).toHaveBeenCalledOnce();
+      }
+    );
+
     it.each([false, true])(
       "continues update installation after a failed position flush (installer fails: %s)",
       async (installFails) => {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -7,6 +7,7 @@ import { writable } from "svelte/store";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { session } from "./stores/session.svelte";
+import { synopsisSaves } from "./stores/synopsisSaves.svelte";
 
 export interface UpdateState {
   /** Update is downloaded and ready to install */
@@ -42,6 +43,9 @@ export async function checkForUpdate(): Promise<void> {
 
 export async function installAndRelaunch(state: UpdateState): Promise<void> {
   if (!state.update) return;
+  // Unlike position metadata, unsaved writing must block installation on failure.
+  // Let the banner report the error and keep the downloaded update available for retry.
+  await synopsisSaves.flush();
   try {
     // On Windows install can exit the process before its promise resolves.
     await session.flush();

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -57,6 +57,7 @@ export async function installAndRelaunch(state: UpdateState): Promise<void> {
     await relaunch();
   } catch (e) {
     console.error("Failed to install update:", e);
+    throw e;
   }
 }
 

--- a/src/lib/utils/proseSaves.test.ts
+++ b/src/lib/utils/proseSaves.test.ts
@@ -22,6 +22,21 @@ it("retains failed saves for retry, isolates projects, and recovers after failur
   await queue.flush("project");
   expect(invoke).toHaveBeenCalledTimes(count);
 });
+it("flushes drafts across projects on exit and retains terminal failures for confirmation", async () => {
+  const queue = new ProseSaveQueue();
+  const page = { ...save, projectId: "other", kind: "page" as const, id: "scene" };
+  const locked = { ...save, projectId: "third", id: "locked" };
+  vi.mocked(invoke).mockRejectedValue("Disk full");
+  await expect(queue.save(save)).rejects.toBe("Disk full");
+  await expect(queue.save(page)).rejects.toBe("Disk full");
+  vi.mocked(invoke).mockRejectedValue("Cannot edit a locked scene");
+  await expect(queue.save(locked)).rejects.toBe("Cannot edit a locked scene");
+  expect(queue.draftsForRecovery()).toEqual(expect.arrayContaining([save, page, locked]));
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  expect(await queue.flush()).toEqual([save, page]);
+  expect(queue.pendingFor()).toEqual([]);
+  expect(queue.draftsForRecovery()).toEqual([locked]);
+});
 it("serializes writes and retains the newest failed draft when an earlier write succeeds", async () => {
   const queue = new ProseSaveQueue();
   let finish!: () => void;

--- a/src/lib/utils/proseSaves.ts
+++ b/src/lib/utils/proseSaves.ts
@@ -49,14 +49,16 @@ export class ProseSaveQueue {
     return writing;
   }
 
-  pendingFor(projectId: string): ProseSave[] {
-    return [...this.pending.values()].filter((save) => save.projectId === projectId);
+  pendingFor(projectId?: string): ProseSave[] {
+    return [...this.pending.values()].filter(
+      (save) => projectId === undefined || save.projectId === projectId
+    );
   }
 
-  draftsForRecovery(projectId: string): ProseSave[] {
+  draftsForRecovery(projectId?: string): ProseSave[] {
     return [...this.recovery.values()]
       .map((entry) => entry.draft)
-      .filter((save) => save.projectId === projectId)
+      .filter((save) => projectId === undefined || save.projectId === projectId)
       .concat(this.pendingFor(projectId));
   }
 
@@ -93,7 +95,7 @@ export class ProseSaveQueue {
     onDiscarded?.();
   }
 
-  async flush(projectId: string, onSaved?: (save: ProseSave) => void): Promise<ProseSave[]> {
+  async flush(projectId?: string, onSaved?: (save: ProseSave) => void): Promise<ProseSave[]> {
     await this.queue;
     const saved: ProseSave[] = [];
     const errors: string[] = [];


### PR DESCRIPTION
## Summary

Autosaving a synopsis could close its editor while the writer was typing, and switching scenes could leave a stale beat title until hover. Keep synopsis editing active across saves and key beat rows by ID so each scene renders the correct beat content.

Retain failed synopsis drafts with visible errors and retry. Before menu quit, window close, or update restart, submit debounced beat/page prose and save queued drafts. Failed quit saves offer an explicit discard choice; discard still saves the writing position. Update installation and relaunch errors now appear in the banner's error handler.

## Related Issues

Reported in Discord on Windows 11. Deferred review follow-ups: #272 (global keyboard shortcuts during close/update) and #273 (focus/caret restoration after a failed update save).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed (no public API or setup changes)
- [x] I have added relevant labels to this PR

## Testing Instructions

1. Type in a synopsis across multiple autosaves; verify the editor stays open and the caret stays in place. Switch scenes and verify beat titles update immediately.
2. Type beat or page prose, then immediately quit or close the window. Reopen and verify the final words persisted. Repeat with a debounced synopsis.
3. Simulate a failed write and verify drafts remain available, the save error survives further typing, and quit offers Keep editing or Quit and discard. Confirming discard must allow exit while saving the writing position.
4. With an update ready, type and immediately restart. Verify saves finish before installation; a failed save blocks restart, and install/relaunch failures show their error. Restart must be disabled during quit confirmation.

## Validation

- 358 frontend tests pass with coverage: 99.68% statements, 97.05% branches, 99.53% functions, 99.82% lines.
- 407 Rust tests pass with all features.
- `npm run check:all` and `npm run build` pass, including Rust Clippy with all targets/features.
- Normal pre-push hooks pass without bypass.
- GitHub CI passes: Frontend, Rust, commit validation, and native Linux E2E (45 passed, 3 skipped; all 7 spec files pass).
- New exit regression tests exercise the real Svelte/TipTap editors with mocked Tauri IPC; the 12 latest behavior tests failed before the final fix and pass afterward. Windows quit and native update installation have not been manually exercised.

## Additional Notes

The final review fixes are limited to prose flushing and visible update errors. Keyboard handling and focus restoration are tracked separately in #272 and #273.
