### PR TITLE
feat(ui): show a loading overlay from app startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Or grab the latest directly from the [Releases page](https://github.com/smith-an
 
 ## Features
 
+On launch, a theme-matched loading indicator appears while the interface starts.
+It respects your system's reduced-motion setting and disappears as soon as the
+interface is rendered, without adding a startup delay.
+
 | Feature | Description |
 |---------|-------------|
 | **Import from popular tools** | Scrivener 3 (`.scriv`), Plottr (`.pltr`), Markdown (`.md`), yWriter (`.yw7`), and Longform/Obsidian |

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Or grab the latest directly from the [Releases page](https://github.com/smith-an
 
 ## Features
 
-On launch, a theme-matched loading indicator appears while the interface starts.
-It respects your system's reduced-motion setting and disappears as soon as the
-interface is rendered, without adding a startup delay.
+On launch, the window opens with a theme-matched loading overlay before the main
+interface loads. It respects your system's reduced-motion setting and stays until
+initial content, fonts and images are ready and the interface has had a chance to
+paint. There is no minimum display timer.
 
 | Feature | Description |
 |---------|-------------|

--- a/index.html
+++ b/index.html
@@ -18,11 +18,12 @@
     </script>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app" inert aria-busy="true"></div>
     <div id="startup-loading" role="status" aria-live="polite">
       <span class="startup-spinner" aria-hidden="true"></span>
-      <span>Starting Kindling…</span>
+      <span id="startup-message">Starting Kindling…</span>
+      <button id="startup-retry" type="button" hidden>Try again</button>
     </div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/startup.ts"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kindling</title>
+    <!-- Render startup feedback before the application module is available. -->
+    <link rel="stylesheet" href="/src/startup.css" />
     <script>
       // Apply theme before first paint to prevent flash
       (function () {
@@ -17,6 +19,10 @@
   </head>
   <body>
     <div id="app"></div>
+    <div id="startup-loading" role="status" aria-live="polite">
+      <span class="startup-spinner" aria-hidden="true"></span>
+      <span>Starting Kindling…</span>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "prepare": "git config core.hooksPath .githooks",
     "tauri:qa": "KINDLING_DATA_DIR=$PWD/qa/visual/data npm run tauri dev",
     "tauri:demo": "KINDLING_DATA_DIR=$PWD/qa/demo/data npm run tauri dev",
-    "seed:demo": "node qa/demo/seed.mjs"
+    "seed:demo": "node qa/demo/seed.mjs",
+    "test:startup": "node qa/visual/startup.mjs"
   },
   "license": "MIT",
   "dependencies": {

--- a/qa/visual/README.md
+++ b/qa/visual/README.md
@@ -261,3 +261,21 @@ covered once by `99-dark-sweep.md` and narrow widths by `98-narrow-sweep.md`;
 add a screen there only if it introduces a surface the sweeps do not show.
 When a control has no test id, add one in the component and list it in
 `e2e/README.md` rather than matching on text.
+
+## Startup overlay regression
+
+Run `npm run build && npm run test:startup` with a Playwright Chromium browser
+installed (`npx playwright install chromium`). To use an existing Chrome binary,
+set `PLAYWRIGHT_CHROMIUM_EXECUTABLE` to its executable path.
+
+The test serves production assets, withholds the application bundle and initial
+project response, and checks first paint before the bundle request, overlay
+stacking, disabled background interaction, light/dark/system themes, reduced
+motion, ready-state handoff, and retry after a failed bundle request. It uses an
+isolated browser context and a minimal IPC fixture; no project data is changed.
+Screenshots are saved under `qa/visual/results/startup/`.
+
+Also smoke-test a native cold launch: the first visible window should contain the
+loading overlay and then uncover the start screen (or a document opened at launch).
+Reload should not steal focus. Browsers provide rendering opportunities through
+animation frames, not a portable guarantee that pixels reached the display.

--- a/qa/visual/startup.mjs
+++ b/qa/visual/startup.mjs
@@ -1,0 +1,225 @@
+// Production startup regression: first paint precedes the app bundle, and the
+// overlay survives slow content loading. Native window visibility is checked in
+// the desktop smoke test; this harness supplies only the IPC needed by launch.
+import assert from "node:assert/strict";
+import { readFile, mkdir } from "node:fs/promises";
+import { createServer } from "node:http";
+import { resolve, extname } from "node:path";
+import { chromium } from "playwright";
+
+const root = resolve("dist");
+const output = resolve("qa/visual/results/startup");
+await mkdir(output, { recursive: true });
+const mime = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2",
+};
+const server = createServer(async (request, response) => {
+  const pathname = new URL(request.url, "http://localhost").pathname;
+  const file = resolve(root, `.${pathname === "/" ? "/index.html" : pathname}`);
+  if (!file.startsWith(`${root}/`)) {
+    response.writeHead(403).end();
+    return;
+  }
+  try {
+    const body = await readFile(file);
+    response
+      .writeHead(200, { "Content-Type": mime[extname(file)] || "application/octet-stream" })
+      .end(body);
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+await new Promise((done) => server.listen(0, "127.0.0.1", done));
+const url = `http://127.0.0.1:${server.address().port}`;
+let browser;
+try {
+  browser = await chromium.launch({ executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE });
+  async function pageFor(context, preference, holdProjects = true, review = null) {
+    const page = await context.newPage();
+    await page.addInitScript(
+      ({ preference, holdProjects, review }) => {
+        let filesTaken = false;
+        if (preference) localStorage.setItem("kindling:theme", preference);
+        localStorage.setItem("kindling:onboardingCompleted", "true");
+        localStorage.setItem("kindling:guidanceEnabled", "false");
+        window.isTauri = false;
+        window.__TAURI_INTERNALS__ = {
+          metadata: {
+            currentWindow: { label: "main" },
+            currentWebview: { label: "main", windowLabel: "main" },
+          },
+          transformCallback: () => 1,
+          invoke: async (command) => {
+            if (command === "get_recent_projects" && holdProjects)
+              return new Promise((resolve) => {
+                window.__releaseProjects = () => resolve([]);
+              });
+            if (command === "take_editorial_open_files" && review && !filesTaken) {
+              filesTaken = true;
+              return ["/startup.kindling-review"];
+            }
+            if (command === "open_editorial_package") return review;
+            if (command === "plugin:event|listen") return 1;
+            if (command === "plugin:os|platform") return "macos";
+            return [];
+          },
+        };
+      },
+      { preference, holdProjects, review }
+    );
+    return page;
+  }
+  for (const [preference, scheme, motion] of [
+    [null, "light", "no-preference"],
+    ["dark", "light", "no-preference"],
+    ["system", "dark", "no-preference"],
+    ["system", "light", "no-preference"],
+    ["dark", "dark", "reduce"],
+  ]) {
+    const context = await browser.newContext({
+      viewport: { width: 1000, height: 700 },
+      colorScheme: scheme,
+      reducedMotion: motion,
+    });
+    const page = await pageFor(context, preference);
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    let releaseBundle;
+    const bundleGate = new Promise((done) => {
+      releaseBundle = done;
+    });
+    let mainRequestTime;
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("Network.enable");
+    cdp.on("Network.requestWillBeSent", (event) => {
+      if (/\/assets\/main-.*\.js$/.test(event.request.url)) mainRequestTime = event.wallTime * 1000;
+    });
+    await page.route("**/assets/main-*.js", async (route) => {
+      await bundleGate;
+      await route.continue();
+    });
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => performance.getEntriesByName("first-contentful-paint").length > 0
+    );
+    assert(await page.locator("#startup-loading").isVisible());
+    assert.equal(await page.locator("#app").innerHTML(), "");
+    const before = await page.evaluate(() => ({
+      theme: document.documentElement.dataset.theme,
+      bg: getComputedStyle(document.querySelector("#startup-loading")).backgroundColor,
+      animation: getComputedStyle(document.querySelector(".startup-spinner")).animationName,
+      transform: getComputedStyle(document.querySelector(".startup-spinner")).transform,
+      firstPaint: performance.getEntriesByName("first-contentful-paint")[0].startTime,
+      origin: performance.timeOrigin,
+    }));
+    const expected = preference === "system" ? scheme : preference || "light";
+    assert.equal(before.theme, expected);
+    assert.equal(before.bg, expected === "dark" ? "rgb(30, 26, 22)" : "rgb(244, 239, 230)");
+    await page.waitForTimeout(150);
+    const transform = await page
+      .locator(".startup-spinner")
+      .evaluate((el) => getComputedStyle(el).transform);
+    if (motion === "reduce") assert.equal(before.animation, "none");
+    else {
+      assert.equal(before.animation, "startup-spin");
+      assert.notEqual(before.transform, transform);
+    }
+    await page.screenshot({ path: `${output}/${preference || "default"}-${scheme}-${motion}.png` });
+    releaseBundle();
+    await page.waitForFunction(() => typeof window.__releaseProjects === "function");
+    assert(await page.locator("#startup-loading").isVisible());
+    assert(await page.locator("#app").evaluate((el) => el.inert));
+    assert(
+      await page.evaluate(
+        () =>
+          !!document.elementFromPoint(innerWidth / 2, innerHeight / 2).closest("#startup-loading")
+      )
+    );
+    await page.evaluate(() => window.__releaseProjects());
+    await page.locator("#startup-loading").waitFor({ state: "detached" });
+    assert.equal(await page.locator("#app").evaluate((el) => el.inert), false);
+    assert.equal(await page.locator("#app main").count(), 1);
+    assert.deepEqual(errors, []);
+    // Capture request creation, not the later network send after our route gate.
+    const bundleStart = mainRequestTime - before.origin;
+    assert(
+      before.firstPaint <= bundleStart,
+      `First paint ${before.firstPaint}ms must precede app request ${bundleStart}ms`
+    );
+    console.log(
+      JSON.stringify({
+        preference,
+        scheme,
+        motion,
+        firstPaint: before.firstPaint,
+        bundleStart,
+        pass: true,
+      })
+    );
+    await context.close();
+  }
+  const reviewContext = await browser.newContext();
+  const reviewPage = await pageFor(reviewContext, "light", false, {
+    format: "kindling-editorial",
+    version: 1,
+    kind: "review",
+    session: null,
+    round: {
+      id: "startup-round",
+      project_id: "startup-project",
+      title: "Startup review",
+      name: "First review",
+      brief: "Check keyboard focus",
+      created_at: "2026-09-10",
+      sources: [
+        {
+          id: "source",
+          scene_id: "scene",
+          chapter_id: "chapter",
+          chapter: "Chapter One",
+          scene: "The Letter",
+          mode: "page",
+          html: "<p>Eleanor opened the letter.</p>",
+          locked: false,
+        },
+      ],
+    },
+  });
+  await reviewPage.goto(url, { waitUntil: "domcontentloaded" });
+  await reviewPage.locator("#startup-loading").waitFor({ state: "detached" });
+  const workspace = reviewPage.getByRole("region", { name: "Editorial workspace" });
+  assert(await workspace.isVisible());
+  assert(await workspace.evaluate((el) => document.activeElement === el));
+  await reviewPage.keyboard.press("Control+f");
+  const search = reviewPage.getByRole("searchbox", { name: "Find in manuscript" });
+  await search.waitFor();
+  assert(await search.evaluate((el) => document.activeElement === el));
+  console.log("Document-open startup keyboard focus: pass");
+  await reviewContext.close();
+
+  const context = await browser.newContext();
+  const page = await pageFor(context, "light", false);
+  let fail = true;
+  await page.route("**/assets/main-*.js", (route) => {
+    if (fail) {
+      fail = false;
+      return route.abort();
+    }
+    return route.continue();
+  });
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.getByText("Kindling couldn’t start. Please try again.").waitFor();
+  assert.equal(await page.locator(".startup-spinner").isVisible(), false);
+  await page.getByRole("button", { name: "Try again" }).click();
+  await page.locator("#startup-loading").waitFor({ state: "detached" });
+  assert.equal(await page.locator("#app main").count(), 1);
+  console.log("Failed-bundle recovery: pass");
+  await context.close();
+} finally {
+  await browser?.close();
+  await new Promise((done) => server.close(done));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod models;
 pub mod parsers;
 
 use commands::AppState;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
 
 /// Returns `Some((key, value))` when the WebKitGTK DMABUF renderer workaround
@@ -84,7 +85,25 @@ pub fn run() {
         std::env::set_var(key, val);
     }
 
+    let initial_page_loaded = AtomicBool::new(false);
     let builder = tauri::Builder::default()
+        .on_page_load(move |webview, payload| {
+            // Show the small loading shell as soon as its document finishes
+            // loading, even if its JavaScript failed. The bootstrap waits for
+            // a visible frame before requesting the full application bundle.
+            // A reload must not steal focus or re-show a hidden window.
+            if webview.label() == "main"
+                && matches!(payload.event(), tauri::webview::PageLoadEvent::Finished)
+                && !initial_page_loaded.swap(true, Ordering::Relaxed)
+            {
+                let window = webview.window();
+                if let Err(error) = window.show() {
+                    eprintln!("Failed to show startup window: {error}");
+                } else if let Err(error) = window.set_focus() {
+                    eprintln!("Failed to focus startup window: {error}");
+                }
+            }
+        })
         .manage(editorial_files::PendingEditorialFiles::default())
         .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             editorial_files::enqueue(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,6 +13,7 @@
     "windows": [
       {
         "title": "Kindling",
+        "visible": false,
         "width": 1600,
         "height": 1000,
         "minWidth": 1360,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,8 +38,19 @@
   import type { ProseDocument } from "./lib/utils/proseSearch";
   import type { Project, ExportResult, Chapter, Scene, Beat } from "./lib/types";
 
+  let { onReady }: { onReady?: () => void } = $props();
+  let initialProjectsLoaded = $state(false);
+  let initialEditorialLoaded = $state(false);
+
+  $effect(() => {
+    if (initialProjectsLoaded && initialEditorialLoaded) onReady?.();
+  });
+
   let scenePanel: ReturnType<typeof ScenePanel> | undefined = $state();
   let editorial: ReturnType<typeof EditorialWorkspace> | undefined = $state();
+  export function focusAfterStartup() {
+    editorial?.focusIfOpen();
+  }
   let searchDialog: ReturnType<typeof FindReplaceDialog> | undefined = $state();
   let search = $state<{ projectId: string; scope: "scene" | "project"; replace: boolean } | null>(
     null
@@ -99,6 +110,8 @@
     } catch (e) {
       console.error("Failed to load recent projects:", e);
       recentProjects = [];
+    } finally {
+      initialProjectsLoaded = true;
     }
   }
 
@@ -677,6 +690,7 @@
 
   <EditorialWorkspace
     bind:this={editorial}
+    onReady={() => (initialEditorialLoaded = true)}
     prepareWriting={async () => {
       await scenePanel?.prepareForSearch();
       await proseSaves.flush();

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1102,3 +1102,62 @@ it.each(["sidebar", "menu", "keyboard"])(
     expect(within(editorial).getByRole("button", { name: "Return to writing" })).toBeTruthy();
   }
 );
+
+it.each(["projects", "editorial"])(
+  "waits for both initial content requests when %s finishes first",
+  async (first) => {
+    currentProject.setProject(null);
+    let projectsReady!: () => void;
+    let editorialReady!: () => void;
+    const projects = new Promise<never[]>((resolve) => (projectsReady = () => resolve([])));
+    const editorial = new Promise<never[]>((resolve) => (editorialReady = () => resolve([])));
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === "get_recent_projects") return projects;
+      if (command === "take_editorial_open_files") return editorial;
+      return [];
+    });
+    const onReady = vi.fn();
+    render(App, { onReady });
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("take_editorial_open_files"));
+    expect(onReady).not.toHaveBeenCalled();
+    (first === "projects" ? projectsReady : editorialReady)();
+    await tick();
+    expect(onReady).not.toHaveBeenCalled();
+    (first === "projects" ? editorialReady : projectsReady)();
+    await waitFor(() => expect(onReady).toHaveBeenCalledOnce());
+  }
+);
+
+it("settles startup even if initial content requests fail", async () => {
+  currentProject.setProject(null);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.mocked(invoke).mockRejectedValue(new Error("Database unavailable"));
+  const onReady = vi.fn();
+  render(App, { onReady });
+  await waitFor(() => expect(onReady).toHaveBeenCalledOnce());
+  expect(screen.getByText("Your projects will appear here")).toBeTruthy();
+});
+
+it("waits for a native file drain that starts before the listener handshake finishes", async () => {
+  currentProject.setProject(null);
+  let finish!: () => void;
+  const pending = new Promise<never[]>((resolve) => (finish = () => resolve([])));
+  vi.mocked(invoke).mockImplementation(async (command) =>
+    command === "take_editorial_open_files" ? pending : []
+  );
+  vi.mocked(listen).mockImplementation(async (event, callback) => {
+    if (event === "editorial-open") callback({ event, id: 1, payload: undefined });
+    return () => {};
+  });
+  try {
+    const onReady = vi.fn();
+    render(App, { onReady });
+    await tick();
+    expect(invoke).toHaveBeenCalledWith("take_editorial_open_files");
+    expect(onReady).not.toHaveBeenCalled();
+    finish();
+    await waitFor(() => expect(onReady).toHaveBeenCalledOnce());
+  } finally {
+    vi.mocked(listen).mockResolvedValue(() => {});
+  }
+});

--- a/src/lib/components/EditorialWorkspace.svelte
+++ b/src/lib/components/EditorialWorkspace.svelte
@@ -64,10 +64,12 @@
     prepareWriting,
     onManuscriptChanged,
     references,
+    onReady,
   }: {
     prepareWriting: () => Promise<void>;
     onManuscriptChanged: () => Promise<void>;
     references?: Snippet<[string]>;
+    onReady?: () => void;
   } = $props();
   let dialog: HTMLElement;
   let local = $state(false);
@@ -699,11 +701,14 @@
       void flush().catch(() => {});
     }, 350);
   }
+  export function focusIfOpen() {
+    if (active) dialog.focus();
+  }
   async function show() {
     const alreadyOpen = active;
     active = true;
     await tick();
-    if (!alreadyOpen) dialog.focus();
+    if (!alreadyOpen) focusIfOpen();
   }
   async function close() {
     try {
@@ -1165,6 +1170,10 @@
       if (drainAgain) {
         drainAgain = false;
         void drainFiles();
+      } else if (!incoming.length) {
+        // A native open event can begin draining before listen() resolves.
+        // Signal readiness only from the drain that actually emptied the queue.
+        onReady?.();
       }
     }
   }
@@ -1177,6 +1186,7 @@
       .then(() => drainFiles())
       .catch((e) => {
         error = String(e);
+        onReady?.();
       });
     return () => {
       clearTimeout(timer);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,62 +1,37 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import startupHtml from "../index.html?raw";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
-const { mount, tick, setupPluginListeners } = vi.hoisted(() => ({
-  mount: vi.fn(),
-  tick: vi.fn(),
-  setupPluginListeners: vi.fn().mockResolvedValue(undefined),
-}));
-
+const { mount, tick } = vi.hoisted(() => ({ mount: vi.fn(), tick: vi.fn() }));
 vi.mock("svelte", () => ({ mount, tick }));
 vi.mock("./App.svelte", () => ({ default: {} }));
-vi.mock("tauri-plugin-mcp", () => ({ setupPluginListeners }));
 vi.mock("./lib/stores/project.svelte", () => ({ currentProject: {} }));
 vi.mock("./lib/stores/ui.svelte", () => ({ ui: {} }));
 
-describe("startup loading screen", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    mount.mockReset();
-    tick.mockReset();
-    const page = new DOMParser().parseFromString(startupHtml, "text/html");
-    document.body.innerHTML = page.body.innerHTML;
-  });
+beforeEach(() => {
+  vi.resetModules();
+  mount.mockReset().mockReturnValue({ focusAfterStartup: vi.fn() });
+  tick.mockReset();
+  document.body.innerHTML = '<div id="app"></div><div id="startup-loading"></div>';
+});
+afterEach(() => {
+  document.body.innerHTML = "";
+  delete window.__KINDLING_TEST__;
+});
 
-  afterEach(() => {
-    document.body.innerHTML = "";
-    delete window.__KINDLING_TEST__;
-  });
-
-  it("shows accessible feedback before JavaScript mounts the app", () => {
-    const loader = document.getElementById("startup-loading")!;
-    expect(loader.getAttribute("role")).toBe("status");
-    expect(loader.textContent).toContain("Starting Kindling…");
-    expect(loader.querySelector(".startup-spinner")?.getAttribute("aria-hidden")).toBe("true");
-    expect(document.getElementById("app")!.contains(loader)).toBe(false);
-    expect(mount).not.toHaveBeenCalled();
-  });
-
-  it("keeps feedback until Svelte's first render completes, then removes it", async () => {
-    let rendered!: () => void;
-    tick.mockImplementation(() => new Promise<void>((resolve) => (rendered = resolve)));
-    mount.mockImplementation((_component: unknown, { target }: { target: HTMLElement }) => {
-      target.innerHTML = "<main>Ready to write</main>";
-    });
-
-    const startup = import("./main");
-    await vi.waitFor(() => expect(tick).toHaveBeenCalledOnce());
-    expect(document.getElementById("startup-loading")).not.toBeNull();
-    rendered();
-    await startup;
-
-    expect(document.getElementById("startup-loading")).toBeNull();
-    expect(document.querySelector("#app main")?.textContent).toBe("Ready to write");
-  });
-
-  it("also mounts when the loading element is absent", async () => {
-    document.getElementById("startup-loading")!.remove();
-    tick.mockResolvedValue(undefined);
-    await import("./main");
-    expect(mount).toHaveBeenCalledOnce();
-  });
+it("reports readiness only after the app's content hook and Svelte flush", async () => {
+  let flushed!: () => void;
+  tick.mockImplementation(() => new Promise<void>((resolve) => (flushed = resolve)));
+  const { ready } = await import("./main");
+  const completed = vi.fn();
+  void ready.then(completed);
+  expect(mount).toHaveBeenCalledOnce();
+  expect(tick).not.toHaveBeenCalled();
+  expect(window.__KINDLING_TEST__).toBeDefined();
+  mount.mock.calls[0][1].props.onReady();
+  await vi.waitFor(() => expect(tick).toHaveBeenCalledOnce());
+  expect(completed).not.toHaveBeenCalled();
+  flushed();
+  await ready;
+  expect(completed).toHaveBeenCalledOnce();
+  // Only the bootstrap may uncover the app after its paint opportunity.
+  expect(document.getElementById("startup-loading")).not.toBeNull();
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import startupHtml from "../index.html?raw";
+
+const { mount, tick, setupPluginListeners } = vi.hoisted(() => ({
+  mount: vi.fn(),
+  tick: vi.fn(),
+  setupPluginListeners: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("svelte", () => ({ mount, tick }));
+vi.mock("./App.svelte", () => ({ default: {} }));
+vi.mock("tauri-plugin-mcp", () => ({ setupPluginListeners }));
+vi.mock("./lib/stores/project.svelte", () => ({ currentProject: {} }));
+vi.mock("./lib/stores/ui.svelte", () => ({ ui: {} }));
+
+describe("startup loading screen", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mount.mockReset();
+    tick.mockReset();
+    const page = new DOMParser().parseFromString(startupHtml, "text/html");
+    document.body.innerHTML = page.body.innerHTML;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.__KINDLING_TEST__;
+  });
+
+  it("shows accessible feedback before JavaScript mounts the app", () => {
+    const loader = document.getElementById("startup-loading")!;
+    expect(loader.getAttribute("role")).toBe("status");
+    expect(loader.textContent).toContain("Starting Kindling…");
+    expect(loader.querySelector(".startup-spinner")?.getAttribute("aria-hidden")).toBe("true");
+    expect(document.getElementById("app")!.contains(loader)).toBe(false);
+    expect(mount).not.toHaveBeenCalled();
+  });
+
+  it("keeps feedback until Svelte's first render completes, then removes it", async () => {
+    let rendered!: () => void;
+    tick.mockImplementation(() => new Promise<void>((resolve) => (rendered = resolve)));
+    mount.mockImplementation((_component: unknown, { target }: { target: HTMLElement }) => {
+      target.innerHTML = "<main>Ready to write</main>";
+    });
+
+    const startup = import("./main");
+    await vi.waitFor(() => expect(tick).toHaveBeenCalledOnce());
+    expect(document.getElementById("startup-loading")).not.toBeNull();
+    rendered();
+    await startup;
+
+    expect(document.getElementById("startup-loading")).toBeNull();
+    expect(document.querySelector("#app main")?.textContent).toBe("Ready to write");
+  });
+
+  it("also mounts when the loading element is absent", async () => {
+    document.getElementById("startup-loading")!.remove();
+    tick.mockResolvedValue(undefined);
+    await import("./main");
+    expect(mount).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,3 @@
-// MCP plugin guest JS — must run before any framework mounts (dev only)
-if (import.meta.env.DEV) {
-  const { setupPluginListeners } = await import("tauri-plugin-mcp");
-  await setupPluginListeners();
-}
-
 import "./app.css";
 import App from "./App.svelte";
 import { mount } from "svelte";
@@ -13,14 +7,17 @@ import { currentProject } from "./lib/stores/project.svelte";
 import { ui } from "./lib/stores/ui.svelte";
 import type { Project, Chapter } from "./lib/types";
 
+let contentReady!: () => void;
+const initialContent = new Promise<void>((resolve) => (contentReady = resolve));
 const app = mount(App, {
   target: document.getElementById("app")!,
+  props: { onReady: contentReady },
 });
 
-// Keep the HTML loading screen through module loading and Svelte's first render.
-// It lives outside #app because mount appends rather than replacing its contents.
-await tick();
-document.getElementById("startup-loading")?.remove();
+// The bootstrap keeps its overlay until initial content has settled and Svelte
+// has flushed it, then waits for fonts, images and a paint opportunity.
+export const ready = initialContent.then(() => tick());
+export const focusAfterStartup = app.focusAfterStartup;
 
 import { IMPORT_COMMANDS, isImportType, type ImportType } from "./lib/importFormats";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,11 @@ const app = mount(App, {
   target: document.getElementById("app")!,
 });
 
+// Keep the HTML loading screen through module loading and Svelte's first render.
+// It lives outside #app because mount appends rather than replacing its contents.
+await tick();
+document.getElementById("startup-loading")?.remove();
+
 import { IMPORT_COMMANDS, isImportType, type ImportType } from "./lib/importFormats";
 
 // Expose Tauri invoke and store helpers for E2E testing

--- a/src/startup.css
+++ b/src/startup.css
@@ -1,0 +1,64 @@
+@import "./styles/press/tokens.css";
+
+/* This stylesheet is linked by index.html, independently of the JS bundle. */
+@font-face {
+  font-family: "Inter";
+  src: url("/fonts/Inter-Regular-latin.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+}
+
+#startup-loading {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-s);
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-family: var(--font-ui);
+  font-size: var(--text-small);
+  line-height: var(--leading);
+}
+
+#startup-loading::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--grain-tile);
+  opacity: var(--grain-strength);
+  pointer-events: none;
+}
+
+#startup-loading > span {
+  position: relative;
+}
+
+.startup-spinner {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: startup-spin 900ms linear infinite;
+}
+
+@keyframes startup-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .startup-spinner {
+    animation: none;
+  }
+}

--- a/src/startup.css
+++ b/src/startup.css
@@ -14,6 +14,11 @@ body {
   background: var(--color-bg);
 }
 
+/* Keep every app layer beneath the startup overlay while it renders. */
+#app[aria-busy="true"] {
+  isolation: isolate;
+}
+
 #startup-loading {
   position: fixed;
   inset: 0;
@@ -38,8 +43,23 @@ body {
   pointer-events: none;
 }
 
-#startup-loading > span {
+#startup-loading > span,
+#startup-retry {
   position: relative;
+}
+
+#startup-retry {
+  padding: var(--space-2xs) var(--space-s);
+  border: var(--border-hair);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  cursor: pointer;
+}
+
+#startup-retry:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .startup-spinner {

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import startupHtml from "../index.html?raw";
+import tauriConfig from "../src-tauri/tauri.conf.json";
+
+const mocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  loadMain: vi.fn(),
+  focus: vi.fn(),
+  setupPluginListeners: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ isTauri: mocks.isTauri }));
+vi.mock("tauri-plugin-mcp", () => ({ setupPluginListeners: mocks.setupPluginListeners }));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => (resolve = done));
+  return { promise, resolve };
+}
+let frames: FrameRequestCallback[];
+let content: ReturnType<typeof deferred>;
+let fonts: ReturnType<typeof deferred>;
+const originalFonts = Object.getOwnPropertyDescriptor(document, "fonts");
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  document.body.innerHTML = new DOMParser().parseFromString(
+    startupHtml,
+    "text/html"
+  ).body.innerHTML;
+  frames = [];
+  vi.stubGlobal("PerformanceObserver", undefined);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  content = deferred();
+  fonts = deferred();
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: {
+      get ready() {
+        return mocks.loadMain.mock.calls.length ? fonts.promise : Promise.resolve();
+      },
+    },
+  });
+  mocks.isTauri.mockReturnValue(true);
+  mocks.setupPluginListeners.mockResolvedValue(undefined);
+  mocks.focus.mockImplementation(() => {
+    expect(document.getElementById("app")?.inert).toBe(false);
+    expect(document.getElementById("startup-loading")).toBeNull();
+  });
+  mocks.loadMain.mockReturnValue({ ready: content.promise, focusAfterStartup: mocks.focus });
+  vi.doMock("./main", () => mocks.loadMain());
+});
+afterEach(() => {
+  document.body.innerHTML = "";
+  if (originalFonts) Object.defineProperty(document, "fonts", originalFonts);
+  else Reflect.deleteProperty(document, "fonts");
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+function frame() {
+  for (const callback of frames.splice(0)) callback(performance.now());
+}
+async function begin() {
+  const { startup } = await import("./startup");
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  return { startup };
+}
+
+async function shellFrames() {
+  frame();
+  frame();
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  frame();
+  frame();
+}
+
+it("ships the shell and small entry point with the app initially inert", () => {
+  expect(tauriConfig.app.windows[0].visible).toBe(false);
+  const page = new DOMParser().parseFromString(startupHtml, "text/html");
+  expect(page.querySelector('script[type="module"]')?.getAttribute("src")).toBe("/src/startup.ts");
+  expect(page.querySelector('link[href="/src/startup.css"]')).not.toBeNull();
+  expect(page.querySelector("#app")?.hasAttribute("inert")).toBe(true);
+  expect(page.querySelector("#startup-loading")?.getAttribute("role")).toBe("status");
+  expect(page.querySelector("#startup-loading")?.textContent).toContain("Starting Kindling…");
+});
+it("paints before loading the app and waits for content, assets and another paint", async () => {
+  const decoded = deferred();
+  const image = document.createElement("img");
+  image.decode = vi.fn(() => decoded.promise);
+  document.getElementById("app")!.append(image);
+  const { startup } = await begin();
+  expect(mocks.loadMain).not.toHaveBeenCalled();
+  frame();
+  expect(mocks.loadMain).not.toHaveBeenCalled();
+  frame();
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  expect(mocks.loadMain).not.toHaveBeenCalled();
+  frame();
+  frame();
+  await vi.waitFor(() => expect(mocks.loadMain).toHaveBeenCalledOnce());
+  expect(document.getElementById("startup-loading")).not.toBeNull();
+  expect(frames).toHaveLength(0);
+  content.resolve();
+  await Promise.resolve();
+  expect(image.decode).not.toHaveBeenCalled();
+  fonts.resolve();
+  await vi.waitFor(() => expect(image.decode).toHaveBeenCalledOnce());
+  expect(frames).toHaveLength(0);
+  decoded.resolve();
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  frame();
+  expect(document.getElementById("startup-loading")).not.toBeNull();
+  frame();
+  await startup;
+  expect(document.getElementById("startup-loading")).toBeNull();
+  expect(document.getElementById("app")?.inert).toBe(false);
+  expect(document.getElementById("app")?.hasAttribute("aria-busy")).toBe(false);
+});
+it("tolerates failed images", async () => {
+  const image = document.createElement("img");
+  image.decode = vi.fn().mockRejectedValue(new Error("Missing image"));
+  document.getElementById("app")!.append(image);
+  const { startup } = await begin();
+  await shellFrames();
+  content.resolve();
+  fonts.resolve();
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  frame();
+  frame();
+  await startup;
+  expect(document.getElementById("startup-loading")).toBeNull();
+});
+it("offers retry when the application module fails instead of spinning forever", async () => {
+  mocks.isTauri.mockReturnValue(false);
+  mocks.loadMain.mockImplementation(() => {
+    throw new Error("Bundle unavailable");
+  });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  const { startup } = await begin();
+  await shellFrames();
+  await startup;
+  expect(mocks.setupPluginListeners).not.toHaveBeenCalled();
+  expect(document.getElementById("startup-loading")?.getAttribute("role")).toBe("alert");
+  expect(document.getElementById("startup-message")?.textContent).toContain("couldn’t start");
+  expect(document.querySelector<HTMLElement>(".startup-spinner")?.hidden).toBe(true);
+  expect(document.getElementById("startup-retry")?.hidden).toBe(false);
+  expect(document.getElementById("startup-retry")?.onclick).toBeTypeOf("function");
+  expect(document.getElementById("app")?.hasAttribute("inert")).toBe(true);
+});
+
+it("waits for reported contentful paint when the browser supports paint timing", async () => {
+  let report!: (entries: { getEntries: () => { name: string }[] }) => void;
+  const observe = vi.fn();
+  const disconnect = vi.fn();
+  vi.stubGlobal(
+    "PerformanceObserver",
+    class {
+      static supportedEntryTypes = ["paint"];
+      constructor(callback: typeof report) {
+        report = callback;
+      }
+      observe = observe;
+      disconnect = disconnect;
+    }
+  );
+  const { startup } = await import("./startup");
+  await vi.waitFor(() => expect(observe).toHaveBeenCalledWith({ type: "paint", buffered: true }));
+  expect(mocks.loadMain).not.toHaveBeenCalled();
+  report({ getEntries: () => [{ name: "first-paint" }] });
+  await Promise.resolve();
+  expect(mocks.loadMain).not.toHaveBeenCalled();
+  report({ getEntries: () => [{ name: "first-contentful-paint" }] });
+  await vi.waitFor(() => expect(mocks.loadMain).toHaveBeenCalledOnce());
+  expect(disconnect).toHaveBeenCalledOnce();
+  content.resolve();
+  fonts.resolve();
+  await vi.waitFor(() => expect(frames).toHaveLength(1));
+  frame();
+  frame();
+  await startup;
+  expect(mocks.focus).toHaveBeenCalledOnce();
+});

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,0 +1,77 @@
+// Keep this entry point small: no Svelte, app stores or editor imports before
+// the loading screen has had a chance to paint.
+import { isTauri } from "@tauri-apps/api/core";
+
+function paintOpportunity(): Promise<void> {
+  // rAF runs BEFORE paint. Two frames leave a rendering opportunity between
+  // them; browsers do not expose a portable "pixels presented" event.
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+}
+
+async function loadingPaint() {
+  if (
+    typeof PerformanceObserver !== "undefined" &&
+    PerformanceObserver.supportedEntryTypes.includes("paint")
+  ) {
+    // Chromium reports the actual first contentful paint, including one that
+    // happened before this small module evaluated.
+    await new Promise<void>((resolve) => {
+      const observer = new PerformanceObserver((entries) => {
+        if (entries.getEntries().some((entry) => entry.name === "first-contentful-paint")) {
+          observer.disconnect();
+          resolve();
+        }
+      });
+      observer.observe({ type: "paint", buffered: true });
+    });
+  } else {
+    // Without Paint Timing, let initial layout request its fonts,
+    // then give the complete shell another rendering opportunity.
+    await paintOpportunity();
+    await document.fonts.ready;
+    await paintOpportunity();
+  }
+}
+
+async function start() {
+  try {
+    // Native page-load handling reveals this shell independently of JS success.
+    // No top-level await: the page-load event must be free to complete while
+    // this promise waits for the first visible frame.
+    await loadingPaint();
+
+    // MCP guest listeners must precede Svelte, but must not delay the first paint.
+    if (import.meta.env.DEV && isTauri()) {
+      const { setupPluginListeners } = await import("tauri-plugin-mcp");
+      await setupPluginListeners();
+    }
+
+    const { ready, focusAfterStartup } = await import("./main");
+    await ready;
+    await document.fonts.ready;
+    await Promise.all(Array.from(document.images, (image) => image.decode().catch(() => {})));
+    await paintOpportunity();
+
+    const app = document.getElementById("app")!;
+    app.inert = false;
+    app.removeAttribute("aria-busy");
+    document.getElementById("startup-loading")?.remove();
+    focusAfterStartup();
+  } catch (error) {
+    console.error("Kindling could not start:", error);
+    document.getElementById("startup-loading")?.setAttribute("role", "alert");
+    const message = document.getElementById("startup-message");
+    if (message) message.textContent = "Kindling couldn’t start. Please try again.";
+    const spinner = document.querySelector<HTMLElement>(".startup-spinner");
+    if (spinner) spinner.hidden = true;
+    const retry = document.getElementById("startup-retry");
+    if (retry) {
+      retry.hidden = false;
+      retry.onclick = () => window.location.reload();
+    }
+  }
+}
+
+export const startup = start();


### PR DESCRIPTION
## Summary

Kindling previously displayed a plain background while starting. Add a theme-matched loading overlay that paints before the main application bundle loads and remains until initial content, fonts and images are ready and the UI has had a rendering opportunity.

The native window opens on the initial document-load callback. A small bootstrap coordinates the handoff, keeps the background UI inert, restores keyboard focus for documents opened at launch, and offers retry if application loading fails. The overlay respects reduced motion and has no minimum display timer.

## Related Issues

Requested and visually accepted during interactive development; no linked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Screenshots/Recordings

Native macOS cold-launch capture verified the loading overlay in the first captured visible window frame, followed by the populated start screen. Browser regression screenshots are generated locally under `qa/visual/results/startup/`.

## Testing Instructions

1. Cold-launch with `npm run tauri dev`. Confirm the first visible window shows the overlay and then the populated start screen. Repeat with a review package opened at launch and confirm keyboard navigation works.
2. Repeat in light/dark themes and with reduced motion enabled. Reload and confirm the window does not steal focus.
3. Run `npm run build && npm run test:startup` with Playwright Chromium installed, or set `PLAYWRIGHT_CHROMIUM_EXECUTABLE` to an existing Chrome executable. This verifies paint before the main bundle request, delayed content loading, theme/motion behavior, document keyboard focus, and failed-bundle retry.

## Additional Notes

Validation on the final implementation:

- `npm run check:all` passed, with six existing Svelte warnings and two existing ESLint warnings.
- `npm test -- --coverage --maxWorkers=2`: 585 tests passed.
- `npm run test:rust`: 458 tests passed.
- Production build and startup browser regression passed.
- Native macOS cold-launch smoke test passed; user confirmed appearance and behavior.
- Independent review-agent and Claude code-review at high effort both reported no remaining actionable findings after fixes.

The final handoff uses explicit content readiness and animation frames; browsers do not expose a portable guarantee that pixels have reached the display. Native Windows/Linux launch behavior awaits CI and platform validation.
