### PR TITLE
feat(editor): add scene revisions and editorial review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ trusting it.
 ## The IPC boundary (Rust ↔ TypeScript)
 
 Rust and TypeScript are maintained independently and **nothing checks their
-agreement at build time**. Currently 135 `#[tauri::command]` functions, 135
+agreement at build time**. Currently 138 `#[tauri::command]` functions, 138
 registered. Three things must line
 up for every command:
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ View prose and exclude archived content and outline prompts.
 Set a **Daily writing goal** in **Project Settings** (default: 500 words; 0 turns the
 goal off). Daily and session totals measure net words added by saved edits, including
 Find and Replace; deleting words reduces these totals, which can be negative.
-Imports, duplication and reorganization do not earn writing credit.
+Imports, duplication, reorganization, draft restoration and accepted editorial suggestions do not earn or remove writing credit. If you restore an earlier draft and write the text again, those new saved edits count as new writing activity.
 
 Daily totals use your computer's local calendar day and persist across app restarts.
 Your streak counts consecutive days meeting their goals; an unfinished today keeps
@@ -238,3 +238,11 @@ Your sponsorship helps keep Kindling free and open source.
 <p align="center">
   Made with ☕ for writers who plan before they write.
 </p>
+
+### Scene revisions and editorial review
+
+Open **Revisions** above a scene to review its prose without changing the manuscript as you annotate it. In **Draft history**, save a named draft (Draft 1, Draft 2, and so on), compare any two saved drafts or a draft with current prose, or restore a draft. Restoring and accepting suggestions automatically preserve the current prose as another draft. Drafts retain page prose, beat prose, and the editing mode; restoring requires the same beat structure. Comparison shows text changes; saved drafts retain formatting. Large, heavily changed scenes may show a single replacement for the changed passage to keep comparison responsive.
+
+In **Editorial review**, select text to add a comment or suggest a replacement/deletion, or place the cursor to propose an insertion. Enter your name to identify comments, reply to threads, and resolve or reopen them. Review insertions underlined in color and deletions struck through. Use **Previous change** / **Next change** to step through suggestions, then accept or reject one or all. Overlapping suggestions must be handled individually. When prose changes outside review, affected annotations are marked outdated: select their intended text and choose **Re-anchor to selection** before accepting them. No suggestion changes prose until accepted. Accepting changes marks the scene Revised. Bulk decisions and navigation cover the active editing mode; annotations on inactive prose remain available when you return to their original mode.
+
+Set a scene’s revision status to **First Draft**, **Editor Review**, **Revised**, or **Final**; **All scenes** shows the project’s statuses and saved-draft counts by chapter. Locked scenes can be read but not changed. Revision history and comments live in the local project database and are included in newly created project snapshots. This initial version supports writers and editors taking turns on the same local project; it does not exchange annotations through manuscript exports or provide simultaneous collaboration.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -64,3 +64,6 @@ pub use templates::*;
 
 mod writing;
 pub use writing::*;
+
+mod revisions;
+pub use revisions::*;

--- a/src-tauri/src/commands/revisions.rs
+++ b/src-tauri/src/commands/revisions.rs
@@ -1,0 +1,35 @@
+use super::AppState;
+use crate::db::revisions::{self, ReviewData, ReviewDraft, RevisionOverview, SceneReview};
+use tauri::State;
+use uuid::Uuid;
+
+#[tauri::command]
+pub async fn get_scene_review(
+    scene_id: String,
+    state: State<'_, AppState>,
+) -> Result<SceneReview, String> {
+    let id = Uuid::parse_str(&scene_id).map_err(|e| e.to_string())?;
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    revisions::load(&conn, &id)
+}
+
+#[tauri::command]
+pub async fn save_scene_review(
+    expected: SceneReview,
+    data: ReviewData,
+    next: Option<ReviewDraft>,
+    state: State<'_, AppState>,
+) -> Result<SceneReview, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    revisions::save(&conn, &expected, &data, next.as_ref())
+}
+
+#[tauri::command]
+pub async fn get_revision_overview(
+    project_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<RevisionOverview>, String> {
+    let id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    revisions::overview(&conn, &id)
+}

--- a/src-tauri/src/commands/snapshot.rs
+++ b/src-tauri/src/commands/snapshot.rs
@@ -80,7 +80,7 @@ fn collect_project_data(
     let discovery_notes =
         db::get_all_discovery_notes_for_project(conn, project_id).map_err(|e| e.to_string())?;
 
-    Ok(SnapshotData::new(
+    let mut data = SnapshotData::new(
         project,
         chapters,
         scenes,
@@ -93,7 +93,9 @@ fn collect_project_data(
         scene_reference_item_refs,
         scene_reference_states,
         discovery_notes,
-    ))
+    );
+    data.scene_reviews = db::revisions::backup(conn, project_id)?;
+    Ok(data)
 }
 
 /// Serialize and compress snapshot data to a file
@@ -272,6 +274,10 @@ fn restore_replace_current(
         db::insert_beat(&tx, beat).map_err(|e| e.to_string())?;
     }
 
+    for review in &data.scene_reviews {
+        db::revisions::restore_backup(&tx, review, &HashMap::new())?;
+    }
+
     // Insert characters
     for character in &data.characters {
         db::insert_character(&tx, character).map_err(|e| e.to_string())?;
@@ -441,6 +447,10 @@ fn restore_create_new(
         db::insert_beat(&tx, &new_beat).map_err(|e| e.to_string())?;
     }
 
+    for review in &data.scene_reviews {
+        db::revisions::restore_backup(&tx, review, &id_map)?;
+    }
+
     // Insert characters with remapped IDs
     for character in &data.characters {
         let new_character = Character {
@@ -576,6 +586,74 @@ mod tests {
     use super::*;
     use crate::models::SourceType;
     use tempfile::tempdir;
+
+    #[test]
+    fn editorial_history_survives_both_snapshot_restore_paths() {
+        use crate::db::revisions::{self, Annotation, ReviewDraft};
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON").unwrap();
+        let project = Project::new("Editorial snapshot".into(), SourceType::Blank, None);
+        db::insert_project(&conn, &project).unwrap();
+        let chapter = Chapter::new(project.id, "Chapter".into(), 0);
+        db::insert_chapter(&conn, &chapter).unwrap();
+        let scene = Scene::new(chapter.id, "Scene".into(), None, 0);
+        db::insert_scene(&conn, &scene).unwrap();
+        let mut beat = Beat::new(scene.id, "Beat".into(), 0);
+        beat.prose = Some("<p>Original prose</p>".into());
+        db::insert_beat(&conn, &beat).unwrap();
+        let review = revisions::load(&conn, &scene.id).unwrap();
+        let mut data = review.data.clone();
+        data.drafts.push(ReviewDraft {
+            name: "First draft".into(),
+            created_at: "today".into(),
+            mode: review.mode,
+            documents: review.documents.clone(),
+        });
+        data.annotations.push(Annotation {
+            id: "thread".into(),
+            document_id: beat.id.to_string(),
+            anchor_html: beat.prose.clone().unwrap(),
+            from: 1,
+            to: 9,
+            quote: "Original".into(),
+            replacement: Some("Revised".into()),
+            state: "open".into(),
+            messages: vec![],
+        });
+        revisions::save(&conn, &review, &data, None).unwrap();
+        let snapshot = collect_project_data(&conn, &project.id).unwrap();
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        let snapshot: SnapshotData = serde_json::from_str(&serialized).unwrap();
+        db::update_beat_prose(&conn, &beat.id, "Later prose").unwrap();
+        restore_replace_current(&conn, snapshot.clone()).unwrap();
+        let restored = revisions::load(&conn, &scene.id).unwrap();
+        assert_eq!(restored.documents[1].html, "<p>Original prose</p>");
+        assert_eq!(restored.data.drafts.len(), 1);
+        assert_eq!(
+            restored.data.annotations[0].document_id,
+            beat.id.to_string()
+        );
+        let copy = restore_create_new(&conn, snapshot, Some("Copy".into())).unwrap();
+        let chapters = db::get_chapters(&conn, &copy.id).unwrap();
+        let scenes = db::get_scenes(&conn, &chapters[0].id).unwrap();
+        let copied = revisions::load(&conn, &scenes[0].id).unwrap();
+        assert_ne!(copied.scene_id, restored.scene_id);
+        assert_eq!(copied.data.drafts[0].documents[0].id, copied.scene_id);
+        assert_eq!(
+            copied.data.annotations[0].document_id,
+            copied.documents[1].id
+        );
+        assert_ne!(copied.documents[1].id, beat.id.to_string());
+        // Earlier snapshots have no editorial field and still deserialize.
+        let mut old =
+            serde_json::to_value(collect_project_data(&conn, &project.id).unwrap()).unwrap();
+        old.as_object_mut().unwrap().remove("scene_reviews");
+        assert!(serde_json::from_value::<SnapshotData>(old)
+            .unwrap()
+            .scene_reviews
+            .is_empty());
+    }
 
     #[test]
     fn test_generate_snapshot_filename_includes_trigger() {

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -14,3 +14,5 @@ pub use session::*;
 pub use tags::*;
 
 pub mod writing;
+
+pub mod revisions;

--- a/src-tauri/src/db/revisions.rs
+++ b/src-tauri/src/db/revisions.rs
@@ -1,0 +1,444 @@
+//! Local editorial workspaces. Prose and review decisions commit together, with
+//! optimistic checks against both the workspace and every current prose source.
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::EditorMode;
+
+type Result<T> = std::result::Result<T, String>;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewDocument {
+    pub id: String,
+    pub label: String,
+    pub html: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewDraft {
+    pub name: String,
+    pub created_at: String,
+    pub mode: EditorMode,
+    pub documents: Vec<ReviewDocument>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewMessage {
+    pub author: String,
+    pub text: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    pub id: String,
+    pub document_id: String,
+    pub anchor_html: String,
+    pub from: usize,
+    pub to: usize,
+    pub quote: String,
+    pub replacement: Option<String>,
+    pub state: String,
+    pub messages: Vec<ReviewMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewData {
+    pub status: String,
+    pub drafts: Vec<ReviewDraft>,
+    pub annotations: Vec<Annotation>,
+}
+
+impl Default for ReviewData {
+    fn default() -> Self {
+        Self {
+            status: "first_draft".into(),
+            drafts: vec![],
+            annotations: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SceneReview {
+    pub scene_id: String,
+    pub version: i64,
+    pub mode: EditorMode,
+    pub documents: Vec<ReviewDocument>,
+    pub data: ReviewData,
+}
+
+fn err(e: impl std::fmt::Display) -> String {
+    e.to_string()
+}
+
+pub fn load(conn: &Connection, scene_id: &Uuid) -> Result<SceneReview> {
+    let scene = super::get_scene_by_id(conn, scene_id)
+        .map_err(err)?
+        .ok_or("Scene no longer exists")?;
+    // Keep both storage modes, including inactive page prose, so a restore can
+    // recover the precise draft without concatenating or discarding beat prose.
+    let mut documents = vec![ReviewDocument {
+        id: scene_id.to_string(),
+        label: "Scene page".into(),
+        html: scene.prose.unwrap_or_default(),
+    }];
+    for (index, beat) in super::get_beats(conn, scene_id)
+        .map_err(err)?
+        .into_iter()
+        .enumerate()
+    {
+        documents.push(ReviewDocument {
+            id: beat.id.to_string(),
+            label: format!("Beat {}", index + 1),
+            html: beat.prose.unwrap_or_default(),
+        });
+    }
+    let saved: Option<(i64, String)> = conn
+        .query_row(
+            "SELECT version, data FROM scene_reviews WHERE scene_id = ?1",
+            [scene_id.to_string()],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()
+        .map_err(err)?;
+    let (version, data) = match saved {
+        Some((v, json)) => (v, serde_json::from_str(&json).map_err(err)?),
+        None => (0, ReviewData::default()),
+    };
+    Ok(SceneReview {
+        scene_id: scene_id.to_string(),
+        version,
+        mode: scene.editor_mode,
+        documents,
+        data,
+    })
+}
+
+pub fn save(
+    conn: &Connection,
+    expected: &SceneReview,
+    data: &ReviewData,
+    next: Option<&ReviewDraft>,
+) -> Result<SceneReview> {
+    let id = Uuid::parse_str(&expected.scene_id).map_err(err)?;
+    let tx = conn.unchecked_transaction().map_err(err)?;
+    if super::is_scene_locked(&tx, &id).map_err(err)? {
+        return Err("Cannot edit a locked scene".into());
+    }
+    let current = load(&tx, &id)?;
+    if current.version != expected.version
+        || current.mode != expected.mode
+        || current.documents != expected.documents
+    {
+        return Err(
+            "Scene or review changed. Close and reopen Revisions before trying again.".into(),
+        );
+    }
+    if !["first_draft", "editor_review", "revised", "final"].contains(&data.status.as_str()) {
+        return Err("Invalid revision status".into());
+    }
+    // Saved drafts are append-only. A malformed/stale client cannot erase history.
+    if !data.drafts.starts_with(&current.data.drafts) {
+        return Err("Saved drafts cannot be changed or removed".into());
+    }
+    if data.drafts.iter().any(|d| d.name.trim().is_empty()) {
+        return Err("A draft needs a name".into());
+    }
+    if let Some(next) = next {
+        if next.documents.len() != current.documents.len()
+            || next
+                .documents
+                .iter()
+                .zip(&current.documents)
+                .any(|(a, b)| a.id != b.id)
+        {
+            return Err("Scene structure changed. This draft can be compared but cannot be restored to different beats.".into());
+        }
+        // Any prose replacement must first preserve the exact current draft.
+        if !data.drafts[current.data.drafts.len()..]
+            .iter()
+            .any(|d| d.mode == current.mode && d.documents == current.documents)
+        {
+            return Err("Preserve the current draft before changing prose".into());
+        }
+        for doc in &next.documents {
+            let doc_id = Uuid::parse_str(&doc.id).map_err(err)?;
+            if doc.id == expected.scene_id {
+                super::update_scene_prose(&tx, &doc_id, &doc.html).map_err(err)?;
+            } else {
+                super::update_beat_prose(&tx, &doc_id, &doc.html).map_err(err)?;
+            }
+        }
+        tx.execute(
+            "UPDATE scenes SET editor_mode = ?1 WHERE id = ?2",
+            params![next.mode.as_str(), id.to_string()],
+        )
+        .map_err(err)?;
+    }
+    let json = serde_json::to_string(data).map_err(err)?;
+    tx.execute(
+        "INSERT INTO scene_reviews(scene_id, version, data) VALUES (?1, ?2, ?3)
+        ON CONFLICT(scene_id) DO UPDATE SET version = excluded.version, data = excluded.data",
+        params![id.to_string(), current.version + 1, json],
+    )
+    .map_err(err)?;
+    let project_id = super::get_scene_project_id(&tx, &id)
+        .map_err(err)?
+        .ok_or("Project no longer exists")?;
+    super::update_project_modified(&tx, &project_id).map_err(err)?;
+    let result = load(&tx, &id)?;
+    tx.commit().map_err(err)?;
+    Ok(result)
+}
+
+#[derive(Serialize)]
+pub struct RevisionOverview {
+    pub scene_id: String,
+    pub title: String,
+    pub chapter: String,
+    pub status: String,
+    pub drafts: usize,
+}
+
+pub fn overview(conn: &Connection, project_id: &Uuid) -> Result<Vec<RevisionOverview>> {
+    let mut stmt = conn.prepare("SELECT s.id, s.title, c.title, r.data FROM scenes s JOIN chapters c ON c.id = s.chapter_id
+        LEFT JOIN scene_reviews r ON r.scene_id = s.id WHERE c.project_id = ?1 AND NOT s.archived AND NOT c.archived
+        ORDER BY c.position, s.position").map_err(err)?;
+    let rows = stmt
+        .query_map([project_id.to_string()], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(err)?
+        .map(|row| {
+            let (scene_id, title, chapter, json) = row.map_err(err)?;
+            let data: ReviewData = json
+                .map(|j| serde_json::from_str(&j))
+                .transpose()
+                .map_err(err)?
+                .unwrap_or_default();
+            Ok(RevisionOverview {
+                scene_id,
+                title,
+                chapter,
+                status: data.status,
+                drafts: data.drafts.len(),
+            })
+        })
+        .collect();
+    rows
+}
+
+/// Snapshot payloads preserve editorial metadata; old snapshots default to none.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewBackup {
+    pub scene_id: Uuid,
+    pub data: ReviewData,
+}
+
+pub fn backup(conn: &Connection, project_id: &Uuid) -> Result<Vec<ReviewBackup>> {
+    let mut stmt = conn.prepare("SELECT r.scene_id, r.data FROM scene_reviews r JOIN scenes s ON s.id = r.scene_id JOIN chapters c ON c.id = s.chapter_id WHERE c.project_id = ?1").map_err(err)?;
+    let rows = stmt
+        .query_map([project_id.to_string()], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })
+        .map_err(err)?
+        .map(|row| {
+            let (id, json) = row.map_err(err)?;
+            Ok(ReviewBackup {
+                scene_id: Uuid::parse_str(&id).map_err(err)?,
+                data: serde_json::from_str(&json).map_err(err)?,
+            })
+        })
+        .collect();
+    rows
+}
+
+pub fn restore_backup(
+    conn: &Connection,
+    backup: &ReviewBackup,
+    ids: &std::collections::HashMap<Uuid, Uuid>,
+) -> Result<()> {
+    let remap = |id: &str| -> String {
+        Uuid::parse_str(id)
+            .ok()
+            .and_then(|id| ids.get(&id))
+            .map(ToString::to_string)
+            .unwrap_or_else(|| id.to_string())
+    };
+    let mut data = backup.data.clone();
+    for draft in &mut data.drafts {
+        for doc in &mut draft.documents {
+            doc.id = remap(&doc.id);
+        }
+    }
+    for annotation in &mut data.annotations {
+        annotation.document_id = remap(&annotation.document_id);
+    }
+    conn.execute(
+        "INSERT INTO scene_reviews(scene_id, version, data) VALUES (?1, 1, ?2)",
+        params![
+            remap(&backup.scene_id.to_string()),
+            serde_json::to_string(&data).map_err(err)?
+        ],
+    )
+    .map_err(err)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db,
+        models::{Beat, Chapter, Project, Scene, SourceType},
+    };
+    fn fixture() -> (Connection, Project, Chapter, Scene, Beat) {
+        let conn = Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON").unwrap();
+        let p = Project::new("Novel".into(), SourceType::Blank, None);
+        db::insert_project(&conn, &p).unwrap();
+        let c = Chapter::new(p.id, "Chapter".into(), 0);
+        db::insert_chapter(&conn, &c).unwrap();
+        let s = Scene::new(c.id, "Scene".into(), None, 0);
+        db::insert_scene(&conn, &s).unwrap();
+        let b = Beat::new(s.id, "Beat".into(), 0);
+        db::insert_beat(&conn, &b).unwrap();
+        db::update_beat_prose(&conn, &b.id, "<p>Original</p>").unwrap();
+        (conn, p, c, s, b)
+    }
+    fn draft(r: &SceneReview) -> ReviewDraft {
+        ReviewDraft {
+            name: "First draft".into(),
+            created_at: "2026-09-07".into(),
+            mode: r.mode,
+            documents: r.documents.clone(),
+        }
+    }
+    #[test]
+    fn persists_history_status_and_atomic_prose_restore() {
+        let (conn, p, _, s, _) = fixture();
+        let r = load(&conn, &s.id).unwrap();
+        let mut data = r.data.clone();
+        data.drafts.push(draft(&r));
+        data.status = "editor_review".into();
+        let r = save(&conn, &r, &data, None).unwrap();
+        assert_eq!(r.version, 1);
+        let mut next = draft(&r);
+        next.documents[1].html = "<p>Revised</p>".into();
+        assert!(save(&conn, &r, &data, Some(&next))
+            .unwrap_err()
+            .contains("Preserve"));
+        data.drafts.push(draft(&r));
+        let r = save(&conn, &r, &data, Some(&next)).unwrap();
+        assert_eq!(r.documents[1].html, "<p>Revised</p>");
+        data.drafts.push(draft(&r));
+        let restored = save(&conn, &r, &data, Some(&data.drafts[0])).unwrap();
+        assert_eq!(restored.documents[1].html, "<p>Original</p>");
+        assert_eq!(restored.data.drafts[2].documents[1].html, "<p>Revised</p>");
+        let rows = overview(&conn, &p.id).unwrap();
+        assert_eq!(rows[0].drafts, 3);
+        assert_eq!(rows[0].status, "editor_review");
+        // Restores/editorial changes don't manufacture daily writing credit.
+        assert_eq!(
+            db::writing::stats(&conn, &p.id, chrono::Local::now().date_naive())
+                .unwrap()
+                .session_words,
+            0
+        );
+    }
+    #[test]
+    fn rejects_concurrent_edits_versions_and_locked_chapters() {
+        let (conn, _, c, s, b) = fixture();
+        let r = load(&conn, &s.id).unwrap();
+        save(&conn, &r, &r.data, None).unwrap();
+        assert!(save(&conn, &r, &r.data, None)
+            .unwrap_err()
+            .contains("changed"));
+        let r = load(&conn, &s.id).unwrap();
+        db::update_beat_prose(&conn, &b.id, "Newer prose").unwrap();
+        assert!(save(&conn, &r, &r.data, None)
+            .unwrap_err()
+            .contains("changed"));
+        let r = load(&conn, &s.id).unwrap();
+        db::lock_chapter(&conn, &c.id).unwrap();
+        assert!(save(&conn, &r, &r.data, None)
+            .unwrap_err()
+            .contains("locked"));
+        assert_eq!(load(&conn, &s.id).unwrap().version, 1);
+    }
+    #[test]
+    fn rejects_history_loss_invalid_status_and_changed_structure() {
+        let (conn, _, _, s, _) = fixture();
+        let r = load(&conn, &s.id).unwrap();
+        let mut data = r.data.clone();
+        data.status = "nonsense".into();
+        assert!(save(&conn, &r, &data, None).is_err());
+        data = r.data.clone();
+        data.drafts.push(draft(&r));
+        let r = save(&conn, &r, &data, None).unwrap();
+        assert!(save(&conn, &r, &ReviewData::default(), None)
+            .unwrap_err()
+            .contains("cannot be changed"));
+        let mut next = draft(&r);
+        next.documents.pop();
+        data.drafts.push(draft(&r));
+        assert!(save(&conn, &r, &data, Some(&next))
+            .unwrap_err()
+            .contains("structure changed"));
+        assert_eq!(load(&conn, &s.id).unwrap().version, 1);
+        data.drafts[1].name = " ".into();
+        assert!(save(&conn, &r, &data, None).unwrap_err().contains("name"));
+    }
+    #[test]
+    fn backup_remaps_draft_sources_and_annotations_and_cascades_on_delete() {
+        let (conn, p, c, s, b) = fixture();
+        let r = load(&conn, &s.id).unwrap();
+        let mut data = r.data.clone();
+        data.drafts.push(draft(&r));
+        data.annotations.push(Annotation {
+            id: "thread".into(),
+            document_id: b.id.to_string(),
+            anchor_html: r.documents[1].html.clone(),
+            from: 1,
+            to: 9,
+            quote: "Original".into(),
+            replacement: None,
+            state: "open".into(),
+            messages: vec![ReviewMessage {
+                author: "Editor".into(),
+                text: "Comment".into(),
+                created_at: "today".into(),
+            }],
+        });
+        save(&conn, &r, &data, None).unwrap();
+        let copy = Scene::new(c.id, "Copy".into(), None, 1);
+        db::insert_scene(&conn, &copy).unwrap();
+        let copy_beat = Beat::new(copy.id, "Beat".into(), 0);
+        db::insert_beat(&conn, &copy_beat).unwrap();
+        let backups = backup(&conn, &p.id).unwrap();
+        restore_backup(
+            &conn,
+            &backups[0],
+            &[(s.id, copy.id), (b.id, copy_beat.id)].into(),
+        )
+        .unwrap();
+        let copied = load(&conn, &copy.id).unwrap();
+        assert_eq!(copied.data.drafts[0].documents[0].id, copy.id.to_string());
+        assert_eq!(
+            copied.data.annotations[0].document_id,
+            copy_beat.id.to_string()
+        );
+        conn.execute("DELETE FROM scenes WHERE id = ?1", [s.id.to_string()])
+            .unwrap();
+        assert_eq!(backup(&conn, &p.id).unwrap().len(), 1);
+        assert!(load(&conn, &s.id).is_err());
+    }
+}

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -161,6 +161,12 @@ CREATE TABLE IF NOT EXISTS writing_goals (
             words INTEGER NOT NULL DEFAULT 0
         );
 
+        CREATE TABLE IF NOT EXISTS scene_reviews (
+            scene_id TEXT PRIMARY KEY REFERENCES scenes(id) ON DELETE CASCADE,
+            version INTEGER NOT NULL,
+            data TEXT NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS snapshots (
             id TEXT PRIMARY KEY,
             project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -226,6 +226,9 @@ pub fn run() {
             commands::preview_scrivener_matches,
             commands::export_to_scrivener,
             commands::export_to_novelwriter,
+            commands::get_scene_review,
+            commands::save_scene_review,
+            commands::get_revision_overview,
             // Snapshot commands
             commands::create_snapshot,
             commands::list_snapshots,

--- a/src-tauri/src/models/snapshot.rs
+++ b/src-tauri/src/models/snapshot.rs
@@ -129,6 +129,8 @@ pub struct SnapshotData {
     pub scene_reference_states: Vec<SceneReferenceState>,
     #[serde(default)]
     pub discovery_notes: Vec<DiscoveryNote>,
+    #[serde(default)]
+    pub scene_reviews: Vec<crate::db::revisions::ReviewBackup>,
 }
 
 impl SnapshotData {
@@ -162,6 +164,7 @@ impl SnapshotData {
             scene_reference_item_refs,
             scene_reference_states,
             discovery_notes,
+            scene_reviews: vec![],
         }
     }
 

--- a/src/lib/components/ReviewProse.svelte
+++ b/src/lib/components/ReviewProse.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { Editor } from "@tiptap/core";
+  import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+  import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view";
+  import {
+    reviewExtensions,
+    isAnchored,
+    type Annotation,
+    type ReviewDocument,
+  } from "../utils/revisions";
+  let {
+    source,
+    annotations,
+    selectedId,
+    navigationVersion = 0,
+    onSelect,
+  }: {
+    source: ReviewDocument;
+    annotations: Annotation[];
+    selectedId: string | null;
+    navigationVersion?: number;
+    onSelect: (from: number, to: number, quote: string, explicit: boolean) => void;
+  } = $props();
+  let element: HTMLDivElement;
+  let editor = $state.raw<Editor>();
+  let appliedHtml = "";
+  let programmaticSelection = false;
+  let navigatedVersion = -1;
+  let navigatedId: string | null = null;
+  function captureDomSelection(view: EditorView) {
+    const selection = window.getSelection();
+    if (
+      selection?.anchorNode &&
+      selection.focusNode &&
+      view.dom.contains(selection.anchorNode) &&
+      view.dom.contains(selection.focusNode)
+    ) {
+      const anchor = view.posAtDOM(selection.anchorNode, selection.anchorOffset);
+      const head = view.posAtDOM(selection.focusNode, selection.focusOffset);
+      const { from, to } = TextSelection.between(
+        view.state.doc.resolve(anchor),
+        view.state.doc.resolve(head)
+      );
+      onSelect(from, to, view.state.doc.textBetween(from, to, "\n"), true);
+    }
+    return false;
+  }
+  const key = new PluginKey("editorial-annotations");
+  onMount(() => {
+    appliedHtml = source.html;
+    const instance = new Editor({
+      element,
+      extensions: reviewExtensions,
+      content: source.html,
+      editable: false,
+      editorProps: {
+        handleDOMEvents: { mouseup: captureDomSelection, keyup: captureDomSelection },
+        attributes: { class: "review-prose", "aria-label": "Prose for editorial review" },
+      },
+      onSelectionUpdate: ({ editor }) => {
+        if (programmaticSelection) return;
+        const { from, to } = editor.state.selection;
+        onSelect(from, to, editor.state.doc.textBetween(from, to, "\n"), true);
+      },
+    });
+    instance.registerPlugin(
+      new Plugin({
+        key,
+        state: {
+          init: () => DecorationSet.empty,
+          apply: (tr, previous) => tr.getMeta(key) ?? previous.map(tr.mapping, tr.doc),
+        },
+        props: { decorations: (state) => key.getState(state) },
+      })
+    );
+    editor = instance;
+    onSelect(instance.state.selection.from, instance.state.selection.to, "", false);
+    return () => instance.destroy();
+  });
+  $effect(() => {
+    if (!editor) return;
+    programmaticSelection = true;
+    try {
+      if (appliedHtml !== source.html) {
+        editor.commands.setContent(source.html, { emitUpdate: false });
+        appliedHtml = source.html;
+      }
+      const decorations: Decoration[] = [];
+      for (const a of annotations) {
+        if (a.state !== "open" || !isAnchored(a, [source], editor.state.doc)) continue;
+        if (a.from < a.to)
+          decorations.push(
+            Decoration.inline(a.from, a.to, {
+              class: a.replacement !== null ? "review-deletion" : "review-comment",
+              ...(a.id === selectedId ? { "data-selected": "true" } : {}),
+            })
+          );
+        if (a.replacement !== null)
+          decorations.push(
+            Decoration.widget(a.to, () => {
+              const span = document.createElement("ins");
+              span.className = "review-insertion";
+              if (a.id === selectedId) span.dataset.selected = "true";
+              span.textContent = a.replacement;
+              return span;
+            })
+          );
+      }
+      editor.view.dispatch(
+        editor.state.tr.setMeta(key, DecorationSet.create(editor.state.doc, decorations))
+      );
+      const selected = annotations.find((a) => a.id === selectedId);
+      if (
+        selected &&
+        (selected.id !== navigatedId || navigationVersion !== navigatedVersion) &&
+        isAnchored(selected, [source], editor.state.doc)
+      ) {
+        editor.commands.setTextSelection({ from: selected.from, to: selected.to });
+        // A read-only editor may have no native selection when a navigation
+        // button holds focus. Scroll the decoration directly in that case too.
+        element
+          .querySelector<HTMLElement>('[data-selected="true"]')
+          ?.scrollIntoView({ block: "nearest" });
+      }
+      navigatedId = selectedId;
+      navigatedVersion = navigationVersion;
+    } finally {
+      programmaticSelection = false;
+    }
+  });
+</script>
+
+<div class="app-prose-sheet p-6" bind:this={element}></div>
+
+<style>
+  div {
+    max-width: var(--measure);
+    width: 100%;
+  }
+  :global(.review-prose) {
+    font-family: var(--font-body);
+    font-size: var(--text-body);
+    color: var(--color-text);
+    white-space: pre-wrap;
+    min-height: 12rem;
+    outline: none;
+  }
+  :global(.review-deletion) {
+    color: var(--color-error);
+    text-decoration: line-through;
+  }
+  :global(.review-comment),
+  :global(.review-prose [data-selected]) {
+    background: var(--color-accent-wash);
+    border-bottom: 1px solid var(--color-accent);
+  }
+  :global(.review-prose [data-selected]) {
+    outline: 1px solid var(--color-accent);
+  }
+  :global(.review-insertion) {
+    color: var(--color-success);
+    text-decoration: underline;
+  }
+</style>

--- a/src/lib/components/RevisionsPanel.svelte
+++ b/src/lib/components/RevisionsPanel.svelte
@@ -1,0 +1,532 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { invoke } from "@tauri-apps/api/core";
+  import ReviewProse from "./ReviewProse.svelte";
+  import { proseText } from "../utils/proseSearch";
+  import {
+    acceptSuggestions,
+    activeDocuments,
+    diffText,
+    draftOf,
+    isAnchored,
+    revisionStatuses,
+    type SceneReview,
+    type ReviewData,
+    type ReviewDraft,
+    type Annotation,
+    type RevisionOverview,
+  } from "../utils/revisions";
+  let {
+    sceneId,
+    projectId,
+    title,
+    locked,
+    onApplied,
+    onClose,
+  }: {
+    sceneId: string;
+    projectId: string;
+    title: string;
+    locked: boolean;
+    onApplied: (review: SceneReview) => void;
+    onClose: () => void;
+  } = $props();
+  let dialog: HTMLDialogElement;
+  let review = $state.raw<SceneReview>();
+  let overview = $state<RevisionOverview[]>([]);
+  let busy = $state(false);
+  let error = $state("");
+  let tab = $state<"review" | "history" | "overview">("review");
+  let documentId = $state("");
+  let name = $state("");
+  let author = $state("Writer");
+  let comment = $state("");
+  let replacement = $state("");
+  let reply = $state("");
+  let kind = $state<"comment" | "suggestion">("comment");
+  let selection = $state<{ from: number; to: number; quote: string } | null>(null);
+  let selectionIsExplicit = $state(false);
+  let navigationVersion = $state(0);
+  let selectedId = $state<string | null>(null);
+  let before = $state(0);
+  let after = $state(-1);
+  let restoreIndex = $state<number | null>(null);
+  const documents = $derived(review ? activeDocuments(review) : []);
+  const source = $derived(documents.find((d) => d.id === documentId) ?? documents[0]);
+  const visibleAnnotations = $derived(
+    review?.data.annotations.filter((a) => documents.some((d) => d.id === a.document_id)) ?? []
+  );
+  const inactiveCount = $derived(
+    (review?.data.annotations.length ?? 0) - visibleAnnotations.length
+  );
+  const selected = $derived(visibleAnnotations.find((a) => a.id === selectedId));
+  const canReanchor = $derived(
+    selectionIsExplicit &&
+      !!selection &&
+      !!selected &&
+      (selected.from === selected.to
+        ? selection.from === selection.to
+        : selection.from < selection.to)
+  );
+  const pending = $derived(
+    visibleAnnotations.filter((a) => a.state === "open" && a.replacement !== null)
+  );
+  const oldDraft = $derived(review?.data.drafts[before]);
+  const newDraft = $derived(after < 0 ? review : review?.data.drafts[after]);
+
+  onMount(() => {
+    dialog.showModal();
+    void load();
+  });
+  async function load() {
+    busy = true;
+    error = "";
+    try {
+      review = await invoke<SceneReview>("get_scene_review", { sceneId });
+      overview = await invoke<RevisionOverview[]>("get_revision_overview", { projectId });
+    } catch (e) {
+      error = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+  async function save(data: ReviewData, next: ReviewDraft | null = null) {
+    if (!review || busy || locked) return false;
+    busy = true;
+    error = "";
+    try {
+      review = await invoke<SceneReview>("save_scene_review", { expected: review, data, next });
+      if (next) {
+        selection = null;
+        onApplied(review);
+      }
+      // Update the overview locally after the committed write, so a failed
+      // auxiliary read cannot make a successful decision appear to have failed.
+      overview = overview.map((row) =>
+        row.scene_id === sceneId ? { ...row, status: data.status, drafts: data.drafts.length } : row
+      );
+      return true;
+    } catch (e) {
+      error = String(e);
+      return false;
+    } finally {
+      busy = false;
+    }
+  }
+  async function createDraft() {
+    if (!review || !name.trim()) return;
+    const data = window.structuredClone(review.data);
+    data.drafts.push(draftOf(review, name));
+    if (await save(data)) {
+      before = data.drafts.length - 1;
+      name = "";
+    }
+  }
+  async function restore() {
+    if (!review || restoreIndex === null) return;
+    const next = review.data.drafts[restoreIndex];
+    const data = window.structuredClone(review.data);
+    data.drafts.push(draftOf(review, "Before restoring " + next.name));
+    if (await save(data, next)) restoreIndex = null;
+  }
+  async function setStatus(status: string) {
+    if (review) await save({ ...review.data, status });
+  }
+  async function addAnnotation() {
+    if (!review || !source || !selection || !selectionIsExplicit || !author.trim()) return;
+    if (kind === "comment" && (!comment.trim() || selection.from === selection.to)) return;
+    if (kind === "suggestion" && !replacement && selection.from === selection.to) return;
+    const a: Annotation = {
+      id: window.crypto.randomUUID(),
+      document_id: source.id,
+      anchor_html: source.html,
+      ...selection,
+      replacement: kind === "suggestion" ? replacement : null,
+      state: "open",
+      messages: [
+        { author: author.trim(), text: comment.trim(), created_at: new Date().toISOString() },
+      ],
+    };
+    if (await save({ ...review.data, annotations: [...review.data.annotations, a] })) {
+      selectedId = a.id;
+      comment = "";
+      replacement = "";
+    }
+  }
+  async function changeAnnotations(ids: string[], state: Annotation["state"]) {
+    if (!review) return;
+    await save({
+      ...review.data,
+      annotations: review.data.annotations.map((a) => (ids.includes(a.id) ? { ...a, state } : a)),
+    });
+  }
+  async function accept(ids: string[]) {
+    if (!review) return;
+    try {
+      const { data, next } = acceptSuggestions(review, ids);
+      await save(data, next);
+    } catch (e) {
+      error = String(e);
+    }
+  }
+  async function addReply() {
+    if (!review || !selected || !reply.trim() || !author.trim()) return;
+    const data = window.structuredClone(review.data);
+    data.annotations
+      .find((a) => a.id === selectedId)!
+      .messages.push({
+        author: author.trim(),
+        text: reply.trim(),
+        created_at: new Date().toISOString(),
+      });
+    if (await save(data)) reply = "";
+  }
+  async function reanchor() {
+    if (!review || !source || !selected || !selection || !canReanchor) return;
+    const data = window.structuredClone(review.data);
+    Object.assign(data.annotations.find((a) => a.id === selectedId)!, selection, {
+      document_id: source.id,
+      anchor_html: source.html,
+    });
+    await save(data);
+  }
+  function selectAnnotation(a: Annotation) {
+    documentId = a.document_id;
+    selectedId = a.id;
+    navigationVersion++;
+    selection = null;
+    reply = "";
+  }
+  function step(direction: number) {
+    const i = pending.findIndex((a) => a.id === selectedId);
+    const a = pending[(i + direction + pending.length) % pending.length];
+    if (a) selectAnnotation(a);
+  }
+</script>
+
+<dialog
+  bind:this={dialog}
+  aria-labelledby="revisions-title"
+  oncancel={(e) => {
+    e.preventDefault();
+    if (!busy) onClose();
+  }}
+  onkeydown={(e) => e.stopPropagation()}
+>
+  <header class="flex items-center justify-between gap-4 border-b border-press-border pb-3">
+    <h2 id="revisions-title" class="font-heading text-press-h3">Revisions · {title}</h2>
+    <button type="button" disabled={busy} onclick={onClose}>Close</button>
+  </header>
+  <nav aria-label="Revision views" class="flex gap-4 py-3">
+    <button aria-pressed={tab === "review"} onclick={() => (tab = "review")}
+      >Editorial review</button
+    >
+    <button aria-pressed={tab === "history"} onclick={() => (tab = "history")}>Draft history</button
+    >
+    <button aria-pressed={tab === "overview"} onclick={() => (tab = "overview")}>All scenes</button>
+  </nav>
+  {#if error}<p role="alert" class="text-press-error">{error}</p>{/if}
+  {#if !review}
+    <p>{busy ? "Loading revisions…" : "Could not load revisions."}</p>
+    {#if !busy}<button onclick={load}>Retry</button>{/if}
+  {:else}
+    {#if locked}<p class="text-press-muted">
+        This scene is locked. History and comments are read-only.
+      </p>{/if}
+    <fieldset disabled={busy || locked}>
+      <label
+        >Revision status
+        <select value={review.data.status} onchange={(e) => setStatus(e.currentTarget.value)}>
+          {#each Object.entries(revisionStatuses) as [value, label]}<option {value}>{label}</option
+            >{/each}
+        </select>
+      </label>
+    </fieldset>
+    {#if tab === "history"}
+      <fieldset disabled={busy || locked} class="flex gap-3 my-4">
+        <label>Draft name <input bind:value={name} placeholder="Post-editor pass" /></label>
+        <button disabled={!name.trim()} onclick={createDraft}>Save named draft</button>
+      </fieldset>
+      {#if review.data.drafts.length === 0}
+        <p>No saved drafts yet. Save a named draft to keep this scene’s current prose.</p>
+      {:else}
+        <div class="flex flex-wrap gap-3 my-4">
+          <label
+            >Compare from <select bind:value={before}
+              >{#each review.data.drafts as d, i}<option value={i}>Draft {i + 1} · {d.name}</option
+                >{/each}</select
+            ></label
+          >
+          <label
+            >Compare to <select bind:value={after}
+              ><option value={-1}>Current prose</option>{#each review.data.drafts as d, i}<option
+                  value={i}>Draft {i + 1} · {d.name}</option
+                >{/each}</select
+            ></label
+          >
+          <button disabled={busy || locked} onclick={() => (restoreIndex = before)}
+            >Restore selected draft</button
+          >
+        </div>
+        {#if restoreIndex !== null}
+          <div class="border-y border-press-border py-3">
+            <p>
+              Restore “{review.data.drafts[restoreIndex].name}”? Current prose will be preserved as
+              another draft. Beat structure must still match.
+            </p>
+            <button disabled={busy || locked} onclick={restore}
+              >Restore and preserve current prose</button
+            >
+            <button disabled={busy} onclick={() => (restoreIndex = null)}>Cancel restore</button>
+          </div>
+        {/if}
+        {#if oldDraft && newDraft}
+          <p class="text-press-muted my-3">
+            Deleted text is struck through; inserted text is underlined. This comparison shows prose
+            text, not formatting.
+          </p>
+          {#each [...new Set( [...oldDraft.documents.map((d) => d.id), ...newDraft.documents.map((d) => d.id)] )] as id}
+            {@const oldDoc = oldDraft.documents.find((d) => d.id === id)}
+            {@const newDoc = newDraft.documents.find((d) => d.id === id)}
+            <h3 class="font-heading text-press-body-lg mt-4">{newDoc?.label ?? oldDoc?.label}</h3>
+            <div class="diff-prose">
+              {#each diffText(proseText(oldDoc?.html ?? ""), proseText(newDoc?.html ?? "")) as part}{#if part.kind === "delete"}<del
+                    >{part.text}</del
+                  >{:else if part.kind === "insert"}<ins>{part.text}</ins
+                  >{:else}{part.text}{/if}{/each}
+            </div>
+          {/each}
+        {/if}
+      {/if}
+    {:else if tab === "overview"}
+      <table class="w-full my-4 text-left">
+        <thead
+          ><tr><th>Chapter</th><th>Scene</th><th>Revision status</th><th>Saved drafts</th></tr
+          ></thead
+        >
+        <tbody
+          >{#each overview as row}<tr
+              ><td>{row.chapter}</td><td>{row.title}</td><td
+                >{revisionStatuses[row.status as keyof typeof revisionStatuses]}</td
+              ><td>{row.drafts}</td></tr
+            >{/each}</tbody
+        >
+      </table>
+    {:else if source}
+      <p class="text-press-muted my-3">
+        Select prose to comment or suggest a deletion/replacement. Place the cursor to suggest an
+        insertion. Suggestions change the manuscript only when accepted.
+      </p>
+      <label
+        >Prose source <select
+          value={source.id}
+          onchange={(e) => {
+            documentId = e.currentTarget.value;
+            selection = null;
+            selectedId = null;
+          }}
+        >
+          {#each documents as doc}<option value={doc.id}>{doc.label}</option>{/each}
+        </select></label
+      >
+      <div class="review-columns mt-4">
+        <div>
+          {#key source.id}
+            <ReviewProse
+              {source}
+              annotations={visibleAnnotations}
+              {selectedId}
+              {navigationVersion}
+              onSelect={(from, to, quote, explicit) => {
+                selection = { from, to, quote };
+                selectionIsExplicit = explicit;
+              }}
+            />
+          {/key}
+          <fieldset disabled={busy || locked} class="mt-4 flex flex-col gap-3">
+            <label>Your name <input bind:value={author} /></label>
+            <label
+              >Annotation <select bind:value={kind}
+                ><option value="comment">Comment</option><option value="suggestion"
+                  >Suggest change</option
+                ></select
+              ></label
+            >
+            <p class="text-press-muted">
+              {selection
+                ? selection.quote || "Insertion at cursor"
+                : "Select text in the prose above."}
+            </p>
+            {#if kind === "suggestion"}<label
+                >Suggested text (leave empty to delete)<textarea bind:value={replacement}
+                ></textarea></label
+              >{/if}
+            <label
+              >{kind === "comment" ? "Comment" : "Reason (optional)"}<textarea bind:value={comment}
+              ></textarea></label
+            >
+            <button
+              disabled={!selection ||
+                !selectionIsExplicit ||
+                !author.trim() ||
+                (kind === "comment"
+                  ? !comment.trim() || selection.from === selection.to
+                  : !replacement && selection.from === selection.to)}
+              onclick={addAnnotation}>Add {kind === "comment" ? "comment" : "suggestion"}</button
+            >
+          </fieldset>
+        </div>
+        <aside aria-label="Comments and suggestions">
+          <div class="flex flex-wrap gap-3">
+            <button disabled={!pending.length} onclick={() => step(-1)}>Previous change</button>
+            <button disabled={!pending.length} onclick={() => step(1)}>Next change</button>
+            <button
+              disabled={busy || locked || !pending.length}
+              onclick={() => accept(pending.map((a) => a.id))}>Accept all</button
+            >
+            <button
+              disabled={busy || locked || !pending.length}
+              onclick={() =>
+                changeAnnotations(
+                  pending.map((a) => a.id),
+                  "rejected"
+                )}>Reject all</button
+            >
+          </div>
+          <p class="text-press-muted my-3">{pending.length} pending changes</p>
+          {#if inactiveCount}<p class="text-press-muted">
+              {inactiveCount}
+              {inactiveCount === 1 ? "annotation belongs" : "annotations belong"} to inactive prose. Return
+              to their original editing mode to review them.
+            </p>{/if}
+          {#each visibleAnnotations as a}
+            <div class="border-t border-press-border py-3">
+              <button
+                class="text-left"
+                aria-pressed={a.id === selectedId}
+                onclick={() => selectAnnotation(a)}
+                >{a.replacement === null ? "Comment" : "Suggestion"} · {a.state} · {a.quote ||
+                  "Insertion"}</button
+              >
+              {#if a.id === selectedId}
+                {#if a.replacement !== null}<p class="diff-prose">
+                    <del>{a.quote}</del> <ins>{a.replacement}</ins>
+                  </p>{/if}
+                {#if !isAnchored(a, review.documents) && a.state === "open"}
+                  <p class="text-press-warning">
+                    Outdated anchor: prose changed. Select the intended text and re-anchor before
+                    accepting.
+                  </p>
+                  <button disabled={busy || locked || !canReanchor} onclick={reanchor}
+                    >Re-anchor to selection</button
+                  >
+                {/if}
+                {#each a.messages as message}<p class="my-2">
+                    <strong>{message.author}</strong>
+                    <span class="text-press-muted"
+                      >{new Date(message.created_at).toLocaleDateString()}</span
+                    ><br />{message.text}
+                  </p>{/each}
+                <fieldset disabled={busy || locked} class="flex flex-col gap-2">
+                  <label>Reply <textarea bind:value={reply}></textarea></label>
+                  <button disabled={!reply.trim() || !author.trim()} onclick={addReply}
+                    >Reply to thread</button
+                  >
+                  {#if a.state === "open"}
+                    {#if a.replacement === null}<button
+                        onclick={() => changeAnnotations([a.id], "resolved")}>Resolve thread</button
+                      >
+                    {:else}
+                      <button
+                        disabled={!isAnchored(a, review.documents)}
+                        onclick={() => accept([a.id])}>Accept change</button
+                      >
+                      <button onclick={() => changeAnnotations([a.id], "rejected")}
+                        >Reject change</button
+                      >
+                    {/if}
+                  {:else if a.state === "resolved"}<button
+                      onclick={() => changeAnnotations([a.id], "open")}>Reopen thread</button
+                    >{/if}
+                </fieldset>
+              {/if}
+            </div>
+          {/each}
+          {#if !visibleAnnotations.length}<p>No comments or suggestions yet.</p>{/if}
+        </aside>
+      </div>
+    {/if}
+  {/if}
+  {#if busy}<p role="status">Saving or loading…</p>{/if}
+</dialog>
+
+<style>
+  dialog {
+    width: min(72rem, calc(100vw - var(--space-xl)));
+    max-height: calc(100vh - var(--space-xl));
+    margin: auto;
+    padding: var(--space-l);
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-overlay);
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    overflow: auto;
+  }
+  dialog::backdrop {
+    background: var(--color-overlay-scrim);
+  }
+  .review-columns {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    gap: var(--space-l);
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+  button {
+    padding: var(--space-xs) var(--space-s);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-s);
+  }
+  button[aria-pressed="true"] {
+    background: var(--color-accent-wash);
+  }
+  button:disabled {
+    color: var(--color-disabled-text);
+    background: var(--color-disabled-bg);
+  }
+  input,
+  select,
+  textarea {
+    font-size: var(--text-base);
+    max-width: 100%;
+  }
+  .diff-prose {
+    font-family: var(--font-body);
+    font-size: var(--text-body);
+    max-width: var(--measure);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  del {
+    color: var(--color-error);
+  }
+  ins {
+    color: var(--color-success);
+  }
+  td,
+  th {
+    padding: var(--space-s);
+    border-bottom: 1px solid var(--color-border);
+  }
+  @media (max-width: 800px) {
+    .review-columns {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/src/lib/components/RevisionsPanel.test.ts
+++ b/src/lib/components/RevisionsPanel.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import type { Editor } from "@tiptap/core";
+import { invoke } from "@tauri-apps/api/core";
+import RevisionsPanel from "./RevisionsPanel.svelte";
+import type { SceneReview } from "../utils/revisions";
+let persisted: SceneReview;
+let failSave = false;
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true;
+  };
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+  persisted = {
+    scene_id: "scene",
+    version: 0,
+    mode: "page",
+    documents: [{ id: "scene", label: "Scene page", html: "<p>The red fox.</p>" }],
+    data: { status: "first_draft", drafts: [], annotations: [] },
+  };
+  failSave = false;
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+    if (cmd === "get_scene_review") return structuredClone(persisted);
+    if (cmd === "get_revision_overview")
+      return [
+        {
+          scene_id: "scene",
+          title: "Arrival",
+          chapter: "Chapter 1",
+          status: "first_draft",
+          drafts: 0,
+        },
+      ];
+    if (cmd === "save_scene_review") {
+      if (failSave) throw new Error("database is locked");
+      const { data, next } = args as {
+        data: SceneReview["data"];
+        next: { documents: SceneReview["documents"]; mode: SceneReview["mode"] } | null;
+      };
+      persisted = {
+        ...persisted,
+        version: persisted.version + 1,
+        data: structuredClone(data),
+        ...(next ? { documents: next.documents, mode: next.mode } : {}),
+      };
+      return structuredClone(persisted);
+    }
+  });
+});
+afterEach(cleanup);
+async function setup(locked = false) {
+  const onApplied = vi.fn(),
+    onClose = vi.fn();
+  render(RevisionsPanel, {
+    sceneId: "scene",
+    projectId: "project",
+    title: "Arrival",
+    locked,
+    onApplied,
+    onClose,
+  });
+  await screen.findByText("No comments or suggestions yet.");
+  return { onApplied, onClose };
+}
+async function select(from = 5, to = 8) {
+  const element = document.querySelector(".tiptap") as HTMLElement & { editor: Editor };
+  element.editor.commands.setTextSelection({ from, to });
+  await waitFor(() => expect(screen.queryByText("Select text in the prose above.")).toBeNull());
+}
+it("creates numbered named drafts, compares and restores with a preserved current draft", async () => {
+  const { onApplied } = await setup();
+  await fireEvent.click(screen.getByText("Draft history"));
+  await fireEvent.input(screen.getByLabelText("Draft name"), { target: { value: "First pass" } });
+  await fireEvent.click(screen.getByText("Save named draft"));
+  await screen.findAllByRole("option", { name: "Draft 1 · First pass" });
+  await fireEvent.click(screen.getByText("Restore selected draft"));
+  await fireEvent.click(screen.getByText("Restore and preserve current prose"));
+  await waitFor(() => expect(persisted.data.drafts).toHaveLength(2));
+  expect(persisted.data.drafts[1].name).toBe("Before restoring First pass");
+  expect(onApplied).toHaveBeenCalledOnce();
+  await fireEvent.click(screen.getByText("All scenes"));
+  expect(screen.getByText("Chapter 1")).toBeTruthy();
+});
+it("anchors inline comments, persists replies and resolves/reopens the thread", async () => {
+  await setup();
+  await select();
+  await fireEvent.input(screen.getByLabelText("Comment"), { target: { value: "Stronger image?" } });
+  await fireEvent.click(screen.getByText("Add comment"));
+  await screen.findByText("Stronger image?");
+  expect(document.querySelector(".review-comment")?.textContent).toBe("red");
+  await fireEvent.input(screen.getByLabelText("Reply"), { target: { value: "Agreed." } });
+  await fireEvent.click(screen.getByText("Reply to thread"));
+  await screen.findByText("Agreed.");
+  await fireEvent.click(screen.getByText("Resolve thread"));
+  await screen.findByText("Reopen thread");
+  expect(persisted.data.annotations[0].state).toBe("resolved");
+  await fireEvent.click(screen.getByText("Reopen thread"));
+  await screen.findByText("Resolve thread");
+});
+it("previews and accepts suggestions only after successful persistence; rejection leaves prose intact", async () => {
+  const { onApplied } = await setup();
+  await select();
+  await fireEvent.change(screen.getByLabelText("Annotation"), { target: { value: "suggestion" } });
+  await fireEvent.input(screen.getByLabelText("Suggested text (leave empty to delete)"), {
+    target: { value: "blue" },
+  });
+  await fireEvent.click(screen.getByText("Add suggestion"));
+  await screen.findByText("Accept change");
+  expect(document.querySelector(".review-deletion")?.textContent).toBe("red");
+  expect(document.querySelector(".review-insertion")?.textContent).toBe("blue");
+  failSave = true;
+  await fireEvent.click(screen.getByText("Accept change"));
+  await screen.findByRole("alert");
+  expect(onApplied).not.toHaveBeenCalled();
+  expect(persisted.documents[0].html).toBe("<p>The red fox.</p>");
+  failSave = false;
+  await fireEvent.click(screen.getByText("Accept all"));
+  await waitFor(() => expect(onApplied).toHaveBeenCalledOnce());
+  expect(persisted.documents[0].html).toBe("<p>The blue fox.</p>");
+  expect(persisted.data.drafts[0].documents[0].html).toBe("<p>The red fox.</p>");
+  await select(1, 4);
+  await fireEvent.input(screen.getByLabelText("Suggested text (leave empty to delete)"), {
+    target: { value: "A" },
+  });
+  await fireEvent.click(screen.getByText("Add suggestion"));
+  await screen.findByText("Reject change");
+  await fireEvent.click(screen.getByText("Reject all"));
+  await waitFor(() => expect(persisted.data.annotations[1].state).toBe("rejected"));
+  expect(persisted.documents[0].html).toBe("<p>The blue fox.</p>");
+});
+it("allows reading locked scenes while disabling writes", async () => {
+  await setup(true);
+  expect(
+    (screen.getByLabelText("Revision status") as HTMLSelectElement).closest("fieldset")?.disabled
+  ).toBe(true);
+  await fireEvent.click(screen.getByText("Draft history"));
+  expect(
+    (screen.getByLabelText("Draft name") as HTMLInputElement).closest("fieldset")?.disabled
+  ).toBe(true);
+});
+
+it("scrolls to changes on fresh-open and cross-beat navigation without native selection", async () => {
+  persisted.mode = "beat";
+  persisted.documents.push(
+    { id: "beat-1", label: "Beat 1", html: "<p>First beat.</p>" },
+    { id: "beat-2", label: "Beat 2", html: "<p>Second beat.</p>" }
+  );
+  persisted.data.annotations = [1, 2].map((i) => ({
+    id: "change-" + i,
+    document_id: "beat-" + i,
+    anchor_html: persisted.documents[i].html,
+    from: 1,
+    to: 1,
+    quote: "",
+    replacement: "New ",
+    state: "open",
+    messages: [],
+  }));
+  const onApplied = vi.fn(),
+    onClose = vi.fn();
+  render(RevisionsPanel, {
+    sceneId: "scene",
+    projectId: "project",
+    title: "Arrival",
+    locked: false,
+    onApplied,
+    onClose,
+  });
+  await screen.findByText("2 pending changes");
+  window.getSelection()?.removeAllRanges();
+  await fireEvent.click(screen.getByText("Next change"));
+  await waitFor(() => expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled());
+  vi.mocked(HTMLElement.prototype.scrollIntoView).mockClear();
+  await fireEvent.click(screen.getByText("Next change"));
+  await waitFor(() =>
+    expect((screen.getByLabelText("Prose source") as HTMLSelectElement).value).toBe("beat-2")
+  );
+  expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  expect(document.querySelector('.review-insertion[data-selected="true"]')).toBeTruthy();
+});
+
+it("requires a fresh nonempty range when re-anchoring a replacement", async () => {
+  persisted.data.annotations = [
+    {
+      id: "old",
+      document_id: "scene",
+      anchor_html: "<p>The old fox.</p>",
+      from: 5,
+      to: 8,
+      quote: "old",
+      replacement: "blue",
+      state: "open",
+      messages: [],
+    },
+  ];
+  render(RevisionsPanel, {
+    sceneId: "scene",
+    projectId: "project",
+    title: "Arrival",
+    locked: false,
+    onApplied: vi.fn(),
+    onClose: vi.fn(),
+  });
+  await fireEvent.click(await screen.findByText("Suggestion · open · old"));
+  const button = screen.getByText("Re-anchor to selection") as HTMLButtonElement;
+  expect(button.disabled).toBe(true);
+  await select(2, 2);
+  expect(button.disabled).toBe(true);
+  await select();
+  expect(button.disabled).toBe(false);
+  await fireEvent.click(button);
+  await screen.findByText("Accept change");
+  expect(persisted.data.annotations[0].quote).toBe("red");
+  expect(persisted.data.annotations[0].from).toBe(5);
+  expect(persisted.data.annotations[0].to).toBe(8);
+});
+
+it("keeps inactive-mode suggestions out of navigation and bulk acceptance", async () => {
+  persisted.documents.push({ id: "beat", label: "Beat 1", html: "<p>Beat.</p>" });
+  persisted.data.annotations = [
+    {
+      id: "page",
+      document_id: "scene",
+      anchor_html: persisted.documents[0].html,
+      from: 5,
+      to: 8,
+      quote: "red",
+      replacement: "blue",
+      state: "open",
+      messages: [],
+    },
+    {
+      id: "beat",
+      document_id: "beat",
+      anchor_html: persisted.documents[1].html,
+      from: 1,
+      to: 5,
+      quote: "Beat",
+      replacement: "Changed",
+      state: "open",
+      messages: [],
+    },
+  ];
+  render(RevisionsPanel, {
+    sceneId: "scene",
+    projectId: "project",
+    title: "Arrival",
+    locked: false,
+    onApplied: vi.fn(),
+    onClose: vi.fn(),
+  });
+  await screen.findByText("1 pending changes");
+  expect(screen.queryByText("Suggestion · open · Beat")).toBeNull();
+  await fireEvent.click(screen.getByText("Accept all"));
+  await waitFor(() => expect(persisted.data.annotations[0].state).toBe("accepted"));
+  expect(persisted.data.annotations[1].state).toBe("open");
+  expect(persisted.documents[1].html).toBe("<p>Beat.</p>");
+});
+
+it("does not replace the prose document or reset selection when replying to a thread", async () => {
+  await setup();
+  await select();
+  await fireEvent.input(screen.getByLabelText("Comment"), { target: { value: "Comment here" } });
+  await fireEvent.click(screen.getByText("Add comment"));
+  await screen.findByText("Resolve thread");
+  const editor = (document.querySelector(".tiptap") as HTMLElement & { editor: Editor }).editor;
+  await select(9, 12);
+  const doc = editor.state.doc;
+  await fireEvent.input(screen.getByLabelText("Reply"), { target: { value: "Reply" } });
+  await fireEvent.click(screen.getByText("Reply to thread"));
+  await waitFor(() => expect(persisted.data.annotations[0].messages.length).toBe(2));
+  expect(editor.state.doc).toBe(doc);
+  expect(editor.state.selection.from).toBe(9);
+  expect(editor.state.selection.to).toBe(12);
+});
+
+it("never treats a remounted editor's initial cursor as an explicit re-anchor", async () => {
+  persisted.mode = "beat";
+  persisted.documents.push(
+    { id: "b1", label: "Beat 1", html: "<p>First.</p>" },
+    { id: "b2", label: "Beat 2", html: "<p>Second.</p>" }
+  );
+  persisted.data.annotations = [
+    {
+      id: "outdated",
+      document_id: "b2",
+      anchor_html: "<p>Older.</p>",
+      from: 3,
+      to: 3,
+      quote: "",
+      replacement: "New",
+      state: "open",
+      messages: [],
+    },
+  ];
+  render(RevisionsPanel, {
+    sceneId: "scene",
+    projectId: "project",
+    title: "Arrival",
+    locked: false,
+    onApplied: vi.fn(),
+    onClose: vi.fn(),
+  });
+  await fireEvent.click(await screen.findByText("Suggestion · open · Insertion"));
+  const button = () => screen.getByText("Re-anchor to selection") as HTMLButtonElement;
+  expect(button().disabled).toBe(true);
+  await fireEvent.click(screen.getByText("Draft history"));
+  await fireEvent.click(screen.getByText("Editorial review"));
+  expect(button().disabled).toBe(true);
+  // Explicitly click the same initial position: native selection need not have
+  // changed the ProseMirror selection for this user action to count.
+  const prose = document.querySelector(".review-prose")!;
+  const text = prose.querySelector("p")!.firstChild!;
+  window.getSelection()!.setBaseAndExtent(text, 0, text, 0);
+  await fireEvent.mouseUp(prose);
+  expect(button().disabled).toBe(false);
+  await fireEvent.click(button());
+  await waitFor(() => expect(persisted.data.annotations[0].anchor_html).toBe("<p>Second.</p>"));
+  expect(persisted.data.annotations[0].from).toBe(1);
+});
+
+it("requires an explicit prose selection to create a suggestion and re-scrolls a repeated navigation", async () => {
+  await setup();
+  await fireEvent.change(screen.getByLabelText("Annotation"), { target: { value: "suggestion" } });
+  await fireEvent.input(screen.getByLabelText("Suggested text (leave empty to delete)"), {
+    target: { value: "New " },
+  });
+  expect((screen.getByText("Add suggestion") as HTMLButtonElement).disabled).toBe(true);
+  const prose = document.querySelector(".review-prose")!;
+  const text = prose.querySelector("p")!.firstChild!;
+  window.getSelection()!.setBaseAndExtent(text, 0, text, 0);
+  await fireEvent.mouseUp(prose);
+  await fireEvent.click(screen.getByText("Add suggestion"));
+  await screen.findByText("Accept change");
+  vi.mocked(HTMLElement.prototype.scrollIntoView).mockClear();
+  await fireEvent.click(screen.getByText("Next change"));
+  expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledOnce();
+});

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { countWordsInHtml } from "../utils/wordCount";
   import { writing } from "../stores/writing.svelte";
+  import RevisionsPanel from "./RevisionsPanel.svelte";
+  import type { SceneReview } from "../utils/revisions";
   import WritingStatusBar from "./WritingStatusBar.svelte";
   import {
     FileText,
@@ -45,6 +47,49 @@
   import SluglineInput from "./SluglineInput.svelte";
   import TagSelector from "./TagSelector.svelte";
   import Tooltip from "./Tooltip.svelte";
+
+  let revisionsScene = $state<{
+    id: string;
+    projectId: string;
+    title: string;
+    locked: boolean;
+  } | null>(null);
+  let openingRevisions = $state(false);
+  let revisionEditorVersion = $state(0);
+  async function openRevisions() {
+    const scene = currentProject.currentScene;
+    const project = currentProject.value;
+    if (!scene || !project) return;
+    openingRevisions = true;
+    try {
+      await prepareForSearch();
+      if (proseSaves.draftsForRecovery(project.id).length)
+        throw new Error("Save or recover unsaved prose before opening Revisions.");
+      if (currentProject.currentScene?.id !== scene.id) return;
+      revisionsScene = {
+        id: scene.id,
+        projectId: project.id,
+        title: scene.title,
+        locked: isLocked,
+      };
+    } catch (e) {
+      ui.showError(String(e));
+    } finally {
+      openingRevisions = false;
+    }
+  }
+  function applyRevision(review: SceneReview) {
+    if (currentProject.currentScene?.id !== review.scene_id) return;
+    const prose = review.documents.find((d) => d.id === review.scene_id)?.html ?? "";
+    currentProject.updateScene(review.scene_id, { prose, editor_mode: review.mode });
+    pageProseContent = prose;
+    for (const doc of review.documents) {
+      if (doc.id !== review.scene_id) currentProject.updateBeatProse(doc.id, doc.html);
+    }
+    pageEditorVersion++;
+    revisionEditorVersion++;
+    writing.scheduleRefresh(currentProject.value!.id);
+  }
 
   const isScreenplay = $derived(currentProject.value?.project_type === "screenplay");
 
@@ -730,6 +775,14 @@
     {@const projectId = currentProject.value.id}
     <div use:trackSceneScroll={{ projectId, sceneId: scene.id }} class="flex-1 overflow-y-auto">
       <div class="max-w-3xl mx-auto p-8">
+        <div class="flex justify-end border-b border-press-border px-4 py-2">
+          <button
+            disabled={openingRevisions}
+            onclick={openRevisions}
+            class="text-press-ui text-press-text"
+            >{openingRevisions ? "Opening revisions…" : "Revisions"}</button
+          >
+        </div>
         <!-- Scene Title -->
         <header class="mb-8">
           <div class="flex items-center gap-3 flex-wrap">
@@ -1306,7 +1359,7 @@
               projectId={currentProject.value?.id}
               sceneId={scene.id}
               content={pageProseContent}
-              readonly={isLocked || switchingMode}
+              readonly={isLocked || switchingMode || openingRevisions || !!revisionsScene}
               saveStatus={pageProseSaveStatus}
               wordCount={getPageWordCount()}
               onUpdate={handlePageProseUpdate}
@@ -1316,11 +1369,13 @@
 
         <!-- Beats (Fixed + Beat mode only) -->
         {#if (scene.planning_status ?? "fixed") === "fixed" && scene.editor_mode !== "page"}
-          <BeatView
-            bind:this={beatViewRef}
-            beats={currentProject.beats}
-            isLocked={isLocked || switchingMode}
-          />
+          {#key revisionEditorVersion}
+            <BeatView
+              bind:this={beatViewRef}
+              beats={currentProject.beats}
+              isLocked={isLocked || switchingMode || openingRevisions || !!revisionsScene}
+            />
+          {/key}
         {/if}
 
         <!-- Scene Prose fallback (Fixed + Beat mode only, if exists and no beats) -->
@@ -1364,5 +1419,16 @@
       doSwitchMode("beat");
     }}
     onCancel={() => (showSwitchToBeatConfirm = false)}
+  />
+{/if}
+
+{#if revisionsScene}
+  <RevisionsPanel
+    sceneId={revisionsScene.id}
+    projectId={revisionsScene.projectId}
+    title={revisionsScene.title}
+    locked={revisionsScene.locked}
+    onApplied={applyRevision}
+    onClose={() => (revisionsScene = null)}
   />
 {/if}

--- a/src/lib/components/SceneRevisions.test.ts
+++ b/src/lib/components/SceneRevisions.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { invoke } from "@tauri-apps/api/core";
+import type { Editor } from "@tiptap/core";
+import ScenePanel from "./ScenePanel.svelte";
+import { currentProject } from "../stores/project.svelte";
+import { ui } from "../stores/ui.svelte";
+import { session } from "../stores/session.svelte";
+import { proseSaves } from "../utils/proseSaves";
+import { mockProject, mockChapters, mockScenes } from "../../dev/mock-data";
+import type { SceneReview } from "../utils/revisions";
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => data.get(k) ?? null,
+    setItem: (k: string, v: string) => data.set(k, v),
+    removeItem: (k: string) => data.delete(k),
+  });
+});
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true;
+  };
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+  vi.mocked(invoke).mockReset();
+  currentProject.setProject(mockProject);
+  currentProject.setCurrentChapter(mockChapters[0]);
+});
+afterEach(async () => {
+  cleanup();
+  await session.flush();
+  await proseSaves.discard(proseSaves.draftsForRecovery(mockProject.id));
+  currentProject.setProject(null);
+  ui.setExpandedBeat(null);
+  vi.restoreAllMocks();
+});
+it.each(["page", "beat"] as const)(
+  "flushes pending %s prose before review and publishes accepted prose back to its editor",
+  async (mode) => {
+    const scene = {
+      ...mockScenes[0],
+      chapter_id: mockChapters[0].id,
+      prose: "<p>Old prose.</p>",
+      editor_mode: mode,
+      planning_status: "fixed" as const,
+    };
+    const beat = {
+      id: "review-beat",
+      scene_id: scene.id,
+      content: "Beat",
+      prose: "<p>Old prose.</p>",
+      position: 0,
+    };
+    currentProject.setCurrentScene(scene);
+    currentProject.setBeats([beat]);
+    if (mode === "beat") ui.setExpandedBeat(beat.id);
+    let releaseSave!: () => void;
+    let html = "<p>Old prose.</p>";
+    let saved: SceneReview;
+    vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+      if (cmd === "save_scene_page_prose" || cmd === "save_beat_prose") {
+        await new Promise<void>((r) => (releaseSave = r));
+        html = (args as { prose: string }).prose;
+      }
+      if (cmd === "get_scene_reference_items") return {};
+      if (cmd === "get_scene_review") {
+        const id = mode === "page" ? scene.id : beat.id;
+        saved = {
+          scene_id: scene.id,
+          version: 0,
+          mode,
+          documents: [
+            { id: scene.id, label: "Scene page", html: mode === "page" ? html : scene.prose },
+            { id: beat.id, label: "Beat 1", html: mode === "beat" ? html : beat.prose },
+          ],
+          data: {
+            status: "editor_review",
+            drafts: [],
+            annotations: [
+              {
+                id: "change",
+                document_id: id,
+                anchor_html: html,
+                from: 1,
+                to: 7,
+                quote: "Newest",
+                replacement: "Reviewed",
+                state: "open",
+                messages: [],
+              },
+            ],
+          },
+        };
+        return structuredClone(saved);
+      }
+      if (cmd === "save_scene_review") {
+        const input = args as { next: SceneReview; data: SceneReview["data"] };
+        saved = {
+          ...saved!,
+          documents: input.next.documents,
+          mode: input.next.mode,
+          data: input.data,
+          version: 1,
+        };
+        return structuredClone(saved);
+      }
+      return [];
+    });
+    render(ScenePanel);
+    await waitFor(() => expect(document.querySelector(".tiptap")).not.toBeNull());
+    await tick();
+    // NovelEditor enables change notifications on its first timer turn.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const editor = (document.querySelector(".tiptap") as HTMLElement & { editor: Editor }).editor;
+    editor.commands.setContent("<p>Newest prose.</p>");
+    await fireEvent.click(screen.getByText("Revisions"));
+    await waitFor(() => expect(releaseSave).toBeTypeOf("function"));
+    expect(vi.mocked(invoke).mock.calls.some(([cmd]) => cmd === "get_scene_review")).toBe(false);
+    releaseSave();
+    await screen.findByText("1 pending changes");
+    await fireEvent.click(screen.getByText("Accept all"));
+    await waitFor(() =>
+      expect(
+        mode === "page" ? currentProject.currentScene?.prose : currentProject.beats[0].prose
+      ).toBe("<p>Reviewed prose.</p>")
+    );
+    await fireEvent.click(screen.getByText("Close"));
+    await waitFor(() =>
+      expect(
+        (document.querySelector(".tiptap") as HTMLElement & { editor: Editor }).editor.getText()
+      ).toBe("Reviewed prose.")
+    );
+  }
+);

--- a/src/lib/utils/revisions.test.ts
+++ b/src/lib/utils/revisions.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import {
+  acceptSuggestions,
+  activeDocuments,
+  diffText,
+  draftOf,
+  isAnchored,
+  parseReviewHtml,
+  type Annotation,
+  type SceneReview,
+} from "./revisions";
+
+function fixture(): SceneReview {
+  return {
+    scene_id: "scene",
+    version: 0,
+    mode: "page",
+    documents: [
+      { id: "scene", label: "Scene page", html: "<p>The <em>red</em> fox ran.</p>" },
+      { id: "beat", label: "Beat 1", html: "<p>Other prose.</p>" },
+    ],
+    data: { status: "first_draft", drafts: [], annotations: [] },
+  };
+}
+function annotation(
+  review: SceneReview,
+  from = 5,
+  to = 8,
+  replacement: string | null = "blue",
+  id = "a"
+): Annotation {
+  return {
+    id,
+    document_id: "scene",
+    from,
+    to,
+    quote: parseReviewHtml(review.documents[0].html).textBetween(from, to, "\n"),
+    anchor_html: review.documents[0].html,
+    replacement,
+    state: "open",
+    messages: [],
+  };
+}
+describe("editorial suggestions", () => {
+  it("preserves formatting and a recoverable original draft, remapping disjoint comments", () => {
+    const review = fixture();
+    const a = annotation(review);
+    const comment = annotation(review, 9, 12, null, "comment");
+    review.data.annotations = [a, comment];
+    const { data, next } = acceptSuggestions(review, ["a"]);
+    expect(next.documents[0].html).toContain("<em>blue</em>");
+    expect(next.documents[1]).toEqual(review.documents[1]);
+    expect(data.annotations[0].state).toBe("accepted");
+    expect(data.annotations[1].from).toBe(10);
+    expect(isAnchored(data.annotations[1], next.documents)).toBe(true);
+    expect(data.drafts[0].documents).toEqual(review.documents);
+    expect(review.data.annotations[0].state).toBe("open");
+    expect(data.status).toBe("revised");
+  });
+  it("accepts adjacent ranges together and keeps adjacent anchors valid individually", () => {
+    const review = fixture();
+    review.data.annotations = [annotation(review, 1, 4, "A"), annotation(review, 4, 8, "", "b")];
+    const batch = acceptSuggestions(review, ["a", "b"]);
+    expect(parseReviewHtml(batch.next.documents[0].html).textContent).toBe("A fox ran.");
+    const first = acceptSuggestions(review, ["a"]);
+    expect(isAnchored(first.data.annotations[1], first.next.documents)).toBe(true);
+    const second = acceptSuggestions(
+      { ...review, documents: first.next.documents, data: first.data },
+      ["b"]
+    );
+    expect(second.next.documents).toEqual(batch.next.documents);
+    review.data.annotations = [annotation(review, 1, 1, "A"), annotation(review, 1, 4, "", "b")];
+    expect(() => acceptSuggestions(review, ["a", "b"])).toThrow("overlap");
+  });
+  it("inserts literal text, deletes ranges, and handles Unicode positions", () => {
+    const review = fixture();
+    review.data.annotations = [annotation(review, 1, 1, "<b>🌲 & </b>")];
+    const inserted = acceptSuggestions(review, ["a"]);
+    expect(inserted.next.documents[0].html).toContain("&lt;b&gt;🌲 &amp; &lt;/b&gt;");
+    review.documents[0].html = "<p>🌲 café!</p>";
+    review.data.annotations = [annotation(review, 1, 4, "")];
+    expect(acceptSuggestions(review, ["a"]).next.documents[0].html).toBe("<p>café!</p>");
+  });
+  it("applies disjoint batches in reverse order and rejects overlapping or stale batches atomically", () => {
+    const review = fixture();
+    review.data.annotations = [annotation(review), annotation(review, 9, 12, "wolf", "b")];
+    const result = acceptSuggestions(review, ["a", "b"]);
+    expect(result.next.documents[0].html).toContain("wolf ran.");
+    expect(result.data.annotations.every((a) => a.state === "accepted")).toBe(true);
+    review.data.annotations[1] = annotation(review, 5, 12, "wolf", "b");
+    expect(() => acceptSuggestions(review, ["a", "b"])).toThrow("overlap");
+    review.documents[0].html = "<p>Someone edited this</p>";
+    expect(() => acceptSuggestions(review, ["a"])).toThrow("Prose changed");
+    expect(review.data.drafts).toHaveLength(0);
+  });
+  it("leaves overlapping annotations outdated and ignores resolved or unrelated anchors", () => {
+    const review = fixture();
+    const overlap = annotation(review, 5, 8, null, "overlap");
+    const closed = { ...annotation(review, 9, 12, null, "closed"), state: "resolved" as const };
+    const stale = { ...annotation(review, 9, 12, null, "stale"), anchor_html: "old" };
+    review.data.annotations = [annotation(review), overlap, closed, stale];
+    const result = acceptSuggestions(review, ["a"]);
+    expect(isAnchored(result.data.annotations[1], result.next.documents)).toBe(false);
+    expect(result.data.annotations[2]).toEqual(closed);
+    expect(result.data.annotations[3]).toEqual(stale);
+  });
+  it("validates missing, closed and non-suggestion IDs and invalid range anchors", () => {
+    const review = fixture();
+    expect(() => acceptSuggestions(review, ["missing"])).toThrow("no longer open");
+    review.data.annotations = [annotation(review, 1, 2, null)];
+    expect(() => acceptSuggestions(review, ["a"])).toThrow("no longer open");
+    review.data.annotations[0].replacement = "X";
+    review.data.annotations[0].state = "rejected";
+    expect(() => acceptSuggestions(review, ["a"])).toThrow("no longer open");
+    const a = annotation(review);
+    expect(isAnchored(a, [])).toBe(false);
+    expect(isAnchored({ ...a, from: 0 }, review.documents)).toBe(false);
+    expect(isAnchored({ ...a, to: 1 }, review.documents)).toBe(false);
+    expect(isAnchored({ ...a, to: 500 }, review.documents)).toBe(false);
+    expect(isAnchored({ ...a, quote: "wrong" }, review.documents)).toBe(false);
+  });
+  it("selects the active prose mode while drafts retain both modes independently", () => {
+    const review = fixture();
+    expect(activeDocuments(review).map((d) => d.id)).toEqual(["scene"]);
+    review.mode = "beat";
+    expect(activeDocuments(review).map((d) => d.id)).toEqual(["beat"]);
+    const draft = draftOf(review, "  First draft  ");
+    review.documents[0].html = "changed";
+    expect(draft.name).toBe("First draft");
+    expect(draft.documents[0].html).not.toBe("changed");
+    review.documents = [review.documents[0]];
+    expect(activeDocuments(review).map((d) => d.id)).toEqual(["scene"]);
+  });
+});
+describe("draft comparison", () => {
+  it("shows insertions, deletions and shared words with whitespace intact", () => {
+    expect(diffText("The red fox.", "The blue fox.")).toEqual([
+      { kind: "same", text: "The " },
+      { kind: "delete", text: "red" },
+      { kind: "insert", text: "blue" },
+      { kind: "same", text: " fox." },
+    ]);
+    expect(diffText("", "")).toEqual([]);
+    expect(diffText("", "one two")).toEqual([{ kind: "insert", text: "one two" }]);
+    expect(diffText("one two", "")).toEqual([{ kind: "delete", text: "one two" }]);
+    expect(diffText("same", "same")).toEqual([{ kind: "same", text: "same" }]);
+  });
+  it("bounds memory for long scenes while reconstructing both originals exactly", () => {
+    for (const [before, after] of [
+      ["a ".repeat(600) + "old end", "a ".repeat(600) + "new end"],
+      ["a ".repeat(600), "b ".repeat(600)],
+      ["same ".repeat(600), "same ".repeat(600)],
+    ]) {
+      const parts = diffText(before, after);
+      expect(
+        parts
+          .filter((p) => p.kind !== "insert")
+          .map((p) => p.text)
+          .join("")
+      ).toBe(before);
+      expect(
+        parts
+          .filter((p) => p.kind !== "delete")
+          .map((p) => p.text)
+          .join("")
+      ).toBe(after);
+    }
+  });
+});
+
+it("shows separated edits precisely in long scenes and reconstructs insertions and deletions", () => {
+  const words = Array.from({ length: 2000 }, (_, i) => `word${i}`);
+  const before = words.join(" ");
+  const changed = [...words];
+  changed[100] = "red";
+  changed[1500] = "blue";
+  const parts = diffText(before, changed.join(" "));
+  expect(parts.filter((p) => p.kind === "delete").map((p) => p.text)).toEqual([
+    "word100",
+    "word1500",
+  ]);
+  expect(parts.filter((p) => p.kind === "insert").map((p) => p.text)).toEqual(["red", "blue"]);
+  for (const [a, b] of [
+    [before, "new " + before],
+    ["new " + before, before],
+    [before, before + " end"],
+    [before + " end", before],
+  ]) {
+    const diff = diffText(a, b);
+    expect(
+      diff
+        .filter((p) => p.kind !== "insert")
+        .map((p) => p.text)
+        .join("")
+    ).toBe(a);
+    expect(
+      diff
+        .filter((p) => p.kind !== "delete")
+        .map((p) => p.text)
+        .join("")
+    ).toBe(b);
+  }
+});
+
+it("keeps ordinary editorial passes precise past 256 token edits", () => {
+  const words = Array.from({ length: 1500 }, (_, i) => `word${i}`);
+  const revised = words.map((word, i) => (i % 10 === 0 ? `edited${i}` : word));
+  const parts = diffText(words.join(" "), revised.join(" "));
+  expect(parts.filter((p) => p.kind === "delete")).toHaveLength(150);
+  expect(parts.filter((p) => p.kind === "insert")).toHaveLength(150);
+  expect(parts.filter((p) => p.kind === "delete").every((p) => !p.text.includes(" "))).toBe(true);
+  const removed = diffText(
+    words.join(" "),
+    [...words.slice(0, 500), ...words.slice(630)].join(" ")
+  );
+  expect(removed.filter((p) => p.kind === "insert")).toEqual([]);
+  expect(
+    removed
+      .filter((p) => p.kind === "delete")
+      .map((p) => p.text)
+      .join("")
+      .trim()
+      .split(" ")
+  ).toHaveLength(130);
+});

--- a/src/lib/utils/revisions.ts
+++ b/src/lib/utils/revisions.ts
@@ -1,0 +1,274 @@
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import TextAlign from "@tiptap/extension-text-align";
+import { DOMParser as ProseParser, DOMSerializer } from "@tiptap/pm/model";
+import { Transform } from "@tiptap/pm/transform";
+import type { EditorMode } from "../types";
+
+export const reviewExtensions = [
+  StarterKit.configure({
+    heading: false,
+    bulletList: false,
+    orderedList: false,
+    listItem: false,
+    codeBlock: false,
+    horizontalRule: false,
+  }),
+  TextAlign.configure({ types: ["paragraph"] }),
+];
+const schema = getSchema(reviewExtensions);
+export interface ReviewDocument {
+  id: string;
+  label: string;
+  html: string;
+}
+export interface ReviewDraft {
+  name: string;
+  created_at: string;
+  mode: EditorMode;
+  documents: ReviewDocument[];
+}
+export interface ReviewMessage {
+  author: string;
+  text: string;
+  created_at: string;
+}
+export interface Annotation {
+  id: string;
+  document_id: string;
+  anchor_html: string;
+  from: number;
+  to: number;
+  quote: string;
+  replacement: string | null;
+  state: "open" | "resolved" | "accepted" | "rejected";
+  messages: ReviewMessage[];
+}
+export interface ReviewData {
+  status: string;
+  drafts: ReviewDraft[];
+  annotations: Annotation[];
+}
+export interface SceneReview {
+  scene_id: string;
+  version: number;
+  mode: EditorMode;
+  documents: ReviewDocument[];
+  data: ReviewData;
+}
+export interface RevisionOverview {
+  scene_id: string;
+  title: string;
+  chapter: string;
+  status: string;
+  drafts: number;
+}
+export const revisionStatuses = {
+  first_draft: "First Draft",
+  editor_review: "Editor Review",
+  revised: "Revised",
+  final: "Final",
+};
+
+export function parseReviewHtml(html: string) {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  return ProseParser.fromSchema(schema).parse(root);
+}
+
+export function draftOf(review: SceneReview, name: string): ReviewDraft {
+  return {
+    name: name.trim(),
+    created_at: new Date().toISOString(),
+    mode: review.mode,
+    documents: structuredClone(review.documents),
+  };
+}
+
+export function activeDocuments(review: Pick<SceneReview, "scene_id" | "mode" | "documents">) {
+  return review.mode === "page" || review.documents.length === 1
+    ? review.documents.filter((d) => d.id === review.scene_id)
+    : review.documents.filter((d) => d.id !== review.scene_id);
+}
+
+export function isAnchored(
+  annotation: Annotation,
+  documents: ReviewDocument[],
+  parsedDocument?: ReturnType<typeof parseReviewHtml>
+) {
+  const doc = documents.find((d) => d.id === annotation.document_id);
+  if (!doc || doc.html !== annotation.anchor_html) return false;
+  const parsed = parsedDocument ?? parseReviewHtml(doc.html);
+  return (
+    annotation.from >= 1 &&
+    annotation.to >= annotation.from &&
+    annotation.to < parsed.content.size &&
+    parsed.textBetween(annotation.from, annotation.to, "\n") === annotation.quote
+  );
+}
+
+/** Nonempty ranges are half-open. Cursor insertions at a shared edge are
+ * intentionally reviewed individually because their ordering is ambiguous. */
+function overlaps(a: Annotation, b: Annotation) {
+  if (a.from === a.to || b.from === b.to) return a.from <= b.to && b.from <= a.to;
+  return a.from < b.to && b.from < a.to;
+}
+
+/** Apply against exact source HTML. Remap disjoint anchors; invalidate overlaps
+ * instead of ever applying an edit to text the editor did not review. */
+export function acceptSuggestions(
+  review: SceneReview,
+  ids: string[]
+): { data: ReviewData; next: ReviewDraft } {
+  const data: ReviewData = structuredClone(review.data);
+  const next = draftOf(review, "Accepted editorial changes");
+  const targets = ids.map((id) => {
+    const a = data.annotations.find((a) => a.id === id);
+    if (!a || a.state !== "open" || a.replacement === null)
+      throw new Error("Suggestion is no longer open");
+    return a;
+  });
+  // Fail the whole batch for overlaps or outdated anchors; never partially accept all.
+  for (let i = 0; i < targets.length; i++) {
+    const a = targets[i];
+    if (!isAnchored(a, next.documents))
+      throw new Error("Prose changed. Re-anchor outdated suggestions before accepting them.");
+    for (const b of targets.slice(i + 1)) {
+      if (a.document_id === b.document_id && overlaps(a, b))
+        throw new Error("Suggestions overlap. Review and accept them individually.");
+    }
+  }
+  for (const a of targets.sort((a, b) => b.from - a.from)) {
+    const doc = next.documents.find((d) => d.id === a.document_id)!;
+    const oldHtml = doc.html;
+    const parsed = parseReviewHtml(oldHtml);
+    const tr = new Transform(parsed);
+    if (a.replacement)
+      tr.replaceWith(
+        a.from,
+        a.to,
+        schema.text(
+          a.replacement,
+          (a.from < a.to ? parsed.nodeAt(a.from)?.marks : undefined) ??
+            parsed.resolve(a.from).marks()
+        )
+      );
+    else tr.delete(a.from, a.to);
+    const container = document.createElement("div");
+    container.append(DOMSerializer.fromSchema(schema).serializeFragment(tr.doc.content));
+    doc.html = container.innerHTML;
+    a.state = "accepted";
+    for (const other of data.annotations) {
+      if (
+        other === a ||
+        other.state !== "open" ||
+        other.document_id !== doc.id ||
+        other.anchor_html !== oldHtml
+      )
+        continue;
+      if (overlaps(other, a)) continue; // Retain old HTML to flag outdated.
+      other.from = tr.mapping.map(other.from, 1);
+      other.to = tr.mapping.map(other.to, -1);
+      other.anchor_html = doc.html;
+    }
+  }
+  data.drafts.push(draftOf(review, "Before accepting changes"));
+  data.status = "revised";
+  return { data, next };
+}
+
+export interface DiffPart {
+  kind: "same" | "insert" | "delete";
+  text: string;
+}
+/** Myers diff bounds work by edit distance, so a few edits in a long scene
+ * remain precise. Very heavily rewritten scenes use the coarse fallback. */
+function sparseDiff(a: string[], b: string[]): DiffPart[] | null {
+  const frontier = new Map<number, number>([[1, 0]]);
+  const trace: Map<number, number>[] = [];
+  for (let depth = 0; depth <= Math.min(a.length + b.length, 1024); depth++) {
+    trace.push(new Map(frontier));
+    for (let k = -depth; k <= depth; k += 2) {
+      let x =
+        k === -depth || (k !== depth && frontier.get(k - 1)! < frontier.get(k + 1)!)
+          ? frontier.get(k + 1)!
+          : frontier.get(k - 1)! + 1;
+      let y = x - k;
+      while (x < a.length && y < b.length && a[x] === b[y]) {
+        x++;
+        y++;
+      }
+      frontier.set(k, x);
+      if (x < a.length || y < b.length) continue;
+      const reversed: DiffPart[] = [];
+      for (let d = trace.length - 1; d >= 0; d--) {
+        const v = trace[d],
+          diagonal = x - y;
+        const previousK =
+          diagonal === -d || (diagonal !== d && v.get(diagonal - 1)! < v.get(diagonal + 1)!)
+            ? diagonal + 1
+            : diagonal - 1;
+        const previousX = v.get(previousK)!,
+          previousY = previousX - previousK;
+        while (x > previousX && y > previousY) {
+          reversed.push({ kind: "same", text: a[--x] });
+          y--;
+        }
+        if (d === 0) break;
+        if (x === previousX) reversed.push({ kind: "insert", text: b[--y] });
+        else reversed.push({ kind: "delete", text: a[--x] });
+      }
+      return reversed.reverse();
+    }
+  }
+  return null;
+}
+
+/** Word diff with bounded memory. Scenes with more than 1024 changed tokens
+ * and a large comparison retain common edges and show the middle as a replacement. */
+export function diffText(before: string, after: string): DiffPart[] {
+  const a = before.match(/\s+|[^\s]+/gu) ?? [];
+  const b = after.match(/\s+|[^\s]+/gu) ?? [];
+  const parts: DiffPart[] = [];
+  const add = (kind: DiffPart["kind"], text: string) => {
+    if (!text) return;
+    if (parts[parts.length - 1]?.kind === kind) parts[parts.length - 1].text += text;
+    else parts.push({ kind, text });
+  };
+  if (a.length * b.length > 1_000_000) {
+    const precise = sparseDiff(a, b);
+    if (precise) {
+      for (const part of precise) add(part.kind, part.text);
+      return parts;
+    }
+    let start = 0,
+      end = 0;
+    while (start < Math.min(a.length, b.length) && a[start] === b[start]) start++;
+    while (
+      end < Math.min(a.length, b.length) - start &&
+      a[a.length - end - 1] === b[b.length - end - 1]
+    )
+      end++;
+    add("same", a.slice(0, start).join(""));
+    add("delete", a.slice(start, a.length - end).join(""));
+    add("insert", b.slice(start, b.length - end).join(""));
+    add("same", a.slice(a.length - end).join(""));
+    return parts;
+  }
+  const rows = Array.from({ length: a.length + 1 }, () => new Uint32Array(b.length + 1));
+  for (let i = a.length - 1; i >= 0; i--)
+    for (let j = b.length - 1; j >= 0; j--)
+      rows[i][j] =
+        a[i] === b[j] ? rows[i + 1][j + 1] + 1 : Math.max(rows[i + 1][j], rows[i][j + 1]);
+  let i = 0,
+    j = 0;
+  while (i < a.length || j < b.length) {
+    if (i < a.length && j < b.length && a[i] === b[j]) {
+      add("same", a[i++]);
+      j++;
+    } else if (j < b.length && (i === a.length || rows[i][j + 1] > rows[i + 1][j]))
+      add("insert", b[j++]);
+    else add("delete", a[i++]);
+  }
+  return parts;
+}


### PR DESCRIPTION
## Summary

Writers can now keep numbered, named scene drafts and work through editorial feedback inside Kindling. **Revisions** provides text comparisons between drafts, inline comment threads, insertion/deletion/replacement suggestions, individual or bulk accept/reject, and a scene-status overview. Restoring prose or accepting suggestions preserves the current prose as another draft first.

The initial workflow is offline and local: writers and editors take turns on the same project. Drafts retain both page and beat prose plus the editor mode. Prose updates and decisions commit together with stale-write and lock checks; changed beat structures block restoration but remain comparable. Disjoint annotations follow accepted edits; outdated or overlapping anchors require explicit review. New project snapshots include editorial history and remap anchors when restored as a new project.

## Related Issues

Closes #242.

Verified unrelated bug filed separately: #285 (same-second snapshot filename collision).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the Contributing Guidelines
- [x] Code follows the project’s style
- [x] Added regression tests
- [x] All frontend and Rust tests pass locally
- [x] Updated user documentation
- [x] Relevant labels applied

## Validation and review

- Frontend: **463 tests passed**; coverage **99.53% statements / 97.08% branches / 99.59% functions / 99.86% lines**.
- Rust: **442 tests passed** with all features.
- `npm run check:all`, production frontend build, and `git diff --check` passed. Svelte reports six existing warnings in unrelated files.
- Real Tauri IPC/DOM smoke tests: beat and page suggestions, comments/replies/resolve/reopen, named drafts, preservation on accept/restore, stale-write and locked-scene rejection, and snapshot Create New with remapped anchors. Disposable projects and preferences restored afterward.
- Light/dark computed-style checks passed. Desktop capture produced a black image, so screenshot verification was unavailable.
- Independent review-agent: no remaining findings after fixes for adjacent ranges, navigation, selection provenance, long-scene comparisons, and inactive-mode suggestions.
- Claude `code-review` at **high** effort: no remaining findings after focused follow-ups (session `01f0f468-13b1-4ade-aa08-5722c83b905e`).

## Testing Instructions

1. Open a scene and choose **Revisions → Draft history**. Save a named draft, edit the scene, save another, and compare both directions. Restore the first and verify the newer prose remains in history.
2. In **Editorial review**, select text and add a comment; reply, resolve, and reopen it. Suggest a deletion/replacement, and insert text at a cursor position. Step through changes and accept/reject individually or in bulk.
3. Repeat in page mode and beat mode. Try adjacent suggestions, overlapping suggestions, and comments whose prose has changed. Outdated anchors require re-anchoring before acceptance.
4. Set revision statuses and inspect **All scenes**. Confirm locked scenes remain read-only and a newly created project snapshot retains drafts and comments after restore.
