### PR TITLE
feat(editor): show previous scene context while writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ cd src-tauri && cargo test
 npm run check:all
 ```
 
+## Previous scene context
+
+The **Previously** section at the top of a scene shows the preceding scene's title,
+synopsis, and last three sentences of prose (or all available prose if shorter).
+It follows manuscript order across chapters, skips archived scenes and chapters,
+and reads the active Beat or Page view. Outline prompts are never used as prose.
+The first scene has no Previously section. Collapse it to save space; Kindling
+remembers that preference across scenes and app restarts.
+
 ## Writing goals and statistics
 
 The sidebar shows saved word counts for the project, chapters and scenes. The editor

--- a/qa/previously/acceptance.md
+++ b/qa/previously/acceptance.md
@@ -1,0 +1,49 @@
+# Previous scene summary — issue #66
+
+Base: `36aab52a6fd63ab4c896f7e3241fb62caf24f4cd` (latest main at branch creation).
+
+| Criterion                              | Implementation                                                                      | Validation                                                                                                |
+| -------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Collapsible Previously at top of scene | `Previously.svelte`, mounted above scene header                                     | Component tests; native desktop inspection                                                                |
+| Predecessor title and synopsis         | Position-ordered chapter/scene traversal; retains pending synopsis                  | Same/cross-chapter tests, including save completion and cleared synopsis; native cross-chapter inspection |
+| Closing 2–3 prose sentences            | Last three sentence segments; active Page or ordered Beat prose; no outline prompts | HTML/entities/dialogue/empty/short prose tests; native Beat and Page fixtures                             |
+| Remember collapsed state               | `kindling:previouslyCollapsed` localStorage preference                              | Navigation/remount tests; native navigation and webview reload                                            |
+| Hide when no predecessor               | First scene/missing selection return no summary                                     | Component/helper tests; native first-scene inspection                                                     |
+
+Additional regressions cover archived/empty chapters, stale navigation responses,
+load failures/retry, pending prose saves, delayed viewport restoration, and
+refresh after Find/Replace, editorial apply, or draft discard. No new IPC commands, dependencies, or schema changes.
+
+## Automated validation
+
+- Focused suite: 35 tests passed.
+- Full frontend suite with coverage: 560 tests passed in 41 files; statements
+  98.56%, branches 94.11%, functions 98.61%, lines 99.13% (all gates passed).
+- `npm run check:all` passed: Press sync, types, formatting, ESLint, Rust formatting
+  and all-target/all-feature Clippy. Existing Svelte/ESLint warnings remain.
+- `npm run build` passed; existing bundle-size warning remains.
+
+## Native inspection
+
+Ran the real Tauri debug app on macOS with a disposable database at
+`/tmp/kindling-issue66-data` and an isolated application identifier
+`com.kindling.issue66qa`. Imported `test-data/simple-story.pltr` and seeded only
+that disposable project through existing IPC commands.
+
+Verified a Beat excerpt in Discovery, a Page excerpt from Discovery while viewing
+Turning Point in the next chapter, synopsis-only context with no prose, collapse
+across navigation, and collapse persistence after webview reload/reopening the
+project. Inspected the rendered UI and screenshots in both themes. Computed
+reading styles: Newsreader, 17px, 576px maximum width; light ink `rgb(35,29,24)`
+and dark ink `rgb(232,224,212)`.
+
+Read-failure/retry and delayed-response races are covered by automated tests;
+those failure scenarios were not established in the native runtime. Native
+WebDriver E2E is unsupported on macOS.
+
+Light and dark screenshots were inspected inline before the machine locked.
+Later attempts to save screenshots returned black frames, so no screenshot files
+are included as evidence.
+
+The fixture project was deleted through IPC after inspection, saved preferences
+were restored, and the isolated debug app was stopped.

--- a/qa/previously/acceptance.md
+++ b/qa/previously/acceptance.md
@@ -47,3 +47,15 @@ are included as evidence.
 
 The fixture project was deleted through IPC after inspection, saved preferences
 were restored, and the isolated debug app was stopped.
+
+## Toolbar layout follow-up
+
+Previously and Revisions now share one compact, left-aligned Scene tools row.
+The summary expands beneath it; the separate rows and dividing rules are removed.
+Revisions remains available for the first scene, during loading, and on errors.
+
+Validated against the running native app in light/collapsed and dark/expanded
+states. Both controls share the same y-coordinate and 32px height, use Inter,
+and have no borders. Inspected both screenshots and restored the original theme
+and collapse preference. The 19 existing Previously/SceneRevisions component
+tests, type check, ESLint, and production build passed.

--- a/src/lib/components/Previously.svelte
+++ b/src/lib/components/Previously.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import { ChevronDown } from "lucide-svelte";
+  import { currentProject } from "../stores/project.svelte";
+  import { synopsisSaves } from "../stores/synopsisSaves.svelte";
+  import { loadPreviousScene } from "../utils/previousScene";
+
+  let {
+    refreshVersion = 0,
+    loading = $bindable(true),
+  }: { refreshVersion?: number; loading?: boolean } = $props();
+
+  const storageKey = "kindling:previouslyCollapsed";
+  let collapsed = $state(localStorage.getItem(storageKey) === "true");
+  let previous = $state<Awaited<ReturnType<typeof loadPreviousScene>>>(null);
+  let error = $state(false);
+  let retry = $state(0);
+  const synopsis = $derived.by(() => {
+    if (!previous) return null;
+    const draft = synopsisSaves.getState(currentProject.value?.id, previous.scene.id).draft;
+    const scene = currentProject.scenes.find((item) => item.id === previous?.scene.id);
+    return draft ? draft.synopsis : (scene ?? previous.scene).synopsis;
+  });
+  const title = $derived(
+    currentProject.scenes.find((item) => item.id === previous?.scene.id)?.title ??
+      previous?.scene.title
+  );
+  // Observe navigation and outline structure, without refetching on each prose edit.
+  const target = $derived(
+    JSON.stringify([
+      currentProject.value?.id,
+      currentProject.currentScene?.id,
+      currentProject.currentScene?.chapter_id,
+      currentProject.chapters.map((chapter) => [chapter.id, chapter.position, chapter.archived]),
+      currentProject.scenes.map((scene) => [scene.id, scene.position, scene.archived]),
+      retry,
+      refreshVersion,
+    ])
+  );
+  $effect(() => {
+    void target;
+    let cancelled = false;
+    previous = null;
+    error = false;
+    loading = true;
+    // Let ScenePanel/BeatView submit their navigation saves first.
+    void tick().then(async () => {
+      if (cancelled) return;
+      const project = currentProject.value;
+      const scene = currentProject.currentScene;
+      if (!project || !scene) {
+        loading = false;
+        return;
+      }
+      try {
+        const result = await loadPreviousScene(project.id, scene, currentProject.chapters);
+        if (!cancelled) previous = result;
+      } catch {
+        if (!cancelled) error = true;
+      } finally {
+        if (!cancelled) loading = false;
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  function toggle() {
+    collapsed = !collapsed;
+    localStorage.setItem(storageKey, String(collapsed));
+  }
+</script>
+
+{#if previous}
+  <section
+    aria-label="Previously"
+    aria-busy={loading}
+    data-testid="previously"
+    class="border-b border-press-border py-4 mb-6"
+  >
+    <button
+      type="button"
+      onclick={toggle}
+      aria-expanded={!collapsed}
+      aria-controls="previously-content"
+      class="flex items-center gap-2 text-press-ui font-press-ui text-press-muted hover:text-press-text"
+    >
+      <ChevronDown
+        class={collapsed ? "w-4 h-4 -rotate-90" : "w-4 h-4"}
+        strokeWidth={1}
+        aria-hidden="true"
+      />
+      Previously
+    </button>
+    {#if !collapsed}
+      <div id="previously-content" class="mt-3 space-y-3">
+        <h2 class="font-heading text-press-h3 text-press-text break-words">{title}</h2>
+        {#if synopsis}
+          <p
+            class="font-prose text-press-body text-press-text max-w-press-measure whitespace-pre-wrap break-words"
+          >
+            {synopsis}
+          </p>
+        {/if}
+        {#if previous.excerpt}
+          <blockquote
+            class="font-prose text-press-body text-press-text max-w-press-measure border-l border-press-border pl-4 break-words"
+          >
+            {previous.excerpt}
+          </blockquote>
+        {/if}
+      </div>
+    {/if}
+  </section>
+{:else if error}
+  <p role="status" class="py-4 text-press-ui text-press-muted">
+    Could not load previous scene context.
+    <button type="button" onclick={() => retry++} class="underline text-press-text">Retry</button>
+  </p>
+{/if}

--- a/src/lib/components/Previously.svelte
+++ b/src/lib/components/Previously.svelte
@@ -111,7 +111,7 @@
         {/if}
         {#if previous.excerpt}
           <blockquote
-            class="font-prose text-press-body text-press-text max-w-press-measure break-words"
+            class="font-prose text-press-body text-press-text max-w-press-measure italic break-words"
           >
             {previous.excerpt}
           </blockquote>

--- a/src/lib/components/Previously.svelte
+++ b/src/lib/components/Previously.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-  import { tick } from "svelte";
+  import { tick, type Snippet } from "svelte";
   import { ChevronDown } from "lucide-svelte";
   import { currentProject } from "../stores/project.svelte";
   import { synopsisSaves } from "../stores/synopsisSaves.svelte";
   import { loadPreviousScene } from "../utils/previousScene";
 
   let {
+    actions,
     refreshVersion = 0,
     loading = $bindable(true),
-  }: { refreshVersion?: number; loading?: boolean } = $props();
+  }: { actions?: Snippet; refreshVersion?: number; loading?: boolean } = $props();
 
   const storageKey = "kindling:previouslyCollapsed";
   let collapsed = $state(localStorage.getItem(storageKey) === "true");
@@ -72,29 +73,34 @@
   }
 </script>
 
-{#if previous}
-  <section
-    aria-label="Previously"
-    aria-busy={loading}
-    data-testid="previously"
-    class="border-b border-press-border py-4 mb-6"
-  >
-    <button
-      type="button"
-      onclick={toggle}
-      aria-expanded={!collapsed}
-      aria-controls="previously-content"
-      class="flex items-center gap-2 text-press-ui font-press-ui text-press-muted hover:text-press-text"
-    >
-      <ChevronDown
-        class={collapsed ? "w-4 h-4 -rotate-90" : "w-4 h-4"}
-        strokeWidth={1}
-        aria-hidden="true"
-      />
-      Previously
-    </button>
-    {#if !collapsed}
-      <div id="previously-content" class="mt-3 space-y-3">
+{#if previous || actions || error}
+  <div class="mb-6" aria-busy={loading}>
+    <div class="flex flex-wrap items-center gap-x-6 gap-y-2" role="group" aria-label="Scene tools">
+      {#if previous}
+        <button
+          type="button"
+          onclick={toggle}
+          aria-expanded={!collapsed}
+          aria-controls="previously-content"
+          class="flex items-center gap-2 py-1 text-press-ui font-press-ui text-press-muted hover:text-press-text"
+        >
+          <ChevronDown
+            class={collapsed ? "w-4 h-4 -rotate-90" : "w-4 h-4"}
+            strokeWidth={1}
+            aria-hidden="true"
+          />
+          Previously
+        </button>
+      {/if}
+      {@render actions?.()}
+    </div>
+    {#if previous && !collapsed}
+      <section
+        id="previously-content"
+        aria-label="Previously"
+        data-testid="previously"
+        class="mt-4 space-y-3"
+      >
         <h2 class="font-heading text-press-h3 text-press-text break-words">{title}</h2>
         {#if synopsis}
           <p
@@ -105,17 +111,19 @@
         {/if}
         {#if previous.excerpt}
           <blockquote
-            class="font-prose text-press-body text-press-text max-w-press-measure border-l border-press-border pl-4 break-words"
+            class="font-prose text-press-body text-press-text max-w-press-measure break-words"
           >
             {previous.excerpt}
           </blockquote>
         {/if}
-      </div>
+      </section>
+    {:else if error}
+      <p role="status" class="mt-3 text-press-ui text-press-muted">
+        Could not load previous scene context.
+        <button type="button" onclick={() => retry++} class="underline text-press-text"
+          >Retry</button
+        >
+      </p>
     {/if}
-  </section>
-{:else if error}
-  <p role="status" class="py-4 text-press-ui text-press-muted">
-    Could not load previous scene context.
-    <button type="button" onclick={() => retry++} class="underline text-press-text">Retry</button>
-  </p>
+  </div>
 {/if}

--- a/src/lib/components/Previously.test.ts
+++ b/src/lib/components/Previously.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { invoke } from "@tauri-apps/api/core";
+import Previously from "./Previously.svelte";
+import ScenePanel from "./ScenePanel.svelte";
+import { session } from "../stores/session.svelte";
+import type { SceneReview } from "../utils/revisions";
+import { currentProject } from "../stores/project.svelte";
+import { synopsisSaves } from "../stores/synopsisSaves.svelte";
+import { mockProject, mockChapters, mockScenes } from "../../dev/mock-data";
+import type { Scene } from "../types";
+vi.hoisted(() => {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, value),
+    removeItem: (key: string) => data.delete(key),
+  });
+});
+const chapter = mockChapters[0];
+const previous: Scene = {
+  ...mockScenes[0],
+  id: "previous",
+  chapter_id: chapter.id,
+  title: "A prior scene",
+  synopsis: "The bridge collapsed.",
+  prose: "<p>One. Two. Three. Four.</p>",
+  position: 0,
+  editor_mode: "page",
+};
+const current = { ...previous, id: "current", title: "Current scene", position: 1 };
+beforeEach(() => {
+  localStorage.removeItem("kindling:previouslyCollapsed");
+  currentProject.setProject(mockProject);
+  currentProject.setChapters([chapter]);
+  currentProject.setScenes([previous, current]);
+  currentProject.setCurrentScene(current);
+  vi.mocked(invoke).mockImplementation(async (cmd) =>
+    cmd === "get_scenes" ? currentProject.scenes : []
+  );
+});
+afterEach(async () => {
+  cleanup();
+  await synopsisSaves.discardAll(synopsisSaves.snapshot());
+  currentProject.setProject(null);
+  vi.restoreAllMocks();
+});
+it("shows title, synopsis and closing prose in an accessible disclosure", async () => {
+  render(Previously);
+  const button = await screen.findByRole("button", { name: "Previously" });
+  expect(button.getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByRole("heading", { name: previous.title })).toBeTruthy();
+  expect(screen.getByText(previous.synopsis!)).toBeTruthy();
+  expect(screen.getByText("Two. Three. Four.").tagName).toBe("BLOCKQUOTE");
+});
+it("remembers collapse across navigation and remount, and allows expansion", async () => {
+  const view = render(Previously);
+  await fireEvent.click(await screen.findByRole("button", { name: "Previously" }));
+  expect(screen.queryByText(previous.title)).toBeNull();
+  expect(localStorage.getItem("kindling:previouslyCollapsed")).toBe("true");
+  currentProject.setCurrentScene(previous);
+  await tick();
+  expect(screen.queryByRole("button", { name: "Previously" })).toBeNull();
+  currentProject.setCurrentScene(current);
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Previously" }).getAttribute("aria-expanded")).toBe(
+      "false"
+    )
+  );
+  view.unmount();
+  render(Previously);
+  await fireEvent.click(await screen.findByRole("button", { name: "Previously" }));
+  expect(screen.getByText(previous.title)).toBeTruthy();
+  expect(localStorage.getItem("kindling:previouslyCollapsed")).toBe("false");
+});
+it("hides for the first scene and when nothing is selected", async () => {
+  currentProject.setCurrentScene(previous);
+  render(Previously);
+  await tick();
+  expect(screen.queryByRole("region")).toBeNull();
+  currentProject.setCurrentScene(null);
+  await tick();
+  expect(screen.queryByRole("region")).toBeNull();
+});
+it("keeps title-only summaries and renders synopsis as text", async () => {
+  currentProject.setScenes([{ ...previous, synopsis: null, prose: null }, current]);
+  render(Previously);
+  await screen.findByText(previous.title);
+  expect(document.querySelector("blockquote")).toBeNull();
+  currentProject.updateSceneSynopsis(previous.id, "<img src=x onerror=alert(1)>");
+  await screen.findByText("<img src=x onerror=alert(1)>");
+  expect(document.querySelector("img")).toBeNull();
+});
+it("reflects pending synopsis drafts and title updates", async () => {
+  render(Previously);
+  await screen.findByText(previous.title);
+  synopsisSaves.stage({
+    projectId: mockProject.id,
+    sceneId: previous.id,
+    synopsis: "Newest synopsis",
+  });
+  currentProject.updateScene(previous.id, { title: "Renamed scene" });
+  await screen.findByText("Newest synopsis");
+  expect(screen.getByText("Renamed scene")).toBeTruthy();
+});
+it("recomputes after scene reordering", async () => {
+  render(Previously);
+  await screen.findByText(previous.title);
+  currentProject.reorderScenes([current.id, previous.id]);
+  await waitFor(() => expect(screen.queryByRole("region")).toBeNull());
+});
+it("ignores stale responses on rapid navigation, including failures", async () => {
+  let reject!: (error: Error) => void;
+  vi.mocked(invoke).mockImplementationOnce(
+    () =>
+      new Promise((_resolve, fail) => {
+        reject = fail;
+      })
+  );
+  render(Previously);
+  await waitFor(() => expect(reject).toBeTypeOf("function"));
+  currentProject.setCurrentScene(previous);
+  await tick();
+  reject(new Error("Late failure"));
+  await tick();
+  expect(screen.queryByRole("region")).toBeNull();
+  expect(screen.queryByRole("status")).toBeNull();
+});
+it("discards a successful response belonging to the old project", async () => {
+  let resolve!: (scenes: Scene[]) => void;
+  vi.mocked(invoke).mockImplementationOnce(
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      })
+  );
+  render(Previously);
+  await waitFor(() => expect(resolve).toBeTypeOf("function"));
+  currentProject.setProject(null);
+  await tick();
+  resolve([previous, current]);
+  await tick();
+  expect(screen.queryByRole("region")).toBeNull();
+});
+it("offers a retry after a read failure without showing stale context", async () => {
+  vi.mocked(invoke).mockRejectedValueOnce(new Error("Read failed"));
+  render(Previously);
+  await screen.findByRole("status");
+  expect(screen.queryByRole("region")).toBeNull();
+  await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await screen.findByText(previous.title);
+  expect(screen.queryByRole("status")).toBeNull();
+});
+
+it.each(["Newest cross-chapter synopsis", null])(
+  "retains a pending synopsis (%s) after saving across chapters",
+  async (synopsis) => {
+    const nextChapter = { ...chapter, id: "next-chapter", position: chapter.position + 1 };
+    const selected = { ...current, chapter_id: nextChapter.id, position: 0 };
+    currentProject.setChapters([chapter, nextChapter]);
+    currentProject.setScenes([selected]);
+    currentProject.setCurrentScene(selected);
+    let releaseSave!: () => void;
+    vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+      if (cmd === "get_scenes")
+        return (args as { chapterId: string }).chapterId === chapter.id ? [previous] : [selected];
+      if (cmd === "save_scene_synopsis")
+        await new Promise<void>((done) => {
+          releaseSave = done;
+        });
+      return [];
+    });
+    synopsisSaves.stage({ projectId: mockProject.id, sceneId: previous.id, synopsis });
+    const saving = synopsisSaves.flush(mockProject.id, previous.id);
+    render(Previously);
+    await screen.findByText(previous.title);
+    expect(screen.queryByText(previous.synopsis!)).toBeNull();
+    if (synopsis) expect(screen.getByText(synopsis)).toBeTruthy();
+    releaseSave();
+    await saving;
+    await tick();
+    expect(screen.queryByText(previous.synopsis!)).toBeNull();
+    if (synopsis) expect(screen.getByText(synopsis)).toBeTruthy();
+  }
+);
+
+it("reloads changed prose on explicit refresh without navigation", async () => {
+  const view = render(Previously);
+  await screen.findByText("Two. Three. Four.");
+  vi.mocked(invoke).mockResolvedValue([{ ...previous, prose: "Replacement ending." }, current]);
+  await view.rerender({ refreshVersion: 1 });
+  await screen.findByText("Replacement ending.");
+  expect(screen.queryByText("Two. Three. Four.")).toBeNull();
+});
+
+it.each(["replacement", "discard", "editorial"])(
+  "refreshes predecessor prose when ScenePanel applies %s",
+  async (operation) => {
+    const view = render(ScenePanel);
+    await screen.findByText("Two. Three. Four.");
+    vi.mocked(invoke).mockImplementation(async (cmd) =>
+      cmd === "get_scenes" ? [{ ...previous, prose: "Refreshed ending." }, current] : []
+    );
+    if (operation === "replacement")
+      view.component.applySearchChanges([{ id: previous.id, prose: "Refreshed ending." }]);
+    else if (operation === "discard") await view.component.discardFailedSaves([]);
+    else
+      view.component.applyRevision({
+        scene_id: current.id,
+        mode: "page",
+        documents: [{ id: current.id, html: current.prose }],
+        data: {},
+      } as SceneReview);
+    await screen.findByText("Refreshed ending.");
+    expect(screen.queryByText("Two. Three. Four.")).toBeNull();
+  }
+);
+
+it.each(["success", "failure"])(
+  "waits for previous context %s before restoring the saved viewport",
+  async (outcome) => {
+    let finish!: () => void;
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "get_scenes") {
+        await new Promise<void>((done) => {
+          finish = done;
+        });
+        if (outcome === "failure") throw new Error("Context read failed");
+        return [previous, current];
+      }
+      return [];
+    });
+    session.restoreViewport(mockProject.id, current.id, 250);
+    const view = render(ScenePanel);
+    const scroll = view.getByTestId("scene-panel").firstElementChild as HTMLElement;
+    await waitFor(() => expect(finish).toBeTypeOf("function"));
+    // Allow the one-shot restore's animation frame to run if it was scheduled early.
+    await new Promise<void>((done) => requestAnimationFrame(() => done()));
+    expect(scroll.scrollTop).toBe(0);
+    finish();
+    await waitFor(() => expect(scroll.scrollTop).toBe(250));
+    if (outcome === "success") expect(screen.getByText("Two. Three. Four.")).toBeTruthy();
+    else expect(screen.getByText(/Could not load previous scene context/)).toBeTruthy();
+  }
+);

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -6,6 +6,7 @@
   import Previously from "./Previously.svelte";
   import {
     FileText,
+    History,
     ChevronDown,
     Loader2,
     Plus,
@@ -793,15 +794,19 @@
     {@const projectId = currentProject.value.id}
     <div use:trackSceneScroll={{ projectId, sceneId: scene.id }} class="flex-1 overflow-y-auto">
       <div class="max-w-3xl mx-auto p-8">
-        <Previously refreshVersion={previousSceneVersion} bind:loading={previousSceneLoading} />
-        <div class="flex justify-end border-b border-press-border px-4 py-2">
-          <button
-            disabled={openingRevisions}
-            onclick={openRevisions}
-            class="text-press-ui text-press-text"
-            >{openingRevisions ? "Opening revisions…" : "Revisions"}</button
-          >
-        </div>
+        <Previously refreshVersion={previousSceneVersion} bind:loading={previousSceneLoading}>
+          {#snippet actions()}
+            <button
+              type="button"
+              disabled={openingRevisions}
+              onclick={openRevisions}
+              class="flex items-center gap-2 py-1 text-press-ui font-press-ui text-press-muted hover:text-press-text"
+            >
+              <History class="w-4 h-4" strokeWidth={1} aria-hidden="true" />
+              {openingRevisions ? "Opening revisions…" : "Revisions"}
+            </button>
+          {/snippet}
+        </Previously>
         <!-- Scene Title -->
         <header class="mb-8">
           <div class="flex items-center gap-3 flex-wrap">

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -3,6 +3,7 @@
   import { writing } from "../stores/writing.svelte";
   import type { SceneReview } from "../utils/revisions";
   import WritingStatusBar from "./WritingStatusBar.svelte";
+  import Previously from "./Previously.svelte";
   import {
     FileText,
     ChevronDown,
@@ -57,6 +58,8 @@
     ) => Promise<void>;
   } = $props();
   let openingRevisions = $state(false);
+  let previousSceneVersion = $state(0);
+  let previousSceneLoading = $state(true);
   let revisionEditorVersion = $state(0);
   async function openRevisions() {
     const scene = currentProject.currentScene;
@@ -90,6 +93,7 @@
     }
   }
   export function applyRevision(review: SceneReview) {
+    previousSceneVersion++;
     if (currentProject.currentScene?.id !== review.scene_id) return;
     const prose = review.documents.find((d) => d.id === review.scene_id)?.html ?? "";
     currentProject.updateScene(review.scene_id, { prose, editor_mode: review.mode });
@@ -407,7 +411,8 @@
       request.projectId !== currentProject.value?.id ||
       request.sceneId !== currentProject.currentScene?.id ||
       discoveryNotesLoading ||
-      sceneReferenceLoading
+      sceneReferenceLoading ||
+      previousSceneLoading
     )
       return;
     return untrack(() =>
@@ -713,9 +718,11 @@
       }
     }
     pageProseSaveStatus = "idle";
+    previousSceneVersion++;
   }
 
   export function applySearchChanges(changes: Pick<ProseReplacement, "id" | "prose">[]) {
+    previousSceneVersion++;
     void writing.refresh(currentProject.value?.id);
     for (const change of changes) {
       currentProject.updateBeatProse(change.id, change.prose);
@@ -786,6 +793,7 @@
     {@const projectId = currentProject.value.id}
     <div use:trackSceneScroll={{ projectId, sceneId: scene.id }} class="flex-1 overflow-y-auto">
       <div class="max-w-3xl mx-auto p-8">
+        <Previously refreshVersion={previousSceneVersion} bind:loading={previousSceneLoading} />
         <div class="flex justify-end border-b border-press-border px-4 py-2">
           <button
             disabled={openingRevisions}

--- a/src/lib/utils/previousScene.test.ts
+++ b/src/lib/utils/previousScene.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { mockChapters, mockScenes } from "../../dev/mock-data";
+import type { Beat, Scene } from "../types";
+import { closingProse, loadPreviousScene } from "./previousScene";
+import { proseSaves } from "./proseSaves";
+
+const chapter = { ...mockChapters[0], id: "chapter", position: 0 };
+const previous: Scene = {
+  ...mockScenes[0],
+  id: "previous",
+  chapter_id: chapter.id,
+  position: 0,
+  prose: "<p>Page ending.</p>",
+  editor_mode: "page",
+};
+const current: Scene = { ...previous, id: "current", position: 1 };
+let scenes: Scene[];
+let beats: Beat[];
+beforeEach(() => {
+  scenes = [current, previous];
+  beats = [];
+  vi.mocked(invoke).mockImplementation(async (cmd, args) => {
+    if (cmd === "get_scenes")
+      return scenes.filter(
+        (scene) => scene.chapter_id === (args as { chapterId: string }).chapterId
+      );
+    if (cmd === "get_beats") return beats;
+    throw new Error(`Unexpected command: ${cmd}`);
+  });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("closingProse", () => {
+  it.each([
+    ["", ""],
+    ["<p><br></p>", ""],
+    ["<p>Just a fragment</p>", "Just a fragment"],
+    ["<p>One. Two.</p><p>Three! Four?</p>", "Two. Three! Four?"],
+    [
+      "<p>Old.</p><p>She <em>waited</em>. &ldquo;Go!&rdquo; He left</p>",
+      "She waited. “Go!” He left",
+    ],
+    ["<script>Bad.</script><style>Bad.</style><p>A &amp; B.</p>", "A & B."],
+    ["<p>First.</p><p>Next<br>line. Last.</p>", "First. Next line. Last."],
+    ["<p>一。二。三。四。</p>", "二。三。四。"],
+    ['<img src="https://invalid.test/pixel"><p>Only prose.</p>', "Only prose."],
+  ])("extracts inert closing text from %s", (html, expected) =>
+    expect(closingProse(html)).toBe(expected)
+  );
+  it("supports webviews without Intl.Segmenter", () => {
+    vi.spyOn(Intl, "Segmenter", "get").mockReturnValue(undefined as never);
+    expect(closingProse("One. Two! Three? Four")).toBe("Two! Three? Four");
+  });
+});
+
+it("finds the previous scene in position order, without mutating input", async () => {
+  expect(await loadPreviousScene("project", current, [chapter])).toEqual({
+    scene: previous,
+    excerpt: "Page ending.",
+  });
+  expect(scenes[0]).toBe(current);
+});
+it("has no previous scene for the first scene or a missing selection/chapter", async () => {
+  expect(await loadPreviousScene("project", previous, [chapter])).toBeNull();
+  expect(await loadPreviousScene("project", { ...current, id: "missing" }, [chapter])).toBeNull();
+  expect(await loadPreviousScene("project", current, [])).toBeNull();
+});
+it("crosses empty chapters and skips archived chapters/scenes", async () => {
+  const second = { ...chapter, id: "empty", position: 1 };
+  const third = { ...chapter, id: "third", position: 3 };
+  const archived = { ...chapter, id: "archived", position: 2, archived: true };
+  const selected = { ...current, chapter_id: third.id, position: 0 };
+  scenes = [previous, { ...previous, id: "hidden", position: 1, archived: true }, selected];
+  expect(
+    (await loadPreviousScene("project", selected, [third, archived, second, chapter]))?.scene.id
+  ).toBe(previous.id);
+  expect(vi.mocked(invoke).mock.calls).not.toContainEqual([
+    "get_scenes",
+    { chapterId: archived.id },
+  ]);
+});
+it("reads ordered beat prose, ignoring cached page prose and outline prompts", async () => {
+  scenes = [{ ...previous, editor_mode: "beat" }, current];
+  beats = [
+    {
+      id: "last",
+      scene_id: previous.id,
+      content: "Not prose",
+      prose: "<p>Three. Four.</p>",
+      position: 2,
+    },
+    { id: "empty", scene_id: previous.id, content: "Not prose", prose: null, position: 1 },
+    {
+      id: "first",
+      scene_id: previous.id,
+      content: "Not prose",
+      prose: "<p>One. Two.</p>",
+      position: 0,
+    },
+  ];
+  expect((await loadPreviousScene("project", current, [chapter]))?.excerpt).toBe(
+    "Two. Three. Four."
+  );
+});
+it("uses scene prose in beat mode only when there are no beats", async () => {
+  scenes = [{ ...previous, editor_mode: "beat" }, current];
+  expect((await loadPreviousScene("project", current, [chapter]))?.excerpt).toBe("Page ending.");
+  beats = [{ id: "empty", scene_id: previous.id, content: "Prompt", prose: null, position: 0 }];
+  expect((await loadPreviousScene("project", current, [chapter]))?.excerpt).toBe("");
+});
+it("uses pending page prose even when it finishes saving during the read", async () => {
+  vi.spyOn(proseSaves, "draftsForRecovery")
+    .mockReturnValueOnce([
+      { projectId: "project", kind: "page", id: previous.id, prose: "Fresh page." },
+    ])
+    .mockReturnValue([]);
+  expect((await loadPreviousScene("project", current, [chapter]))?.excerpt).toBe("Fresh page.");
+});
+it("uses latest pending beat prose after the read", async () => {
+  scenes = [{ ...previous, editor_mode: "beat" }, current];
+  beats = [{ id: "beat", scene_id: previous.id, content: "Prompt", prose: "Old.", position: 0 }];
+  vi.spyOn(proseSaves, "draftsForRecovery")
+    .mockReturnValueOnce([])
+    .mockReturnValue([{ projectId: "project", kind: "beat", id: "beat", prose: "Latest." }]);
+  expect((await loadPreviousScene("project", current, [chapter]))?.excerpt).toBe("Latest.");
+});
+it("propagates load failures for the retry UI", async () => {
+  vi.mocked(invoke).mockRejectedValue(new Error("database unavailable"));
+  await expect(loadPreviousScene("project", current, [chapter])).rejects.toThrow(
+    "database unavailable"
+  );
+});

--- a/src/lib/utils/previousScene.ts
+++ b/src/lib/utils/previousScene.ts
@@ -1,0 +1,73 @@
+/// <reference lib="es2022.intl" />
+import { invoke } from "@tauri-apps/api/core";
+import type { Beat, Chapter, Scene } from "../types";
+import { proseSaves } from "./proseSaves";
+import { synopsisSaves } from "../stores/synopsisSaves.svelte";
+
+/** Keep only the closing three sentences, with HTML decoded into inert text. */
+export function closingProse(html: string): string {
+  // Parse in an inert template: imported images must not trigger requests just
+  // because a writer opens the next scene. Never mount or return this markup.
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  const root = template.content;
+  for (const node of root.querySelectorAll("script, style")) node.remove();
+  for (const node of root.querySelectorAll(
+    "p, div, blockquote, h1, h2, h3, h4, h5, h6, li, br, hr, pre"
+  )) {
+    node.before(" ");
+    node.after(" ");
+  }
+  const text = (root.textContent ?? "").replace(/\s+/gu, " ").trim();
+  if (!text) return "";
+  const sentences =
+    typeof Intl.Segmenter === "function"
+      ? Array.from(
+          new Intl.Segmenter(undefined, { granularity: "sentence" }).segment(text),
+          (part) => part.segment
+        )
+      : (text.match(/[^.!?。！？]+(?:[.!?。！？]+["'”’)]*|$)\s*/gu) ?? [text]);
+  return sentences.slice(-3).join("").trim();
+}
+
+/** Walk manuscript order backwards, including across empty chapters. */
+export async function loadPreviousScene(projectId: string, scene: Scene, chapters: Chapter[]) {
+  const synopsisDrafts = synopsisSaves.snapshot().filter((draft) => draft.projectId === projectId);
+  const drafts = new Map(
+    proseSaves.draftsForRecovery(projectId).map((draft) => [draft.id, draft.prose])
+  );
+  const ordered = chapters
+    .filter((chapter) => !chapter.archived)
+    .sort((a, b) => a.position - b.position);
+  const chapterIndex = ordered.findIndex((chapter) => chapter.id === scene.chapter_id);
+  for (let index = chapterIndex; index >= 0; index--) {
+    const scenes = (await invoke<Scene[]>("get_scenes", { chapterId: ordered[index].id }))
+      .filter((item) => !item.archived)
+      .sort((a, b) => a.position - b.position);
+    const sceneIndex =
+      index === chapterIndex ? scenes.findIndex((item) => item.id === scene.id) : scenes.length;
+    // A deleted/moved selection must not accidentally point at another chapter's ending.
+    if (index === chapterIndex && sceneIndex < 0) return null;
+    const previous = scenes[sceneIndex - 1];
+    if (!previous) continue;
+    // Navigation submits editor saves before this read. Capture drafts on both sides
+    // of the IPC read so an in-flight save cannot make the excerpt stale.
+    let documents: { id: string; prose: string | null }[] = [previous];
+    if (previous.editor_mode !== "page") {
+      const beats = await invoke<Beat[]>("get_beats", { sceneId: previous.id });
+      if (beats.length) documents = [...beats].sort((a, b) => a.position - b.position);
+    }
+    for (const draft of proseSaves.draftsForRecovery(projectId)) drafts.set(draft.id, draft.prose);
+    const html = documents.map((doc) => drafts.get(doc.id) ?? doc.prose ?? "").join("\n");
+    // Retain a draft even if its save completed during the read. The old chapter
+    // may no longer be in the project store when the save queue publishes it.
+    const synopsisDraft =
+      synopsisSaves.getState(projectId, previous.id).draft ??
+      synopsisDrafts.find((draft) => draft.sceneId === previous.id);
+    return {
+      scene: synopsisDraft ? { ...previous, synopsis: synopsisDraft.synopsis } : previous,
+      excerpt: closingProse(html),
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Writers can now see the preceding scene's title, synopsis, and closing three prose sentences in a collapsible **Previously** section above the scene editor. It follows manuscript order across chapters, uses the active Beat/Page prose, hides for the first scene, and remembers collapse across app restarts.

Previously and Revisions share one compact, left-aligned row without dividing rules. Expanding Previously reveals the summary beneath the controls; quoted prose uses italics to distinguish it from the synopsis.

The summary preserves pending edits and refreshes after Find/Replace, undo, and draft discard. No dependencies, schema changes, or new IPC commands.

## Related Issues

Closes #66

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing frontend tests pass locally
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Testing Instructions

1. Confirm Previously and Revisions share one row with no dividing rules. Open a project with multiple scenes and select the second scene. Confirm Previously shows the first scene's title, synopsis, and closing prose.
2. Select the first scene of the next chapter; confirm context crosses the chapter boundary. Check Page and Beat predecessors, and a predecessor with no prose.
3. Collapse Previously, switch scenes, then restart/reopen the project. Confirm it stays collapsed; expand it again. The first scene should have no summary.
4. Replace text in the predecessor using project Find/Replace and undo it; confirm the excerpt refreshes without navigating away.

## Validation and Review

See [acceptance evidence](qa/previously/acceptance.md) for the criterion matrix and native smoke-test scope.

- 560 frontend tests passed; all coverage gates passed.
- `npm run check:all` and `npm run build` passed.
- Native macOS Tauri smoke checks used a disposable database; light/dark screenshots and computed styles inspected.
- Existing Svelte/ESLint and bundle-size warnings remain. Native WebDriver E2E is unsupported on macOS; delayed/error paths are covered by automated tests.
- Independent `review-agent`: **No findings** on final code.
- Claude `code-review:code-review` at **high** effort: **No remaining actionable findings** after focused follow-up (session `f24ffd81-3234-40a3-b3bd-12401fc04ed8`). Findings fixed with regression coverage.
- Normal pre-commit, commit-message, and pre-push hooks passed; UI follow-up commits `2b1349c` and `f0636e9`; both reviewers also cleared this layout follow-up.
