### PR TITLE
feat(shortcuts): add customizable keyboard bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@
 - **No AI. No subscription. No cloud.** Every word is yours. Your projects are local SQLite files. Works completely offline.
 - **Free and open source.** MIT licensed. Inspect the code, contribute, or fork it. Your tools should be as permanent as your writing.
 
+## Keyboard shortcuts
+
+Open **Settings → Kindling → Preferences → Keyboard Shortcuts** to customize
+Kindling commands and prose formatting. Filter by command name, select a binding,
+and press Command (macOS) or Ctrl (Windows/Linux) with a letter, number,
+punctuation key, or function key. Escape cancels recording; Tab moves on.
+
+Changes apply immediately, update native menus and shortcut hints, and persist
+locally across launches. A conflicting or reserved combination is rejected with
+an explanation. Clear an existing binding before giving its keys to another
+command. **Clear** disables a shortcut; **Reset all to defaults** restores every
+binding. Standard text editing, system controls, and dialog navigation retain
+their usual keys (including copy, paste, undo, Tab, Enter, and Escape).
+
 ## Download
 
 Get Kindling for free at **[kindlingwriter.com/download](https://kindlingwriter.com/download/)**

--- a/docs/editorial-review.md
+++ b/docs/editorial-review.md
@@ -47,12 +47,12 @@ normal undo/redo shortcuts. Selecting across beats or scenes is one editorial
 action. Chapter and scene records remain intact: a replacement belongs to the
 first surviving source, and consumed prose is removed from subsequent sources.
 
-Click **Comment**, or use **Cmd/Ctrl+Alt+M**, to comment on a selection. With a
+Click **Comment**, or use the default **Cmd/Ctrl+Alt+M** shortcut, to comment on a selection. With a
 cursor and no selected text, the comment records broader feedback at that
 reading position. Threads support replies, resolution, and reopening. Refine
 your suggestions by editing them in the manuscript, or select **Withdraw**.
 
-Use **Find in manuscript** or **Cmd/Ctrl+F**, chapter navigation, and previous/next
+Use **Find in manuscript** or the default **Cmd/Ctrl+F** shortcut, chapter navigation, and previous/next
 annotation controls to move through the work. **Simple markup** keeps the prose
 readable and shows paragraph-margin indicators. Click an indicator or a sidebar
 thread to inspect that change beside its passage. Choose **All markup** to show

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,10 +1,11 @@
 # Settings in Kindling
 
-In project view, use **Settings** in the bar at the bottom of the project sidebar. You can also open **File → Settings…** or press **Cmd+,** on macOS / **Ctrl+,** on Windows and Linux. The command palette also has a single **Settings** command. The same window is available from the start screen and while a manuscript is open.
+In project view, use **Settings** in the bar at the bottom of the project sidebar. You can also open **File → Settings…** or use the default shortcut **Cmd+,** on macOS / **Ctrl+,** on Windows and Linux. The command palette also has a single **Settings** command. The same window is available from the start screen and while a manuscript is open.
 
 The Settings sidebar groups **Kindling → Preferences** and **Projects → Manuscript / Reference Library**. Choose an area to display its controls on the right. A location label above the controls identifies the current group and project:
 
 - **Appearance & Guidance**: Light, Dark, or System theme and contextual guidance tips. These preferences apply immediately across Kindling.
+- **Keyboard Shortcuts**: Remap Kindling commands and prose formatting, clear bindings, or reset all to defaults. Conflicts identify the command already using the combination. Changes apply immediately and persist across launches. Standard clipboard, OS, and dialog-navigation keys stay reserved. If saved shortcuts cannot be loaded, **Reset all to defaults** restores usable bindings.
 - **Author & Contact**: Author name, address, phone, and email used on exported manuscript title pages. Choose **Save author details** to apply changes.
 - **Project Details**: Pen name, genre, description, word target, and daily writing goal. A pen name overrides the shared author name for that project's byline. A daily goal of 0 turns off the goal.
 - **Reference Types**: Choose which reference categories appear in the selected project's References panel. Disabling a category keeps its existing entries.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod editorial_files;
 pub mod menu;
 pub mod models;
 pub mod parsers;
+pub mod shortcuts;
 
 use commands::AppState;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -153,8 +154,8 @@ pub fn run() {
 
             // Set up application menu
             let app_handle = app.handle();
-            menu::create_menu(app_handle).expect("Failed to create menu");
             menu::setup_menu_events(app_handle);
+            shortcuts::initialize(app_handle).expect("Failed to create menu");
 
             Ok(())
         })
@@ -284,6 +285,9 @@ pub fn run() {
             commands::delete_snapshot,
             commands::restore_snapshot,
             commands::preview_snapshot,
+            shortcuts::get_keyboard_shortcuts,
+            shortcuts::set_keyboard_shortcuts,
+            shortcuts::suspend_keyboard_shortcuts,
             // App settings commands
             commands::get_app_settings,
             commands::update_app_settings,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,147 +1,45 @@
-//! Application Menu Setup
-//!
-//! Creates the native application menu with File menu items for:
-//! - Import (Plottr, Markdown)
-//! - Import (Longform)
-//! - Export
-//! - Close Project
-//! - Settings
-
+//! Native menus use the same bindings as the frontend command registry.
+use std::collections::BTreeMap;
 use tauri::{
     menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder},
     AppHandle, Emitter, Manager, Wry,
 };
 
-/// Menu item IDs for event handling
-pub mod menu_ids {
-    pub const NEW_PROJECT: &str = "new_project";
-    pub const IMPORT_PLOTTR: &str = "import_plottr";
-    pub const IMPORT_YWRITER: &str = "import_ywriter";
-    pub const IMPORT_MARKDOWN: &str = "import_markdown";
-    pub const IMPORT_LONGFORM: &str = "import_longform";
-    pub const IMPORT_NOVELWRITER: &str = "import_novelwriter";
-    pub const IMPORT_SCRIVENER: &str = "import_scrivener";
-    pub const EXPORT: &str = "export";
-    pub const CLOSE_PROJECT: &str = "close_project";
-    pub const SETTINGS: &str = "settings";
-    pub const QUICK_START: &str = "quick_start";
-    pub const TOGGLE_SIDEBAR: &str = "toggle_sidebar";
-    pub const TOGGLE_REFERENCES: &str = "toggle_references";
-    pub const SYNC: &str = "sync";
-    pub const COMMAND_PALETTE: &str = "command_palette";
-    pub const ABOUT: &str = "about";
-    pub const SEND_FEEDBACK: &str = "send_feedback";
-    pub const QUIT: &str = "quit";
-}
-
-/// Create the application menu
-pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error>> {
-    // Import submenu
-    let import_plottr = MenuItemBuilder::new("Plottr (.pltr)")
-        .id(menu_ids::IMPORT_PLOTTR)
-        .accelerator("CmdOrCtrl+Shift+O")
-        .build(app)?;
-
-    let import_ywriter = MenuItemBuilder::new("yWriter 7 (.yw7)")
-        .id(menu_ids::IMPORT_YWRITER)
-        .accelerator("CmdOrCtrl+Shift+Y")
-        .build(app)?;
-
-    let import_markdown = MenuItemBuilder::new("Markdown (.md)")
-        .id(menu_ids::IMPORT_MARKDOWN)
-        .accelerator("CmdOrCtrl+Shift+M")
-        .build(app)?;
-
-    let import_longform = MenuItemBuilder::new("Longform (Index or Vault...)")
-        .id(menu_ids::IMPORT_LONGFORM)
-        .accelerator("CmdOrCtrl+Shift+L")
-        .build(app)?;
-
-    let import_scrivener = MenuItemBuilder::new("Scrivener 3 (.scriv)")
-        .id(menu_ids::IMPORT_SCRIVENER)
-        .accelerator("CmdOrCtrl+Shift+I")
-        .build(app)?;
-
-    let import_novelwriter = MenuItemBuilder::new("novelWriter (Project Folder)")
-        .id(menu_ids::IMPORT_NOVELWRITER)
-        .build(app)?;
-
+/// Build a fresh menu: muda 0.17 on macOS does not clear the native key
+/// equivalent when set_accelerator(None) is called on an existing item.
+pub fn create_menu(app: &AppHandle<Wry>, bindings: &BTreeMap<String, String>) -> tauri::Result<()> {
+    let command = |id: &str, label: &str| {
+        let mut item = MenuItemBuilder::new(label).id(id);
+        if let Some(binding) = bindings.get(id).filter(|value| !value.is_empty()) {
+            item = item.accelerator(binding.replace("Mod+", "CmdOrCtrl+"));
+        }
+        item.build(app)
+    };
     let import_submenu = SubmenuBuilder::new(app, "Import")
-        .item(&import_plottr)
-        .item(&import_ywriter)
-        .item(&import_markdown)
-        .item(&import_longform)
-        .item(&import_scrivener)
-        .item(&import_novelwriter)
+        .item(&command("import_plottr", "Plottr (.pltr)")?)
+        .item(&command("import_ywriter", "yWriter 7 (.yw7)")?)
+        .item(&command("import_markdown", "Markdown (.md)")?)
+        .item(&command("import_longform", "Longform (Index or Vault...)")?)
+        .item(&command("import_scrivener", "Scrivener 3 (.scriv)")?)
+        .item(&command(
+            "import_novelwriter",
+            "novelWriter (Project Folder)",
+        )?)
         .build()?;
-
-    // Export menu item
-    let export = MenuItemBuilder::new("Export...")
-        .id(menu_ids::EXPORT)
-        .accelerator("CmdOrCtrl+E")
-        .build(app)?;
-
-    // Close Project menu item
-    let close_project = MenuItemBuilder::new("Close Project")
-        .id(menu_ids::CLOSE_PROJECT)
-        .accelerator("CmdOrCtrl+W")
-        .build(app)?;
-
-    // Unified settings
-    let settings = MenuItemBuilder::new("Settings...")
-        .id(menu_ids::SETTINGS)
-        .accelerator("CmdOrCtrl+,")
-        .build(app)?;
-
-    let new_project = MenuItemBuilder::new("New Project")
-        .id(menu_ids::NEW_PROJECT)
-        .accelerator("CmdOrCtrl+N")
-        .build(app)?;
-
-    let quit = MenuItemBuilder::new("Quit Kindling")
-        .id(menu_ids::QUIT)
-        .accelerator("CmdOrCtrl+Q")
-        .build(app)?;
-
-    // Build File submenu
     let file_submenu = SubmenuBuilder::new(app, "File")
-        .item(&new_project)
-        .item(
-            &MenuItemBuilder::new("Open Review or Feedback File…")
-                .id("editorial_open")
-                .accelerator("CmdOrCtrl+O")
-                .build(app)?,
-        )
-        .item(
-            &MenuItemBuilder::new("Editorial Review…")
-                .id("editorial_project")
-                .build(app)?,
-        )
+        .item(&command("new_project", "New Project")?)
+        .item(&command("editorial_open", "Open Review or Feedback File…")?)
+        .item(&command("editorial_project", "Editorial Review…")?)
         .separator()
-        .items(&[&import_submenu])
-        .item(&export)
+        .item(&import_submenu)
+        .item(&command("export", "Export...")?)
         .separator()
-        .item(&close_project)
+        .item(&command("close_project", "Close Project")?)
         .separator()
-        .item(&settings)
+        .item(&command("settings", "Settings...")?)
         .separator()
-        .item(&quit)
+        .item(&command("quit", "Quit Kindling")?)
         .build()?;
-
-    let find = MenuItemBuilder::new("Find in Scene…")
-        .id("find")
-        .accelerator("CmdOrCtrl+F")
-        .build(app)?;
-    let find_replace = MenuItemBuilder::new("Find and Replace…")
-        .id("find_replace")
-        .accelerator("CmdOrCtrl+Alt+F")
-        .build(app)?;
-    let find_project = MenuItemBuilder::new("Find and Replace in Project…")
-        .id("find_project")
-        .accelerator("CmdOrCtrl+Shift+F")
-        .build(app)?;
-
-    // Build Edit submenu with standard items
     let edit_submenu = SubmenuBuilder::new(app, "Edit")
         .undo()
         .redo()
@@ -151,67 +49,28 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
         .paste()
         .select_all()
         .separator()
-        .items(&[&find, &find_replace, &find_project])
+        .item(&command("find", "Find in Scene…")?)
+        .item(&command("find_replace", "Find and Replace…")?)
+        .item(&command("find_project", "Find and Replace in Project…")?)
         .build()?;
-
-    // Build Window submenu with standard items
+    // Close Project owns Mod+W; a second predefined Close Window item would
+    // retain that accelerator after the user's Close Project binding changes.
     let window_submenu = SubmenuBuilder::new(app, "Window")
         .minimize()
         .maximize()
-        .separator()
-        .close_window()
         .build()?;
-
-    // View submenu
-    let toggle_sidebar = MenuItemBuilder::new("Toggle Sidebar")
-        .id(menu_ids::TOGGLE_SIDEBAR)
-        .accelerator("CmdOrCtrl+Backslash")
-        .build(app)?;
-
-    let toggle_references = MenuItemBuilder::new("Toggle References Panel")
-        .id(menu_ids::TOGGLE_REFERENCES)
-        .accelerator("CmdOrCtrl+Shift+R")
-        .build(app)?;
-
-    let sync = MenuItemBuilder::new("Sync from Source")
-        .id(menu_ids::SYNC)
-        .accelerator("CmdOrCtrl+Shift+S")
-        .build(app)?;
-
     let view_submenu = SubmenuBuilder::new(app, "View")
-        .item(&toggle_sidebar)
-        .item(&toggle_references)
-        .item(&sync)
+        .item(&command("toggle_sidebar", "Toggle Sidebar")?)
+        .item(&command("toggle_references", "Toggle References Panel")?)
+        .item(&command("sync", "Sync from Source")?)
         .build()?;
-
-    // Help submenu
-    let about = MenuItemBuilder::new("About Kindling...")
-        .id(menu_ids::ABOUT)
-        .build(app)?;
-
-    let command_palette = MenuItemBuilder::new("Command Palette...")
-        .id(menu_ids::COMMAND_PALETTE)
-        .accelerator("CmdOrCtrl+K")
-        .build(app)?;
-
-    let quick_start = MenuItemBuilder::new("Quick Start")
-        .id(menu_ids::QUICK_START)
-        .accelerator("CmdOrCtrl+Shift+H")
-        .build(app)?;
-
-    let send_feedback = MenuItemBuilder::new("Send Feedback...")
-        .id(menu_ids::SEND_FEEDBACK)
-        .build(app)?;
-
     let help_submenu = SubmenuBuilder::new(app, "Help")
-        .item(&about)
-        .item(&send_feedback)
+        .item(&command("about", "About Kindling...")?)
+        .item(&command("send_feedback", "Send Feedback...")?)
         .separator()
-        .item(&command_palette)
-        .item(&quick_start)
+        .item(&command("command_palette", "Command Palette...")?)
+        .item(&command("quick_start", "Quick Start")?)
         .build()?;
-
-    // Build the full menu
     let menu = MenuBuilder::new(app)
         .items(&[
             &file_submenu,
@@ -221,22 +80,15 @@ pub fn create_menu(app: &AppHandle<Wry>) -> Result<(), Box<dyn std::error::Error
             &help_submenu,
         ])
         .build()?;
-
     app.set_menu(menu)?;
-
     Ok(())
 }
 
-/// Set up menu event handling
 pub fn setup_menu_events(app: &AppHandle<Wry>) {
     let app_handle = app.clone();
-
     app.on_menu_event(move |_app, event| {
-        let id = event.id().0.as_str();
-
-        // Emit event to frontend for handling
         if let Some(window) = app_handle.get_webview_window("main") {
-            let _ = window.emit("menu-event", id);
+            let _ = window.emit("menu-event", event.id().0.as_str());
         }
     });
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -1,0 +1,198 @@
+//! Shared command definitions, durable keybindings, and native menu synchronization.
+use std::{collections::BTreeMap, fs, path::PathBuf, sync::Mutex};
+use tauri::{AppHandle, Manager};
+
+type Bindings = BTreeMap<String, String>;
+#[derive(serde::Deserialize)]
+struct Definition {
+    id: String,
+    binding: String,
+}
+fn defaults() -> Bindings {
+    serde_json::from_str::<Vec<Definition>>(include_str!("../../src/lib/shortcutDefinitions.json"))
+        .expect("valid shared shortcut definitions")
+        .into_iter()
+        .map(|def| (def.id, def.binding))
+        .collect()
+}
+
+#[derive(Default)]
+pub struct ShortcutState {
+    suspended: Mutex<bool>,
+}
+
+fn path(app: &AppHandle) -> Result<PathBuf, String> {
+    // Match the isolated project data directory in debug QA runs.
+    #[cfg(debug_assertions)]
+    if let Ok(dir) = std::env::var("KINDLING_DATA_DIR") {
+        if !dir.trim().is_empty() {
+            fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+            return Ok(PathBuf::from(dir).join("shortcuts.json"));
+        }
+    }
+    Ok(crate::commands::get_settings_path(app)?.with_file_name("shortcuts.json"))
+}
+
+fn validate(bindings: &Bindings) -> Result<(), String> {
+    let known = defaults();
+    if bindings.keys().ne(known.keys()) {
+        return Err("Shortcut commands do not match this version of Kindling".into());
+    }
+    let reserved = [
+        "Mod+X",
+        "Mod+C",
+        "Mod+V",
+        "Mod+Shift+V",
+        "Mod+Alt+Shift+V",
+        "Mod+A",
+        "Mod+Z",
+        "Mod+Shift+Z",
+        "Mod+Y",
+        "Mod+M",
+        "Mod+H",
+        "Mod+Alt+H",
+    ];
+    let mut used = BTreeMap::new();
+    for (id, binding) in bindings {
+        if binding.is_empty() {
+            continue;
+        }
+        let key = binding
+            .strip_prefix("Mod+")
+            .ok_or("Shortcuts require Command/Ctrl")?;
+        let key = key.strip_prefix("Alt+").unwrap_or(key);
+        let key = key.strip_prefix("Shift+").unwrap_or(key);
+        let valid_key = (key.len() == 1
+            && key
+                .bytes()
+                .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit()))
+            || [
+                "Comma",
+                "Period",
+                "Slash",
+                "Backslash",
+                "Semicolon",
+                "Quote",
+                "BracketLeft",
+                "BracketRight",
+                "Minus",
+                "Equal",
+                "Backquote",
+            ]
+            .contains(&key)
+            || (1..=24).any(|n| key == format!("F{n}"));
+        if !valid_key || reserved.contains(&binding.as_str()) {
+            return Err(format!("Invalid or reserved shortcut: {binding}"));
+        }
+        if let Some(other) = used.insert(binding, id) {
+            return Err(format!("Shortcut already used by {other}"));
+        }
+    }
+    Ok(())
+}
+
+fn load(app: &AppHandle) -> Result<Bindings, String> {
+    let file = path(app)?;
+    let mut bindings = defaults();
+    if file.exists() {
+        let saved: Bindings = serde_json::from_slice(&fs::read(file).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+        for (id, value) in saved {
+            if bindings.contains_key(&id) {
+                bindings.insert(id, value);
+            }
+        }
+    }
+    validate(&bindings)?;
+    Ok(bindings)
+}
+
+fn apply(app: &AppHandle, bindings: &Bindings, suspended: bool) -> Result<(), String> {
+    let empty = Bindings::new();
+    crate::menu::create_menu(app, if suspended { &empty } else { bindings })
+        .map_err(|e| e.to_string())
+}
+
+pub fn initialize(app: &AppHandle) -> Result<(), String> {
+    app.manage(ShortcutState::default());
+    // A malformed file is reported by get_keyboard_shortcuts in the UI. Keep menus usable.
+    let bindings = load(app).unwrap_or_else(|_| defaults());
+    apply(app, &bindings, false)
+}
+
+#[tauri::command]
+pub async fn get_keyboard_shortcuts(app: AppHandle) -> Result<Bindings, String> {
+    load(&app)
+}
+
+#[tauri::command]
+pub async fn set_keyboard_shortcuts(
+    app: AppHandle,
+    bindings: Bindings,
+) -> Result<Bindings, String> {
+    validate(&bindings)?;
+    let state = app.state::<ShortcutState>();
+    let suspended = state.suspended.lock().map_err(|e| e.to_string())?;
+    let previous = load(&app).unwrap_or_else(|_| defaults());
+    let file = path(&app)?;
+    let temporary = file.with_extension("json.tmp");
+    fs::write(
+        &temporary,
+        serde_json::to_vec_pretty(&bindings).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+    if let Err(error) = apply(&app, &bindings, *suspended)
+        .and_then(|()| fs::rename(&temporary, &file).map_err(|e| e.to_string()))
+    {
+        let _ = apply(&app, &previous, *suspended);
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(bindings)
+}
+
+#[tauri::command]
+pub async fn suspend_keyboard_shortcuts(app: AppHandle, suspended: bool) -> Result<(), String> {
+    let state = app.state::<ShortcutState>();
+    let mut current = state.suspended.lock().map_err(|e| e.to_string())?;
+    apply(&app, &load(&app).unwrap_or_else(|_| defaults()), suspended)?;
+    *current = suspended;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn defaults_are_valid_and_unique() {
+        validate(&defaults()).unwrap();
+    }
+    #[test]
+    fn rejects_conflicts_reserved_keys_and_invalid_input() {
+        for binding in [
+            "Mod+E",
+            "Mod+C",
+            "Q",
+            "Mod+Shift+Alt+Q",
+            "Mod+F25",
+            "Mod+Shift+",
+            "Mod+Bogus",
+        ] {
+            let mut bindings = defaults();
+            bindings.insert("settings".into(), binding.into());
+            assert!(validate(&bindings).is_err(), "{binding}");
+        }
+    }
+    #[test]
+    fn accepts_remapping_clearing_and_rejects_unknown_commands() {
+        let mut bindings = defaults();
+        bindings.insert("settings".into(), "Mod+Alt+Shift+F12".into());
+        bindings.insert("quit".into(), "".into());
+        validate(&bindings).unwrap();
+        bindings.insert("unknown".into(), "".into());
+        assert!(validate(&bindings).is_err());
+        bindings.remove("unknown");
+        bindings.remove("quit");
+        assert!(validate(&bindings).is_err());
+    }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,6 +29,7 @@
   import { captureWritingFocus } from "./lib/utils/writingFocus";
   import { checkForUpdate } from "./lib/updater";
   import NewProjectDialog from "./lib/components/NewProjectDialog.svelte";
+  import { shortcuts } from "./lib/stores/shortcuts.svelte";
   import { COMMAND_DEFS } from "./lib/commands";
   import { currentProject } from "./lib/stores/project.svelte";
   import { session } from "./lib/stores/session.svelte";
@@ -340,66 +341,7 @@
   // Handle menu events from Tauri
   onMount(() => {
     const unlisten = listen<string>("menu-event", (event) => {
-      if (interactionBlocked) return;
-      const menuId = event.payload;
-      if (showSettings && menuId !== "quit") return;
-      if (menuId === "settings") {
-        showSettings = true;
-        return;
-      }
-      if (menuId === "editorial_open" || menuId === "editorial_project") {
-        runCommand(menuId);
-        return;
-      }
-      if (editorial?.isOpen() && menuId !== "quit") {
-        if (menuId === "close_project") void editorial.closeWorkspace();
-        if (["find", "find_project", "find_replace"].includes(menuId)) editorial.focusSearch();
-        if (menuId === "export") void editorial.exportFeedback();
-        return;
-      }
-
-      if (handleImportCommand(menuId)) return;
-      if (["find", "find_replace", "find_project"].includes(menuId)) {
-        runCommand(menuId);
-        return;
-      }
-      switch (menuId) {
-        case "new_project":
-          showNewProjectDialog = true;
-          break;
-        case "export":
-          if (currentProject.value) {
-            showExportDialog = true;
-          }
-          break;
-        case "close_project":
-          closeProject();
-          break;
-        case "command_palette":
-          showCommandPalette = true;
-          break;
-        case "quick_start":
-          showQuickStart = true;
-          break;
-        case "toggle_sidebar":
-          ui.toggleSidebar();
-          break;
-        case "toggle_references":
-          ui.toggleReferencesPanel();
-          break;
-        case "sync":
-          window.dispatchEvent(new CustomEvent("kindling:sync"));
-          break;
-        case "about":
-          showAboutDialog = true;
-          break;
-        case "send_feedback":
-          showFeedbackDialog = true;
-          break;
-        case "quit":
-          void quit();
-          break;
-      }
+      if (!showSettings || event.payload === "quit") runCommand(event.payload);
     });
 
     return () => {
@@ -415,14 +357,36 @@
       return true;
     }).map((def) => ({
       ...def,
+      shortcut: shortcuts.label(def.id),
       action: () => runCommand(def.id),
     }))
   );
 
   function runCommand(id: string) {
-    if (interactionBlocked) return;
+    if (interactionBlocked || (showSettings && id !== "quit")) return;
+    if (
+      editorial?.isOpen() &&
+      !["settings", "quit", "editorial_open", "editorial_project"].includes(id)
+    ) {
+      if (id === "close_project") void editorial.closeWorkspace();
+      if (["find", "find_project", "find_replace"].includes(id)) editorial.focusSearch();
+      if (id === "export") void editorial.exportFeedback();
+      return;
+    }
+    const def = COMMAND_DEFS.find((item) => item.id === id);
+    if (def?.requiresProject && !currentProject.value) return;
+    if (def?.requiresSourcePath && !currentProject.value?.source_path) return;
     if (handleImportCommand(id)) return;
     switch (id) {
+      case "new_project":
+        showNewProjectDialog = true;
+        break;
+      case "command_palette":
+        showCommandPalette = true;
+        break;
+      case "send_feedback":
+        showFeedbackDialog = true;
+        break;
       case "editorial_open":
         void editorial?.openFile();
         break;
@@ -501,45 +465,47 @@
       });
   });
 
-  // Global keyboard shortcuts
+  // Capture application bindings before TipTap/browser keymaps consume them.
+  onMount(() => {
+    void shortcuts.load();
+    window.addEventListener("keydown", handleKeydown, true);
+    return () => window.removeEventListener("keydown", handleKeydown, true);
+  });
+
+  $effect(() => {
+    void shortcuts.suspend(showSettings).then(() => {
+      if (shortcuts.error) ui.showError(shortcuts.error);
+    });
+  });
+
   function handleKeydown(event: KeyboardEvent) {
-    if (showSettings) return;
-    if ((event.metaKey || event.ctrlKey) && event.key === ",") {
-      event.preventDefault();
-      showSettings = true;
-      return;
-    }
-    if (editorial?.isOpen()) return;
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-      if (!currentProject.value) return;
-      event.preventDefault();
-      openSearch(event.shiftKey ? "project" : "scene", event.altKey || event.shiftKey);
-      return;
-    }
-    // Cmd/Ctrl+K: Open command palette
-    if ((event.metaKey || event.ctrlKey) && event.key === "k") {
-      event.preventDefault();
-      showCommandPalette = true;
-      return;
-    }
-    // Cmd/Ctrl+E: Open export dialog
-    if ((event.metaKey || event.ctrlKey) && event.key === "e") {
-      event.preventDefault();
-      if (currentProject.value && !showExportDialog) {
-        showExportDialog = true;
+    if (interactionBlocked || event.defaultPrevented || event.isComposing) return;
+    const id = shortcuts.match(event);
+    if (showSettings) {
+      if (id === "quit" && !shortcuts.recording) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (!event.repeat) runCommand(id);
       }
       return;
     }
-    // Cmd/Ctrl+Shift+H: Open Quick Start
-    if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === "H") {
-      event.preventDefault();
-      showQuickStart = true;
+    if (
+      showCommandPalette ||
+      (event.target instanceof Element &&
+        event.target.closest('[role="dialog"], dialog') &&
+        !(
+          event.target.closest('dialog[aria-labelledby="find-title"]') &&
+          id &&
+          ["find", "find_replace", "find_project"].includes(id)
+        ))
+    )
       return;
-    }
+    if (!id || !COMMAND_DEFS.some((def) => def.id === id)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (!event.repeat) runCommand(id);
   }
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 {#snippet errorToast()}
   {#if ui.toast}
@@ -720,7 +686,7 @@
   inert={interactionBlocked || editorial?.isOpen()}
   hidden={interactionBlocked || editorial?.isOpen()}
 >
-  <!-- Command palette (⌘K) -->
+  <!-- Command palette -->
   <CommandPalette
     bind:open={showCommandPalette}
     commands={paletteCommands}

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -15,6 +15,8 @@ import { runImport } from "./lib/utils/import";
 import { currentProject } from "./lib/stores/project.svelte";
 import { mockProject, mockScenes, mockChapters } from "./dev/mock-data";
 import App from "./App.svelte";
+import { shortcuts } from "./lib/stores/shortcuts.svelte";
+import { defaultBindings } from "./lib/utils/keyboardShortcuts";
 import { EditorialSaves } from "./lib/utils/editorialSaves";
 
 vi.hoisted(() => {
@@ -49,6 +51,8 @@ const doc = {
   locked: false,
 };
 beforeEach(async () => {
+  shortcuts.bindings = { ...defaultBindings };
+  shortcuts.recording = false;
   ui.clearToast();
   vi.mocked(invoke).mockReset();
   vi.mocked(invoke).mockImplementation(async (cmd) =>
@@ -921,6 +925,7 @@ it("keeps errors visible and dismissable within the active quit modal", async ()
     screen.getByText("Still relevant after cancelling").closest("[data-quit-confirmation]")
   ).toBeNull();
   expect(screen.getAllByRole("button", { name: "Dismiss error" })).toHaveLength(1);
+  shortcuts.bindings = { ...defaultBindings };
   ui.clearToast();
 });
 
@@ -1091,7 +1096,7 @@ it.each(["sidebar", "menu", "keyboard"])(
     } else if (entryPoint === "menu") {
       await menu("settings");
     } else {
-      await fireEvent.keyDown(window, { key: ",", metaKey: true });
+      await fireEvent.keyDown(window, { key: ",", ctrlKey: true });
     }
 
     const settings = await screen.findByRole("dialog", { name: "Settings" });
@@ -1160,4 +1165,47 @@ it("waits for a native file drain that starts before the listener handshake fini
   } finally {
     vi.mocked(listen).mockResolvedValue(() => {});
   }
+});
+
+it("dispatches remapped commands once, drops old bindings, and ignores extra modifiers", async () => {
+  currentProject.setProject(null);
+  render(App);
+  await tick();
+  shortcuts.bindings.command_palette = "Mod+Alt+P";
+  await fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+  expect(screen.queryByPlaceholderText("Type a command or search...")).toBeNull();
+  await fireEvent.keyDown(window, { key: "p", ctrlKey: true, altKey: true, shiftKey: true });
+  expect(screen.queryByPlaceholderText("Type a command or search...")).toBeNull();
+  await fireEvent.keyDown(window, { key: "p", ctrlKey: true, altKey: true });
+  expect(screen.getByPlaceholderText("Type a command or search...")).toBeTruthy();
+});
+
+it("blocks project commands and recording keys in Settings but keeps explicit Quit available", async () => {
+  render(App);
+  await menu("settings");
+  await fireEvent.click(screen.getByRole("button", { name: "Keyboard Shortcuts" }));
+  await menu("new_project");
+  shortcuts.recording = true;
+  await fireEvent.keyDown(window, { key: "q", ctrlKey: true });
+  expect(exit).not.toHaveBeenCalled();
+  expect(screen.getByTestId("settings-dialog")).toBeTruthy();
+  expect(invoke).toHaveBeenCalledWith("suspend_keyboard_shortcuts", { suspended: true });
+  await menu("quit");
+  await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+});
+
+it("preserves paste-as-plain-text and allows Quit from Settings when not recording", async () => {
+  render(App);
+  const event = new KeyboardEvent("keydown", {
+    key: "V",
+    ctrlKey: true,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  await menu("settings");
+  await fireEvent.keyDown(window, { key: "q", ctrlKey: true });
+  await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
 });

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -1,3 +1,4 @@
+import { formatShortcut } from "./utils/keyboardShortcuts";
 import { describe, it, expect } from "vitest";
 import { COMMAND_DEFS, fuzzyMatch, fuzzyScore } from "./commands";
 
@@ -116,7 +117,7 @@ it("exposes one shared settings command without requiring an open project", () =
       id: "settings",
       label: "Settings",
       requiresProject: false,
-      shortcut: "⌘,",
+      shortcut: formatShortcut("Mod+Comma"),
     }),
   ]);
 });

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -2,7 +2,7 @@
  * Command registry for the command palette (US-1.1-5)
  *
  * Each command has an id, label, shortcut, category, and optional keywords for search.
- * Shortcuts use format "Mod+Key" where Mod = Cmd on Mac, Ctrl on Windows/Linux.
+ * Shortcuts here are formatted defaults; the shortcut store supplies live bindings.
  * Actions are bound at runtime by App.svelte.
  */
 
@@ -21,214 +21,16 @@ export interface CommandDef {
   requiresSourcePath?: boolean;
 }
 
-export const COMMAND_DEFS: CommandDef[] = [
-  {
-    id: "editorial_open",
-    label: "Open review or feedback file",
-    shortcut: "⌘O",
-    category: "File",
-    keywords: ["editor", "package"],
-  },
-  {
-    id: "editorial_project",
-    label: "Editorial review and packages",
-    shortcut: "",
-    category: "Project",
-    requiresProject: true,
-    keywords: ["editor", "feedback", "revisions"],
-  },
-  {
-    id: "find",
-    label: "Find in scene",
-    shortcut: "⌘F",
-    category: "Edit",
-    keywords: ["search", "prose"],
-    requiresProject: true,
-  },
-  {
-    id: "find_replace",
-    label: "Find and replace",
-    shortcut: "⌘⌥F",
-    category: "Edit",
-    keywords: ["search", "replace", "prose"],
-    requiresProject: true,
-  },
-  {
-    id: "find_project",
-    label: "Find and replace in project",
-    shortcut: "⌘⇧F",
-    category: "Edit",
-    keywords: ["search", "replace", "all"],
-    requiresProject: true,
-  },
-  // File
-  {
-    id: "export",
-    label: "Export project",
-    shortcut: "⌘E",
-    category: "File",
-    keywords: ["export", "docx", "manuscript"],
-    requiresProject: true,
-  },
-  {
-    id: "close_project",
-    label: "Close project",
-    shortcut: "⌘W",
-    category: "File",
-    keywords: ["close"],
-    requiresProject: true,
-  },
-  {
-    id: "quit",
-    label: "Quit Kindling",
-    shortcut: "⌘Q",
-    category: "File",
-    keywords: ["quit", "exit"],
-    requiresProject: false,
-  },
-  {
-    id: "import_plottr",
-    label: "Import Plottr (.pltr)",
-    shortcut: "⌘⇧O",
-    category: "File",
-    keywords: ["import", "plottr"],
-    requiresProject: false,
-  },
-  {
-    id: "import_markdown",
-    label: "Import Markdown (.md)",
-    shortcut: "⌘⇧M",
-    category: "File",
-    keywords: ["import", "markdown", "md"],
-    requiresProject: false,
-  },
-  {
-    id: "import_longform",
-    label: "Import Longform",
-    shortcut: "⌘⇧L",
-    category: "File",
-    keywords: ["import", "longform", "obsidian"],
-    requiresProject: false,
-  },
-  {
-    id: "import_ywriter",
-    label: "Import yWriter 7 (.yw7)",
-    shortcut: "⌘⇧Y",
-    category: "File",
-    keywords: ["import", "ywriter", "yw7"],
-    requiresProject: false,
-  },
-  {
-    id: "import_scrivener",
-    label: "Import Scrivener 3 (.scriv)",
-    shortcut: "⌘⇧I",
-    category: "File",
-    keywords: ["import", "scrivener", "scriv"],
-    requiresProject: false,
-  },
-  {
-    id: "import_novelwriter",
-    label: "Import novelWriter",
-    shortcut: "",
-    category: "File",
-    keywords: ["import", "novelwriter", "nwx"],
-    requiresProject: false,
-  },
-  // Project
-  {
-    id: "sync",
-    label: "Sync from source",
-    shortcut: "⌘⇧S",
-    category: "Project",
-    keywords: ["sync", "reimport", "refresh", "reload"],
-    requiresProject: true,
-    requiresSourcePath: true,
-  },
-  // View
-  {
-    id: "toggle_sidebar",
-    label: "Toggle sidebar",
-    shortcut: "⌘\\",
-    category: "View",
-    keywords: ["sidebar", "outline", "collapse", "expand"],
-    requiresProject: true,
-  },
-  {
-    id: "toggle_references",
-    label: "Toggle references panel",
-    shortcut: "⌘⇧R",
-    category: "View",
-    keywords: ["references", "characters", "panel", "collapse", "expand"],
-    requiresProject: true,
-  },
-  {
-    id: "toggle_discovery_notes",
-    label: "Toggle discovery notes",
-    shortcut: "⌘D",
-    category: "View",
-    keywords: ["discovery", "notes", "draft"],
-    requiresProject: true,
-  },
-  {
-    id: "toggle_editor_mode",
-    label: "Toggle beat/page view",
-    shortcut: "⌘⇧V",
-    category: "View",
-    keywords: ["page", "beat", "view", "mode", "prose", "editor"],
-    requiresProject: true,
-  },
-  // Project - Detection
-  {
-    id: "detect_references",
-    label: "Detect references in scene",
-    shortcut: "",
-    category: "Project",
-    keywords: ["detect", "references", "scan", "suggest", "smart"],
-    requiresProject: true,
-  },
-  {
-    id: "detect_all_references",
-    label: "Detect references in all scenes",
-    shortcut: "",
-    category: "Project",
-    keywords: ["detect", "all", "references", "scan", "suggest", "bulk"],
-    requiresProject: true,
-  },
-  // Help
-  {
-    id: "about",
-    label: "About Kindling",
-    shortcut: "",
-    category: "Help",
-    keywords: ["about", "version", "info"],
-    requiresProject: false,
-  },
-  {
-    id: "quick_start",
-    label: "Quick start guide",
-    shortcut: "⌘⇧H",
-    category: "Help",
-    keywords: ["help", "quick", "start", "guide", "docs"],
-    requiresProject: false,
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    shortcut: "⌘,",
-    category: "Help",
-    keywords: [
-      "settings",
-      "kindling",
-      "preferences",
-      "author",
-      "project",
-      "theme",
-      "tags",
-      "fields",
-    ],
-    requiresProject: false,
-  },
-];
+import definitions from "./shortcutDefinitions.json";
+import { formatShortcut } from "./utils/keyboardShortcuts";
+
+export const COMMAND_DEFS: CommandDef[] = definitions
+  .filter((def) => def.category !== "Editor")
+  .map((def) => ({
+    ...def,
+    category: def.category as CommandCategory,
+    shortcut: formatShortcut(def.binding),
+  }));
 
 /** Simple fuzzy match: query chars must appear in order in the text */
 export function fuzzyMatch(query: string, text: string): boolean {

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -2,9 +2,10 @@
   CommandPalette.svelte - Cmd+K command palette (US-1.1-5)
 
   Fuzzy-searchable list of commands with keyboard shortcuts.
-  Each command has an accompanying shortcut; palette opens with ⌘K.
+  Displays the current configured bindings.
 -->
 <script lang="ts">
+  import { shortcuts } from "../stores/shortcuts.svelte";
   import { Command, Search } from "lucide-svelte";
   import { fuzzyMatch, fuzzyScore, type CommandDef } from "../commands";
 
@@ -135,10 +136,10 @@
         class="flex-1 bg-transparent text-press-text placeholder:text-press-muted focus:outline-none"
         autofocus
       />
-      <kbd
-        class="rounded border border-press-border px-2 py-0.5 text-press-eyebrow text-press-muted"
-        >⌘K</kbd
-      >
+      {#if shortcuts.label("command_palette")}<kbd
+          class="rounded border border-press-border px-2 py-0.5 text-press-eyebrow text-press-muted"
+          >{shortcuts.label("command_palette")}</kbd
+        >{/if}
     </div>
 
     <!-- Command list -->

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -6,7 +6,7 @@
 -->
 <script lang="ts">
   import { shortcuts } from "../stores/shortcuts.svelte";
-  import { Command, Search } from "lucide-svelte";
+  import { Keyboard, Search } from "lucide-svelte";
   import { fuzzyMatch, fuzzyScore, type CommandDef } from "../commands";
 
   interface CommandWithAction extends CommandDef {
@@ -158,7 +158,7 @@
               : 'hover:bg-press-accent-wash'}"
           >
             <div class="flex items-center gap-3 min-w-0">
-              <Command class="w-4 h-4 shrink-0 text-press-muted" />
+              <Keyboard class="w-4 h-4 shrink-0 text-press-muted" />
               <span class="truncate text-press-text">{cmd.label}</span>
             </div>
             <kbd

--- a/src/lib/components/CommandPalette.test.ts
+++ b/src/lib/components/CommandPalette.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/svelte";
+import CommandPalette from "./CommandPalette.svelte";
+import KeyboardSettings from "./KeyboardSettings.svelte";
+import { shortcuts } from "../stores/shortcuts.svelte";
+import { defaultBindings } from "../utils/keyboardShortcuts";
+
+beforeEach(() => {
+  shortcuts.bindings = { ...defaultBindings, settings: "Mod+Alt+Shift+P" };
+  shortcuts.ready = true;
+  shortcuts.suspended = true;
+  shortcuts.error = null;
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  shortcuts.bindings = { ...defaultBindings };
+});
+
+it.each([
+  ["MacIntel", "⌥⇧⌘P", "⌘K"],
+  ["Win32", "Ctrl+Alt+Shift+P", "Ctrl+K"],
+  ["Linux x86_64", "Ctrl+Alt+Shift+P", "Ctrl+K"],
+])(
+  "renders settings and palette shortcuts for %s without hardcoded Command icons",
+  (platform, settingsLabel, paletteLabel) => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue(platform);
+    const settings = render(KeyboardSettings);
+    const binding = settings.getByRole("button", { name: "Shortcut for Settings" });
+    expect(binding.textContent?.trim()).toBe(settingsLabel);
+    settings.unmount();
+
+    const palette = render(CommandPalette, {
+      open: true,
+      commands: [
+        {
+          id: "settings",
+          label: "Settings",
+          category: "Help",
+          shortcut: shortcuts.label("settings"),
+          action: vi.fn(),
+        },
+      ],
+    });
+    const displayed = Array.from(palette.container.querySelectorAll("kbd"), (element) =>
+      element.textContent?.trim()
+    );
+    expect(displayed).toEqual([paletteLabel, settingsLabel]);
+    expect(palette.container.querySelector("svg.lucide-command")).toBeNull();
+    expect(palette.container.querySelector("svg.lucide-keyboard")).not.toBeNull();
+    if (platform !== "MacIntel") expect(palette.container.textContent).not.toMatch(/[⌘⌥⇧]/);
+  }
+);

--- a/src/lib/components/EditorialManuscript.svelte
+++ b/src/lib/components/EditorialManuscript.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { shortcuts } from "../stores/shortcuts.svelte";
+  import { KeyboardFormatting } from "../utils/keyboardFormatting";
   import { onMount, tick } from "svelte";
   import ProseToolbar from "./ProseToolbar.svelte";
   import { MessageSquare } from "lucide-svelte";
@@ -202,7 +204,7 @@
   onMount(() => {
     const instance = new Editor({
       element,
-      extensions: editorialExtensions,
+      extensions: [...editorialExtensions, KeyboardFormatting],
       content: initial,
       editable: !readonly,
       editorProps: {
@@ -225,12 +227,7 @@
           spellcheck: "true",
         },
         handleKeyDown: (_view, event) => {
-          if (
-            canComment &&
-            (event.metaKey || event.ctrlKey) &&
-            event.altKey &&
-            event.key.toLowerCase() === "m"
-          ) {
+          if (canComment && shortcuts.match(event) === "editorial_comment") {
             event.preventDefault();
             onComment();
             return true;

--- a/src/lib/components/EditorialWorkspace.svelte
+++ b/src/lib/components/EditorialWorkspace.svelte
@@ -1211,10 +1211,6 @@
       menuPosition = null;
       menuTrigger?.focus();
     }
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
-      e.preventDefault();
-      focusSearch();
-    }
     e.stopPropagation();
   }}
 >

--- a/src/lib/components/GuidanceOverlay.svelte
+++ b/src/lib/components/GuidanceOverlay.svelte
@@ -23,7 +23,7 @@
       position: "left",
     },
     scenePanel: {
-      message: "Edit beats and scenes here. Add discovery notes with ⌘D.",
+      message: "Edit beats and scenes here. Capture ideas in Discovery Notes.",
       position: "center",
     },
     references: {

--- a/src/lib/components/KeyboardSettings.svelte
+++ b/src/lib/components/KeyboardSettings.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import definitions from "../shortcutDefinitions.json";
+  import { shortcuts } from "../stores/shortcuts.svelte";
+  import { bindingProblem, defaultBindings, shortcutFromEvent } from "../utils/keyboardShortcuts";
+  let { busy = $bindable(false) }: { busy?: boolean } = $props();
+  let recording = $state<string | null>(null);
+  let message = $state("");
+  let error = $state("");
+  let filter = $state("");
+  const shown = $derived(
+    definitions.filter((def) =>
+      `${def.label} ${def.category}`.toLowerCase().includes(filter.toLowerCase())
+    )
+  );
+  $effect(() => {
+    shortcuts.recording = recording !== null;
+    return () => {
+      shortcuts.recording = false;
+    };
+  });
+  onMount(() => {
+    void shortcuts.load();
+  });
+
+  async function save(bindings: Record<string, string>) {
+    busy = true;
+    error = "";
+    message = "";
+    try {
+      await shortcuts.save(bindings);
+      recording = null;
+      message = "Keyboard shortcuts saved.";
+    } catch (e) {
+      error = `Could not save keyboard shortcuts: ${String(e)}`;
+    } finally {
+      busy = false;
+    }
+  }
+
+  function capture(event: KeyboardEvent, id: string) {
+    if (recording !== id) return;
+    event.stopPropagation();
+    if (event.key === "Tab") {
+      recording = null;
+      return;
+    }
+    event.preventDefault();
+    if (event.key === "Escape") {
+      recording = null;
+      error = "";
+      return;
+    }
+    if (busy || event.repeat || ["Meta", "Control", "Alt", "Shift"].includes(event.key)) return;
+    const binding = shortcutFromEvent(event);
+    if (!binding) {
+      error =
+        "Use Command on macOS or Ctrl on Windows/Linux, with a letter, number, punctuation key, or F1–F24.";
+      return;
+    }
+    const problem = bindingProblem(id, binding, shortcuts.bindings);
+    if (problem) {
+      error = problem;
+      return;
+    }
+    void save({ ...shortcuts.bindings, [id]: binding });
+  }
+</script>
+
+<div class="space-y-4">
+  <p class="text-press-ui">
+    Choose a shortcut, then press a new key combination. Changes apply immediately to all projects.
+    Escape cancels recording; Tab moves to the next control.
+  </p>
+  <p class="text-press-ui text-press-muted">
+    Standard text editing and system controls (such as copy, paste, undo, Tab, and Escape) keep
+    their usual keys.
+  </p>
+  {#if shortcuts.error}
+    <p role="alert" class="text-press-ui text-press-error">{shortcuts.error}</p>
+    <button
+      type="button"
+      onclick={async () => {
+        await shortcuts.load();
+        await shortcuts.suspend(true);
+      }}>Retry loading shortcuts</button
+    >
+  {/if}
+  {#if error}<p role="alert" class="text-press-ui text-press-error">{error}</p>{/if}
+  <p role="status" class="text-press-ui text-press-muted">{message}</p>
+  <div class="flex flex-wrap gap-3 items-end">
+    <label class="flex-1 text-press-ui"
+      >Filter commands
+      <input
+        type="search"
+        bind:value={filter}
+        class="block w-full mt-1 px-3 py-2 border border-press-border hover:border-press-accent focus:border-press-accent rounded"
+      />
+    </label>
+    <button
+      type="button"
+      disabled={busy || !shortcuts.suspended}
+      onclick={() => save({ ...defaultBindings })}
+      class="px-3 py-2 border border-press-border rounded text-press-ui"
+      >Reset all to defaults</button
+    >
+  </div>
+  {#if (!shortcuts.ready || !shortcuts.suspended) && !shortcuts.error}<p role="status">
+      Loading shortcuts…
+    </p>{/if}
+  <ul class="divide-y divide-press-border">
+    {#each shown as def (def.id)}
+      <li class="flex flex-wrap items-center gap-3 py-3">
+        <div class="flex-1 min-w-0">
+          <p class="text-press-ui">{def.label}</p>
+          <p class="text-press-eyebrow text-press-muted">{def.category}</p>
+        </div>
+        <button
+          type="button"
+          aria-label={`Shortcut for ${def.label}`}
+          aria-describedby={`shortcut-binding-${def.id}`}
+          aria-pressed={recording === def.id}
+          disabled={busy || !shortcuts.ready || !shortcuts.suspended}
+          onclick={() => {
+            recording = def.id;
+            error = "";
+            message = "";
+          }}
+          onkeydown={(event) => capture(event, def.id)}
+          onblur={() => {
+            if (recording === def.id) recording = null;
+          }}
+          class="min-w-28 px-3 py-2 border border-press-border rounded text-press-ui"
+        >
+          <span id={`shortcut-binding-${def.id}`}
+            >{recording === def.id ? "Press keys…" : shortcuts.label(def.id) || "Unassigned"}</span
+          >
+        </button>
+        <button
+          type="button"
+          aria-label={`Clear shortcut for ${def.label}`}
+          disabled={busy || !shortcuts.ready || !shortcuts.suspended || !shortcuts.bindings[def.id]}
+          onclick={() => save({ ...shortcuts.bindings, [def.id]: "" })}
+          class="px-2 py-2 text-press-ui text-press-muted">Clear</button
+        >
+      </li>
+    {/each}
+  </ul>
+  {#if shown.length === 0}<p class="text-press-ui">No matching commands.</p>{/if}
+</div>

--- a/src/lib/components/KeyboardSettings.svelte
+++ b/src/lib/components/KeyboardSettings.svelte
@@ -121,7 +121,9 @@
           aria-describedby={`shortcut-binding-${def.id}`}
           aria-pressed={recording === def.id}
           disabled={busy || !shortcuts.ready || !shortcuts.suspended}
-          onclick={() => {
+          onclick={(event) => {
+            // WebKit on macOS does not focus buttons when they are clicked.
+            event.currentTarget.focus();
             recording = def.id;
             error = "";
             message = "";

--- a/src/lib/components/KeyboardSettings.test.ts
+++ b/src/lib/components/KeyboardSettings.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import KeyboardSettings from "./KeyboardSettings.svelte";
+import { shortcuts } from "../stores/shortcuts.svelte";
+import { defaultBindings } from "../utils/keyboardShortcuts";
+const mod = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+beforeEach(() => {
+  shortcuts.bindings = { ...defaultBindings };
+  shortcuts.ready = true;
+  shortcuts.suspended = true;
+  shortcuts.error = null;
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockImplementation(
+    async (_cmd, args) => (args as { bindings: unknown })?.bindings
+  );
+});
+afterEach(cleanup);
+it("records, rejects conflicts, clears, and resets shortcuts", async () => {
+  render(KeyboardSettings);
+  const button = screen.getByRole("button", { name: "Shortcut for Settings" });
+  await fireEvent.click(button);
+  await fireEvent.keyDown(button, { key: "e", ...mod });
+  expect(screen.getByRole("alert").textContent).toContain("Export project");
+  expect(invoke).not.toHaveBeenCalled();
+  await fireEvent.keyDown(button, { key: "c", ...mod });
+  expect(screen.getByRole("alert").textContent).toContain("reserved");
+  await fireEvent.keyDown(button, { key: "p", altKey: true, ...mod });
+  await screen.findByText("Keyboard shortcuts saved.");
+  expect(shortcuts.bindings.settings).toBe("Mod+Alt+P");
+  await fireEvent.click(screen.getByRole("button", { name: "Clear shortcut for Settings" }));
+  await waitFor(() => expect(shortcuts.bindings.settings).toBe(""));
+  await fireEvent.click(screen.getByRole("button", { name: "Reset all to defaults" }));
+  await waitFor(() => expect(shortcuts.bindings).toEqual(defaultBindings));
+});
+it("cancels recording, filters commands, and reports failed saves", async () => {
+  render(KeyboardSettings);
+  const button = screen.getByRole("button", { name: "Shortcut for Settings" });
+  await fireEvent.click(button);
+  await fireEvent.keyDown(button, { key: "Escape" });
+  expect(button.getAttribute("aria-pressed")).toBe("false");
+  await fireEvent.click(button);
+  await fireEvent.keyDown(button, { key: "Tab" });
+  expect(button.getAttribute("aria-pressed")).toBe("false");
+  await fireEvent.click(button);
+  await fireEvent.keyDown(button, { key: "p" });
+  expect(screen.getByRole("alert").textContent).toContain("Use Command");
+  vi.mocked(invoke).mockRejectedValueOnce("disk full");
+  await fireEvent.keyDown(button, { key: "p", altKey: true, ...mod });
+  await screen.findByText(/Could not save keyboard shortcuts: disk full/);
+  expect(shortcuts.bindings.settings).toBe("Mod+Comma");
+  await fireEvent.input(screen.getByRole("searchbox"), { target: { value: "Bold" } });
+  expect(screen.queryByRole("button", { name: "Shortcut for Settings" })).toBeNull();
+  expect(screen.getByRole("button", { name: "Shortcut for Bold" })).toBeTruthy();
+});
+it("keeps recording disabled until native menu shortcuts are suspended", () => {
+  shortcuts.suspended = false;
+  render(KeyboardSettings);
+  expect(
+    (screen.getByRole("button", { name: "Shortcut for Settings" }) as HTMLButtonElement).disabled
+  ).toBe(true);
+});
+
+it("allows resetting a malformed saved configuration without a successful load", async () => {
+  shortcuts.ready = false;
+  vi.mocked(invoke).mockRejectedValueOnce("malformed shortcuts.json");
+  render(KeyboardSettings);
+  await screen.findByText(/Could not load keyboard shortcuts/);
+  const reset = screen.getByRole("button", { name: "Reset all to defaults" }) as HTMLButtonElement;
+  expect(reset.disabled).toBe(false);
+  vi.mocked(invoke).mockResolvedValue(defaultBindings);
+  await fireEvent.click(reset);
+  await screen.findByText("Keyboard shortcuts saved.");
+  expect(shortcuts.ready).toBe(true);
+  expect(shortcuts.error).toBeNull();
+  const button = screen.getByRole("button", { name: "Shortcut for Settings" });
+  expect(document.getElementById(button.getAttribute("aria-describedby")!)?.textContent).toBe(
+    shortcuts.label("settings")
+  );
+});

--- a/src/lib/components/KeyboardSettings.test.ts
+++ b/src/lib/components/KeyboardSettings.test.ts
@@ -15,7 +15,28 @@ beforeEach(() => {
     async (_cmd, args) => (args as { bindings: unknown })?.bindings
   );
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+it.each([
+  ["MacIntel", { metaKey: true }],
+  ["Win32", { ctrlKey: true }],
+  ["Linux x86_64", { ctrlKey: true }],
+])("focuses the clicked recorder and captures keys on %s", async (platform, modifier) => {
+  vi.spyOn(navigator, "platform", "get").mockReturnValue(platform);
+  render(KeyboardSettings);
+  const filter = screen.getByRole("searchbox");
+  filter.focus();
+  const button = screen.getByRole("button", { name: "Shortcut for Settings" });
+  // WebKit on macOS does not focus buttons on pointer clicks. fireEvent likewise
+  // leaves focus alone, so this exercises the component's own focus handling.
+  await fireEvent.click(button.querySelector("span")!);
+  expect(document.activeElement).toBe(button);
+  await fireEvent.keyDown(document.activeElement!, { key: "p", altKey: true, ...modifier });
+  await screen.findByText("Keyboard shortcuts saved.");
+  expect(shortcuts.bindings.settings).toBe("Mod+Alt+P");
+});
 it("records, rejects conflicts, clears, and resets shortcuts", async () => {
   render(KeyboardSettings);
   const button = screen.getByRole("button", { name: "Shortcut for Settings" });

--- a/src/lib/components/NovelEditor.svelte
+++ b/src/lib/components/NovelEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { KeyboardFormatting } from "../utils/keyboardFormatting";
   import { onMount, onDestroy, untrack } from "svelte";
   import { Editor } from "@tiptap/core";
   import StarterKit from "@tiptap/starter-kit";
@@ -74,6 +75,7 @@
     editor = new Editor({
       element: editorElement,
       extensions: [
+        KeyboardFormatting,
         StarterKit.configure({
           heading: false,
           bulletList: false,

--- a/src/lib/components/ProseToolbar.svelte
+++ b/src/lib/components/ProseToolbar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcuts } from "../stores/shortcuts.svelte";
   import type { Snippet } from "svelte";
   import type { Editor } from "@tiptap/core";
   import {
@@ -46,21 +47,21 @@
   {#if !readonly}
     <div class="group">
       <button
-        title="Bold (Ctrl+B)"
+        title={`Bold ${shortcuts.label("bold")}`.trim()}
         aria-label="Bold"
         aria-pressed={!!active.bold}
         onmousedown={(e) => e.preventDefault()}
         onclick={() => editor?.chain().focus().toggleBold().run()}><Bold size={16} /></button
       >
       <button
-        title="Italic (Ctrl+I)"
+        title={`Italic ${shortcuts.label("italic")}`.trim()}
         aria-label="Italic"
         aria-pressed={!!active.italic}
         onmousedown={(e) => e.preventDefault()}
         onclick={() => editor?.chain().focus().toggleItalic().run()}><Italic size={16} /></button
       >
       <button
-        title="Underline (Ctrl+U)"
+        title={`Underline ${shortcuts.label("underline")}`.trim()}
         aria-label="Underline"
         aria-pressed={!!active.underline}
         onmousedown={(e) => e.preventDefault()}
@@ -68,7 +69,7 @@
         ><Underline size={16} /></button
       >
       <button
-        title="Monospace"
+        title={`Monospace ${shortcuts.label("code")}`.trim()}
         aria-label="Monospace"
         aria-pressed={!!active.code}
         onmousedown={(e) => e.preventDefault()}
@@ -78,7 +79,7 @@
     <div class="group separated">
       {#each [{ id: "left", icon: AlignLeft }, { id: "center", icon: AlignCenter }, { id: "right", icon: AlignRight }, { id: "justify", icon: AlignJustify }] as alignment}
         <button
-          title={`Align ${alignment.id}`}
+          title={`Align ${alignment.id} ${shortcuts.label(`align_${alignment.id}`)}`.trim()}
           aria-label={`Align ${alignment.id}`}
           aria-pressed={!!active[alignment.id as "left" | "center" | "right" | "justify"]}
           onmousedown={(e) => e.preventDefault()}
@@ -87,7 +88,7 @@
         >
       {/each}
       <button
-        title="Blockquote"
+        title={`Blockquote ${shortcuts.label("blockquote")}`.trim()}
         aria-label="Blockquote"
         aria-pressed={!!active.blockquote}
         onmousedown={(e) => e.preventDefault()}

--- a/src/lib/components/QuickStartDialog.svelte
+++ b/src/lib/components/QuickStartDialog.svelte
@@ -8,6 +8,7 @@
   - References panel
 -->
 <script lang="ts">
+  import { shortcuts } from "../stores/shortcuts.svelte";
   import {
     BookOpen,
     ChevronDown,
@@ -153,8 +154,10 @@
           <li class="flex items-start gap-2">
             <span class="text-press-accent-text shrink-0">•</span>
             <span
-              ><strong class="text-press-text">Discovery Notes</strong> (⌘D) — Capture ideas as you write;
-              promote to beats when ready</span
+              ><strong class="text-press-text">Discovery Notes</strong
+              >{#if shortcuts.label("toggle_discovery_notes")}
+                ({shortcuts.label("toggle_discovery_notes")}){/if} — Capture ideas as you write; promote
+              to beats when ready</span
             >
           </li>
         </ul>
@@ -195,9 +198,14 @@
           Tips
         </h3>
         <ul class="space-y-2 text-press-ui text-press-muted">
-          <li><strong class="text-press-text">⌘E</strong> — Export your project</li>
           <li>
-            <strong class="text-press-text">⌘D</strong> — Toggle Discovery Notes in the scene panel
+            <strong class="text-press-text">{shortcuts.label("export") || "Export"}</strong> — Export
+            your project
+          </li>
+          <li>
+            <strong class="text-press-text"
+              >{shortcuts.label("toggle_discovery_notes") || "Discovery Notes"}</strong
+            > — Toggle Discovery Notes in the scene panel
           </li>
           <li>
             <strong class="text-press-text">Snapshots</strong> — Create version checkpoints before big

--- a/src/lib/components/ScenePanel.svelte
+++ b/src/lib/components/ScenePanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { shortcuts } from "../stores/shortcuts.svelte";
   import { countWordsInHtml } from "../utils/wordCount";
   import { writing } from "../stores/writing.svelte";
   import type { SceneReview } from "../utils/revisions";
@@ -338,11 +339,6 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "d" && (e.metaKey || e.ctrlKey)) {
-      e.preventDefault();
-      discoveryNotesVisible = !discoveryNotesVisible;
-      return;
-    }
     if (e.key === "Escape") {
       if (ui.expandedBeatId) {
         beatViewRef?.flushOnSceneChange();
@@ -1229,7 +1225,7 @@
           </section>
         {/if}
 
-        <!-- Discovery Notes (Fixed only, Cmd/Ctrl+D) -->
+        <!-- Discovery Notes (Fixed only) -->
         {#if (scene.planning_status ?? "fixed") === "fixed"}
           <section class="mb-8">
             <button
@@ -1243,7 +1239,8 @@
                 Discovery Notes
               </h2>
               <span class="text-press-eyebrow text-press-muted">
-                {discoveryNotesVisible ? "Hide" : "Show"} (⌘D)
+                {discoveryNotesVisible ? "Hide" : "Show"}
+                {shortcuts.label("toggle_discovery_notes")}
               </span>
             </button>
             {#if discoveryNotesVisible}

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -4,6 +4,7 @@
   import { X } from "lucide-svelte";
   import type { Project } from "../types";
   import { currentProject } from "../stores/project.svelte";
+  import KeyboardSettings from "./KeyboardSettings.svelte";
   import AppearanceSettings from "./AppearanceSettings.svelte";
   import AuthorSettings from "./AuthorSettings.svelte";
   import ProjectSettings from "./ProjectSettings.svelte";
@@ -20,6 +21,7 @@
           areas: [
             { id: "appearance", label: "Appearance & Guidance" },
             { id: "author", label: "Author & Contact" },
+            { id: "keyboard", label: "Keyboard Shortcuts" },
           ],
         },
       ],
@@ -52,10 +54,11 @@
   let error = $state<string | null>(null);
   let authorDirty = $state(false);
   let projectDirty = $state(false);
+  let keyboardBusy = $state(false);
   let authorBusy = $state(false);
   let projectBusy = $state(false);
   let pending = $state<{ projectId: string } | { close: true } | null>(null);
-  const busy = $derived(authorBusy || projectBusy);
+  const busy = $derived(authorBusy || projectBusy || keyboardBusy);
   const selected = $derived(projects.find((project) => project.id === selectedId));
   const activeGroup = $derived(
     groups.find((group) =>
@@ -277,6 +280,7 @@
           </p>
           <h3 class="font-heading text-press-body-lg">{activeArea?.label}</h3>
         </header>
+        {#if area === "keyboard"}<KeyboardSettings bind:busy={keyboardBusy} />{/if}
         <div hidden={area !== "appearance"}><AppearanceSettings /></div>
         <div hidden={area !== "author"}>
           <AuthorSettings bind:dirty={authorDirty} bind:busy={authorBusy} />

--- a/src/lib/shortcutDefinitions.json
+++ b/src/lib/shortcutDefinitions.json
@@ -1,0 +1,287 @@
+[
+  {
+    "id": "editorial_open",
+    "label": "Open review or feedback file",
+    "category": "File",
+    "keywords": ["editor", "package"],
+    "binding": "Mod+O"
+  },
+  {
+    "id": "editorial_project",
+    "label": "Editorial review and packages",
+    "category": "Project",
+    "requiresProject": true,
+    "keywords": ["editor", "feedback", "revisions"],
+    "binding": ""
+  },
+  {
+    "id": "find",
+    "label": "Find in scene",
+    "category": "Edit",
+    "requiresProject": true,
+    "keywords": ["search", "prose"],
+    "binding": "Mod+F"
+  },
+  {
+    "id": "find_replace",
+    "label": "Find and replace",
+    "category": "Edit",
+    "requiresProject": true,
+    "keywords": ["search", "replace", "prose"],
+    "binding": "Mod+Alt+F"
+  },
+  {
+    "id": "find_project",
+    "label": "Find and replace in project",
+    "category": "Edit",
+    "requiresProject": true,
+    "keywords": ["search", "replace", "all"],
+    "binding": "Mod+Shift+F"
+  },
+  {
+    "id": "export",
+    "label": "Export project",
+    "category": "File",
+    "requiresProject": true,
+    "keywords": ["export", "docx", "manuscript"],
+    "binding": "Mod+E"
+  },
+  {
+    "id": "close_project",
+    "label": "Close project",
+    "category": "File",
+    "requiresProject": true,
+    "keywords": ["close"],
+    "binding": "Mod+W"
+  },
+  {
+    "id": "quit",
+    "label": "Quit Kindling",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["quit", "exit"],
+    "binding": "Mod+Q"
+  },
+  {
+    "id": "import_plottr",
+    "label": "Import Plottr (.pltr)",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "plottr"],
+    "binding": "Mod+Shift+O"
+  },
+  {
+    "id": "import_markdown",
+    "label": "Import Markdown (.md)",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "markdown", "md"],
+    "binding": "Mod+Shift+M"
+  },
+  {
+    "id": "import_longform",
+    "label": "Import Longform",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "longform", "obsidian"],
+    "binding": "Mod+Shift+L"
+  },
+  {
+    "id": "import_ywriter",
+    "label": "Import yWriter 7 (.yw7)",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "ywriter", "yw7"],
+    "binding": "Mod+Shift+Y"
+  },
+  {
+    "id": "import_scrivener",
+    "label": "Import Scrivener 3 (.scriv)",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "scrivener", "scriv"],
+    "binding": "Mod+Shift+I"
+  },
+  {
+    "id": "import_novelwriter",
+    "label": "Import novelWriter",
+    "category": "File",
+    "requiresProject": false,
+    "keywords": ["import", "novelwriter", "nwx"],
+    "binding": ""
+  },
+  {
+    "id": "sync",
+    "label": "Sync from source",
+    "category": "Project",
+    "requiresProject": true,
+    "requiresSourcePath": true,
+    "keywords": ["sync", "reimport", "refresh", "reload"],
+    "binding": "Mod+Shift+S"
+  },
+  {
+    "id": "toggle_sidebar",
+    "label": "Toggle sidebar",
+    "category": "View",
+    "requiresProject": true,
+    "keywords": ["sidebar", "outline", "collapse", "expand"],
+    "binding": "Mod+Backslash"
+  },
+  {
+    "id": "toggle_references",
+    "label": "Toggle references panel",
+    "category": "View",
+    "requiresProject": true,
+    "keywords": ["references", "characters", "panel", "collapse", "expand"],
+    "binding": "Mod+Shift+R"
+  },
+  {
+    "id": "toggle_discovery_notes",
+    "label": "Toggle discovery notes",
+    "category": "View",
+    "requiresProject": true,
+    "keywords": ["discovery", "notes", "draft"],
+    "binding": "Mod+D"
+  },
+  {
+    "id": "toggle_editor_mode",
+    "label": "Toggle beat/page view",
+    "category": "View",
+    "requiresProject": true,
+    "keywords": ["page", "beat", "view", "mode", "prose", "editor"],
+    "binding": "Mod+Alt+V"
+  },
+  {
+    "id": "detect_references",
+    "label": "Detect references in scene",
+    "category": "Project",
+    "requiresProject": true,
+    "keywords": ["detect", "references", "scan", "suggest", "smart"],
+    "binding": ""
+  },
+  {
+    "id": "detect_all_references",
+    "label": "Detect references in all scenes",
+    "category": "Project",
+    "requiresProject": true,
+    "keywords": ["detect", "all", "references", "scan", "suggest", "bulk"],
+    "binding": ""
+  },
+  {
+    "id": "about",
+    "label": "About Kindling",
+    "category": "Help",
+    "requiresProject": false,
+    "keywords": ["about", "version", "info"],
+    "binding": ""
+  },
+  {
+    "id": "quick_start",
+    "label": "Quick start guide",
+    "category": "Help",
+    "requiresProject": false,
+    "keywords": ["help", "quick", "start", "guide", "docs"],
+    "binding": "Mod+Shift+H"
+  },
+  {
+    "id": "settings",
+    "label": "Settings",
+    "category": "Help",
+    "requiresProject": false,
+    "keywords": [
+      "settings",
+      "kindling",
+      "preferences",
+      "author",
+      "project",
+      "theme",
+      "tags",
+      "fields"
+    ],
+    "binding": "Mod+Comma"
+  },
+  {
+    "id": "new_project",
+    "label": "New project",
+    "binding": "Mod+N",
+    "category": "File"
+  },
+  {
+    "id": "command_palette",
+    "label": "Command palette",
+    "binding": "Mod+K",
+    "category": "Help"
+  },
+  {
+    "id": "send_feedback",
+    "label": "Send feedback",
+    "binding": "",
+    "category": "Help"
+  },
+  {
+    "id": "editorial_comment",
+    "label": "Add editorial comment",
+    "binding": "Mod+Alt+M",
+    "category": "Editor"
+  },
+  {
+    "id": "bold",
+    "label": "Bold",
+    "binding": "Mod+B",
+    "category": "Editor"
+  },
+  {
+    "id": "italic",
+    "label": "Italic",
+    "binding": "Mod+I",
+    "category": "Editor"
+  },
+  {
+    "id": "underline",
+    "label": "Underline",
+    "binding": "Mod+U",
+    "category": "Editor"
+  },
+  {
+    "id": "strike",
+    "label": "Strikethrough",
+    "binding": "Mod+Shift+X",
+    "category": "Editor"
+  },
+  {
+    "id": "code",
+    "label": "Monospace",
+    "binding": "",
+    "category": "Editor"
+  },
+  {
+    "id": "blockquote",
+    "label": "Blockquote",
+    "binding": "Mod+Shift+B",
+    "category": "Editor"
+  },
+  {
+    "id": "align_left",
+    "label": "Align left",
+    "binding": "",
+    "category": "Editor"
+  },
+  {
+    "id": "align_center",
+    "label": "Align center",
+    "binding": "Mod+Shift+E",
+    "category": "Editor"
+  },
+  {
+    "id": "align_right",
+    "label": "Align right",
+    "binding": "",
+    "category": "Editor"
+  },
+  {
+    "id": "align_justify",
+    "label": "Justify",
+    "binding": "Mod+Shift+J",
+    "category": "Editor"
+  }
+]

--- a/src/lib/stores/shortcuts.svelte.test.ts
+++ b/src/lib/stores/shortcuts.svelte.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { Shortcuts } from "./shortcuts.svelte";
+import { defaultBindings } from "../utils/keyboardShortcuts";
+beforeEach(() => vi.mocked(invoke).mockReset());
+it("loads once, applies saved bindings, and reloads them in a new session", async () => {
+  const saved = { ...defaultBindings, command_palette: "Mod+Alt+K" };
+  vi.mocked(invoke).mockResolvedValue(saved);
+  const store = new Shortcuts();
+  await Promise.all([store.load(), store.load()]);
+  await store.load();
+  expect(invoke).toHaveBeenCalledTimes(1);
+  expect(store.ready).toBe(true);
+  expect(store.bindings.command_palette).toBe("Mod+Alt+K");
+  await store.save(saved);
+  const next = new Shortcuts();
+  await next.load();
+  expect(next.bindings).toEqual(saved);
+  expect(next.label("missing")).toBe("");
+  expect(next.label("command_palette")).toContain("K");
+  const mod = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+  expect(next.match(new KeyboardEvent("keydown", { key: "k", altKey: true, ...mod }))).toBe(
+    "command_palette"
+  );
+  expect(next.match(new KeyboardEvent("keydown", { key: "k", ...mod }))).toBeUndefined();
+  expect(next.match(new KeyboardEvent("keydown", { key: "k" }))).toBeUndefined();
+});
+it("reports load failures and retries; failed saves preserve the active bindings", async () => {
+  const store = new Shortcuts();
+  vi.mocked(invoke).mockRejectedValue(new Error("disk unavailable"));
+  await store.load();
+  expect(store.error).toContain("disk unavailable");
+  expect(store.ready).toBe(false);
+  await expect(store.save({ ...defaultBindings, quit: "" })).rejects.toThrow("disk unavailable");
+  expect(store.bindings.quit).toBe(defaultBindings.quit);
+  vi.mocked(invoke).mockResolvedValue(defaultBindings);
+  await store.load();
+  expect(store.ready).toBe(true);
+  expect(store.error).toBeNull();
+});
+it("serializes menu suspension and reports failures without breaking subsequent calls", async () => {
+  const store = new Shortcuts();
+  vi.mocked(invoke).mockRejectedValueOnce("menu failed");
+  await store.suspend(true);
+  expect(store.error).toContain("menu failed");
+  expect(store.suspended).toBe(false);
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  store.ready = true;
+  await Promise.all([store.suspend(true), store.suspend(false)]);
+  expect(store.suspended).toBe(false);
+  expect(store.error).toBeNull();
+  expect(vi.mocked(invoke).mock.calls.slice(-2)).toEqual([
+    ["suspend_keyboard_shortcuts", { suspended: true }],
+    ["suspend_keyboard_shortcuts", { suspended: false }],
+  ]);
+});

--- a/src/lib/stores/shortcuts.svelte.ts
+++ b/src/lib/stores/shortcuts.svelte.ts
@@ -1,0 +1,66 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  defaultBindings,
+  formatShortcut,
+  shortcutFromEvent,
+  type Bindings,
+} from "../utils/keyboardShortcuts";
+
+export class Shortcuts {
+  bindings = $state<Bindings>({ ...defaultBindings });
+  ready = $state(false);
+  error = $state<string | null>(null);
+  suspended = $state(false);
+  recording = $state(false);
+  private suspension = Promise.resolve();
+  private loading: Promise<void> | null = null;
+
+  load(): Promise<void> {
+    if (this.ready) return Promise.resolve();
+    if (this.loading) return this.loading;
+    this.error = null;
+    this.loading = invoke<Bindings>("get_keyboard_shortcuts")
+      .then((bindings) => {
+        this.bindings = { ...defaultBindings, ...bindings };
+        this.ready = true;
+      })
+      .catch((error) => {
+        this.error = `Could not load keyboard shortcuts: ${String(error)}`;
+      })
+      .finally(() => {
+        this.loading = null;
+      });
+    return this.loading;
+  }
+
+  suspend(suspended: boolean): Promise<void> {
+    this.suspension = this.suspension.then(async () => {
+      try {
+        await invoke("suspend_keyboard_shortcuts", { suspended });
+        this.suspended = suspended;
+        if (this.ready) this.error = null;
+      } catch (error) {
+        this.error = `Could not update native keyboard shortcuts: ${String(error)}`;
+      }
+    });
+    return this.suspension;
+  }
+
+  async save(bindings: Bindings) {
+    const saved = await invoke<Bindings>("set_keyboard_shortcuts", { bindings });
+    this.bindings = { ...defaultBindings, ...saved };
+    this.ready = true;
+    this.error = null;
+  }
+
+  label(id: string) {
+    return formatShortcut(this.bindings[id] ?? "");
+  }
+  match(event: KeyboardEvent) {
+    const binding = shortcutFromEvent(event);
+    return binding
+      ? Object.keys(this.bindings).find((id) => this.bindings[id] === binding)
+      : undefined;
+  }
+}
+export const shortcuts = new Shortcuts();

--- a/src/lib/utils/keyboardFormatting.test.ts
+++ b/src/lib/utils/keyboardFormatting.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import TextAlign from "@tiptap/extension-text-align";
+import { KeyboardFormatting } from "./keyboardFormatting";
+import { defaultBindings } from "./keyboardShortcuts";
+import { shortcuts } from "../stores/shortcuts.svelte";
+let editor: Editor;
+const mod = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+beforeEach(() => {
+  shortcuts.bindings = { ...defaultBindings };
+  editor = new Editor({
+    extensions: [StarterKit, TextAlign.configure({ types: ["paragraph"] }), KeyboardFormatting],
+    content: "<p>Words</p>",
+  });
+  editor.commands.setTextSelection({ from: 1, to: 6 });
+});
+afterEach(() => {
+  editor.destroy();
+});
+function press(key: string, extra = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    ...mod,
+    ...extra,
+    bubbles: true,
+    cancelable: true,
+  });
+  editor.view.dom.dispatchEvent(event);
+  return event;
+}
+it("remaps formatting immediately and suppresses the old built-in key", () => {
+  shortcuts.bindings.bold = "Mod+Alt+P";
+  expect(press("b").defaultPrevented).toBe(true);
+  expect(editor.isActive("bold")).toBe(false);
+  press("p", { altKey: true });
+  expect(editor.isActive("bold")).toBe(true);
+  shortcuts.bindings.bold = "";
+  press("p", { altKey: true });
+  expect(editor.isActive("bold")).toBe(true);
+});
+it.each([
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "code",
+  "blockquote",
+  "align_left",
+  "align_center",
+  "align_right",
+  "align_justify",
+])("executes %s through its custom binding", (id) => {
+  shortcuts.bindings[id] = "Mod+Alt+P";
+  press("p", { altKey: true });
+  expect(
+    id.startsWith("align_") ? editor.isActive({ textAlign: id.slice(6) }) : editor.isActive(id)
+  ).toBe(true);
+});
+it("does not mutate read-only prose or toggle twice on a held key", () => {
+  editor.setEditable(false);
+  press("b");
+  expect(editor.isActive("bold")).toBe(false);
+  editor.setEditable(true);
+  press("b", { repeat: true });
+  expect(editor.isActive("bold")).toBe(false);
+  expect(press("Escape").defaultPrevented).toBe(false);
+});
+
+it.each(["B", "I", "U", "S"])(
+  "suppresses legacy shifted %s aliases after clearing formatting",
+  (key) => {
+    for (const id of [
+      "bold",
+      "italic",
+      "underline",
+      "strike",
+      "blockquote",
+      "sync",
+      "import_scrivener",
+    ])
+      shortcuts.bindings[id] = "";
+    press(key, { shiftKey: true });
+    expect(editor.getHTML()).toBe("<p>Words</p>");
+  }
+);

--- a/src/lib/utils/keyboardFormatting.ts
+++ b/src/lib/utils/keyboardFormatting.ts
@@ -1,0 +1,60 @@
+import { Extension } from "@tiptap/core";
+import { Plugin } from "@tiptap/pm/state";
+import { shortcuts } from "../stores/shortcuts.svelte";
+import { shortcutFromEvent } from "./keyboardShortcuts";
+
+// Suppress built-in formatting keys after reassignment, including defaults that
+// collide with Kindling's native commands (code/export and align/import/panels).
+const builtIn = new Set([
+  "Mod+B",
+  "Mod+I",
+  "Mod+U",
+  "Mod+Shift+X",
+  "Mod+Shift+S",
+  "Mod+Shift+I",
+  "Mod+Shift+U",
+  "Mod+E",
+  "Mod+Shift+B",
+  "Mod+Shift+L",
+  "Mod+Shift+E",
+  "Mod+Shift+R",
+  "Mod+Shift+J",
+]);
+export const KeyboardFormatting = Extension.create({
+  name: "keyboardFormatting",
+  priority: 1000,
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    return [
+      new Plugin({
+        props: {
+          handleKeyDown: (_view, event) => {
+            const id = shortcuts.match(event);
+            const commands: Record<string, () => boolean> = {
+              bold: () => editor.commands.toggleBold(),
+              italic: () => editor.commands.toggleItalic(),
+              underline: () => editor.commands.toggleUnderline(),
+              strike: () => editor.commands.toggleStrike(),
+              code: () => editor.commands.toggleCode(),
+              blockquote: () => editor.commands.toggleBlockquote(),
+              align_left: () => editor.commands.setTextAlign("left"),
+              align_center: () => editor.commands.setTextAlign("center"),
+              align_right: () => editor.commands.setTextAlign("right"),
+              align_justify: () => editor.commands.setTextAlign("justify"),
+            };
+            if (id && Object.prototype.hasOwnProperty.call(commands, id)) {
+              event.preventDefault();
+              if (editor.isEditable && !event.repeat) commands[id]();
+              return true;
+            }
+            if (builtIn.has(shortcutFromEvent(event) ?? "")) {
+              event.preventDefault();
+              return true;
+            }
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/lib/utils/keyboardShortcuts.test.ts
+++ b/src/lib/utils/keyboardShortcuts.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import definitions from "../shortcutDefinitions.json";
+import {
+  bindingProblem,
+  defaultBindings,
+  formatShortcut,
+  shortcutFromEvent,
+} from "./keyboardShortcuts";
+
+describe("keyboard shortcuts", () => {
+  it("has unique valid defaults and detects collisions including formatting", () => {
+    for (const def of definitions)
+      expect(bindingProblem(def.id, def.binding, defaultBindings)).toBeNull();
+    expect(bindingProblem("settings", "Mod+B", defaultBindings)).toContain("Bold");
+    expect(bindingProblem("settings", "Mod+Comma", defaultBindings)).toBeNull();
+    expect(bindingProblem("settings", "", defaultBindings)).toBeNull();
+    expect(bindingProblem("settings", "Mod+C", defaultBindings)).toContain("reserved");
+  });
+  it.each([
+    [{ key: "k", code: "KeyK", metaKey: true }, true, "Mod+K"],
+    [{ key: "K", code: "KeyK", ctrlKey: true, shiftKey: true }, false, "Mod+Shift+K"],
+    [{ key: "µ", code: "KeyM", metaKey: true, altKey: true }, true, "Mod+Alt+M"],
+    [{ key: "?", code: "Slash", ctrlKey: true, shiftKey: true }, false, "Mod+Shift+Slash"],
+    [{ key: ",", metaKey: true }, true, "Mod+Comma"],
+    [{ key: "7", code: "Digit7", metaKey: true, altKey: true }, true, "Mod+Alt+7"],
+    [{ key: "F12", ctrlKey: true }, false, "Mod+F12"],
+    [{ key: "k", ctrlKey: true }, true, null],
+    [{ key: "k", metaKey: true }, false, null],
+    [{ key: "k", ctrlKey: true, metaKey: true }, false, null],
+    [{ key: "a" }, false, null],
+    [{ key: "Tab", ctrlKey: true }, false, null],
+    [{ key: "Dead", ctrlKey: true }, false, null],
+    [{ key: "k", ctrlKey: true, isComposing: true }, false, null],
+  ] as const)("normalizes keyboard event %j", (init, mac, expected) => {
+    expect(shortcutFromEvent(new KeyboardEvent("keydown", init), mac)).toBe(expected);
+  });
+  it("ignores AltGraph input", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", ctrlKey: true });
+    Object.defineProperty(event, "getModifierState", { value: () => true });
+    expect(shortcutFromEvent(event, false)).toBeNull();
+  });
+  it("formats each platform and named punctuation", () => {
+    expect(formatShortcut("Mod+Alt+Shift+Comma", true)).toBe("⌥⇧⌘,");
+    expect(formatShortcut("Mod+Alt+Shift+Backslash", false)).toBe("Ctrl+Alt+Shift+\\");
+    expect(formatShortcut("", true)).toBe("");
+  });
+});
+
+it("uses logical AZERTY letters and punctuation rather than US key positions", () => {
+  expect(
+    shortcutFromEvent(
+      new KeyboardEvent("keydown", { key: "m", code: "Semicolon", metaKey: true }),
+      true
+    )
+  ).toBe("Mod+M");
+  expect(
+    shortcutFromEvent(new KeyboardEvent("keydown", { key: ",", code: "KeyM", metaKey: true }), true)
+  ).toBe("Mod+Comma");
+  expect(bindingProblem("settings", "Mod+M", defaultBindings)).toContain("reserved");
+  expect(bindingProblem("settings", "Mod+Shift+V", defaultBindings)).toContain("reserved");
+  expect(bindingProblem("settings", "Mod+Alt+Shift+V", defaultBindings)).toContain("reserved");
+});

--- a/src/lib/utils/keyboardShortcuts.ts
+++ b/src/lib/utils/keyboardShortcuts.ts
@@ -1,0 +1,103 @@
+import definitions from "../shortcutDefinitions.json";
+
+export type Bindings = Record<string, string>;
+export const defaultBindings: Bindings = Object.fromEntries(
+  definitions.map((def) => [def.id, def.binding])
+);
+export const isMac = () => /Mac|iPhone|iPad/.test(navigator.platform);
+const namedKeys: Record<string, string> = {
+  ",": "Comma",
+  ".": "Period",
+  "/": "Slash",
+  "\\": "Backslash",
+  ";": "Semicolon",
+  "'": "Quote",
+  "[": "BracketLeft",
+  "]": "BracketRight",
+  "-": "Minus",
+  "=": "Equal",
+  "`": "Backquote",
+};
+// Native editing and window management stay with the OS. Never steal text input.
+export const reservedBindings = [
+  "Mod+X",
+  "Mod+C",
+  "Mod+V",
+  "Mod+Shift+V",
+  "Mod+Alt+Shift+V",
+  "Mod+A",
+  "Mod+Z",
+  "Mod+Shift+Z",
+  "Mod+Y",
+  "Mod+M",
+  "Mod+H",
+  "Mod+Alt+H",
+];
+
+export function shortcutFromEvent(event: KeyboardEvent, mac = isMac()): string | null {
+  if (event.isComposing || event.getModifierState?.("AltGraph")) return null;
+  if (!(mac ? event.metaKey : event.ctrlKey) || (mac ? event.ctrlKey : event.metaKey)) return null;
+  // Prefer the logical key, regardless of its physical location (e.g. AZERTY M).
+  let key = namedKeys[event.key] ?? event.key.toUpperCase();
+  const recognized =
+    /^[A-Z0-9]$/.test(key) ||
+    Object.values(namedKeys).includes(key) ||
+    /^F([1-9]|1[0-9]|2[0-4])$/.test(key);
+  // Option/Shift can produce a symbol instead of a base key. Fall back only
+  // for those symbols, never overwrite an already recognizable logical key.
+  if (!recognized && (event.altKey || event.shiftKey)) {
+    if (/^Key[A-Z]$/.test(event.code)) key = event.code.slice(3);
+    else if (/^Digit[0-9]$/.test(event.code)) key = event.code.slice(5);
+    else if (Object.values(namedKeys).includes(event.code)) key = event.code;
+  }
+  if (
+    !/^[A-Z0-9]$/.test(key) &&
+    !Object.values(namedKeys).includes(key) &&
+    !/^F([1-9]|1[0-9]|2[0-4])$/.test(key)
+  )
+    return null;
+  return `Mod+${event.altKey ? "Alt+" : ""}${event.shiftKey ? "Shift+" : ""}${key}`;
+}
+
+export function formatShortcut(binding: string, mac = isMac()): string {
+  if (!binding) return "";
+  const names: Record<string, string> = Object.fromEntries(
+    Object.entries(namedKeys).map(([key, name]) => [name, key])
+  );
+  const parts = binding.split("+");
+  if (mac)
+    parts.sort((a, b) =>
+      ["Alt", "Shift", "Mod"].indexOf(a) < 0
+        ? 1
+        : ["Alt", "Shift", "Mod"].indexOf(b) < 0
+          ? -1
+          : ["Alt", "Shift", "Mod"].indexOf(a) - ["Alt", "Shift", "Mod"].indexOf(b)
+    );
+  return parts
+    .map((part) =>
+      part === "Mod"
+        ? mac
+          ? "⌘"
+          : "Ctrl"
+        : part === "Alt"
+          ? mac
+            ? "⌥"
+            : "Alt"
+          : part === "Shift"
+            ? mac
+              ? "⇧"
+              : "Shift"
+            : (names[part] ?? part)
+    )
+    .join(mac ? "" : "+");
+}
+
+export function bindingProblem(id: string, binding: string, bindings: Bindings): string | null {
+  if (!binding) return null;
+  if (reservedBindings.includes(binding))
+    return "This shortcut is reserved for standard text editing or window controls.";
+  const conflict = definitions.find((def) => def.id !== id && bindings[def.id] === binding);
+  return conflict
+    ? `Already used by ${conflict.label}. Clear or change that shortcut first.`
+    : null;
+}


### PR DESCRIPTION
## Summary

Writers can remap Kindling commands and prose-formatting shortcuts in Settings → Kindling → Preferences → Keyboard Shortcuts. Changes apply immediately, persist across launches, and update native menus and visible shortcut hints. The page supports filtering, conflict warnings, clearing bindings, and resetting defaults.

A shared registry drives command dispatch, editor formatting, native accelerators, and platform-specific labels. macOS displays Command symbols; Windows and Linux display Ctrl labels and neutral keyboard icons. Clicking a recorder explicitly focuses it so keypresses reach it in the macOS webview.

## Related Issues

Closes #57

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Testing Instructions

1. Open Settings → Keyboard Shortcuts. Click a binding, press an available combination, and confirm it saves. Close Settings and verify the new binding works and its old binding no longer triggers the command.
2. Assign a combination already used by another command. Verify the warning names the conflict and does not save. Verify Escape cancels recording without closing Settings, and Tab cancels and moves focus.
3. Remap a prose-formatting command and check both its new combination and removed default aliases in the editor.
4. Restart Kindling and verify persistence, native menu accelerators, and displayed hints. Clear a binding and reset defaults.
5. On Windows and Linux, verify Ctrl input and labels; on macOS, verify Command input and symbols. Native Windows/Linux testing remains outstanding.

## Additional Notes

- Standard text editing, OS controls, and dialog navigation remain reserved. The editor-mode default is now Mod+Alt+V to preserve plain-text paste.
- Native menus are rebuilt on binding changes and while Settings is open because the pinned macOS menu library otherwise retains cleared accelerators. TipTap's original formatting aliases are suppressed after remapping.
- The final branch passed all 635 frontend tests in the pre-push hook, including simulated macOS/Windows/Linux labels, modifiers, and focus delivery. The feature also passed coverage thresholds and all 461 Rust tests before the final frontend-only corrections. `check:all` and the production build pass; existing warnings remain.
- Runtime testing used an isolated macOS Tauri data directory. Verified persistence after restart, conflict rejection, failed-save handling, native accelerator suspension/removal, and light/dark appearance. For the recorder fix, OS-generated Command–Option–P saved successfully, Command–O restored the original binding, and trusted Escape/Tab events cancelled correctly. Windows/Linux coverage is simulated, not native end-to-end verification.
- Independent review-agent and Claude code-review at high effort report no remaining actionable findings after fixes, including focused reviews of the final recorder correction.
