### PR TITLE
fix: preserve writing focus, accessible labels, exports, and snapshots

### DIFF
--- a/docs/exporting-projects.md
+++ b/docs/exporting-projects.md
@@ -2,6 +2,14 @@
 
 Kindling exports your work to multiple formats so you can move between outlining, drafting, and publishing workflows.
 
+Manuscript exports (DOCX, Markdown, Longform, EPUB, Scrivener, and novelWriter) use each scene's
+active writing view: Page View prose or Beat View prose, exactly once. Cached prose
+from the other view is excluded. Scenes without beats use Page View prose. DOCX
+body text and its manuscript word count follow this same rule. Longform retains
+beat outline prompts and the active editor mode for roundtripping, but excludes
+inactive beat prose. When beat markers are requested for a Page View scene, its
+outline headings follow the page prose; they do not imply paragraph boundaries.
+
 ## Export Dialog
 
 Open **Export** from the project toolbar or menu, then choose a format and scope.

--- a/docs/scene-workflow.md
+++ b/docs/scene-workflow.md
@@ -37,3 +37,16 @@ These controls influence scene filters in the sidebar and are used in exports.
 ## Scene Locking
 
 Locked scenes (or scenes inside locked chapters) are read-only. Unlock the scene to edit beats, prose, or metadata.
+
+## Cancelling quit after a save failure
+
+If saving fails while quitting, choose **Keep editing** or press **Escape** to
+return to the same writing editor and selection. Kindling restores the caret only
+while that editor still belongs to the same scene and project and you have not
+moved focus to another control outside the quit prompt.
+
+## Snapshot independence
+
+Each newly created project snapshot has its own backing file, including snapshots
+created in rapid succession. Deleting one leaves the others available to preview
+and restore.

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -4,6 +4,7 @@
 
 use crate::commands::{load_app_settings, AppState};
 use crate::db;
+use crate::db::writing::uses_page_prose;
 use crate::models::{AppSettings, Beat, Chapter, Project, Scene, SnapshotTrigger};
 use chrono::Utc;
 use docx_rs::*;
@@ -1163,6 +1164,14 @@ fn generate_scene_markdown(scene: &Scene, beats: &[Beat], include_beat_markers: 
         }
     }
 
+    if uses_page_prose(scene, beats) {
+        let prose = strip_html(scene.prose.as_deref().unwrap_or(""));
+        if !prose.is_empty() {
+            content.push_str(&prose);
+            content.push_str("\n\n");
+        }
+    }
+
     // Beats
     for beat in beats {
         if include_beat_markers {
@@ -1170,7 +1179,11 @@ fn generate_scene_markdown(scene: &Scene, beats: &[Beat], include_beat_markers: 
         }
 
         // Beat prose
-        if let Some(ref prose) = beat.prose {
+        if let Some(prose) = beat
+            .prose
+            .as_ref()
+            .filter(|_| !uses_page_prose(scene, beats))
+        {
             let clean_prose = strip_html(prose);
             if !clean_prose.is_empty() {
                 content.push_str(&clean_prose);
@@ -1286,6 +1299,7 @@ fn generate_longform_scene_markdown(
     let mut meta_parts = vec![
         format!("scene_type={}", scene.scene_type.as_str()),
         format!("scene_status={}", scene.scene_status.as_str()),
+        format!("editor_mode={}", scene.editor_mode.as_str()),
     ];
 
     if let Some(ref synopsis) = scene.synopsis {
@@ -1299,7 +1313,11 @@ fn generate_longform_scene_markdown(
 
     content.push_str(&format!("<!-- kindling: {} -->\n\n", meta_parts.join(" ")));
 
-    if let Some(ref prose) = scene.prose {
+    if let Some(prose) = scene
+        .prose
+        .as_ref()
+        .filter(|_| uses_page_prose(scene, beats))
+    {
         let clean_prose = strip_html(prose);
         if !clean_prose.trim().is_empty() {
             content.push_str(clean_prose.trim());
@@ -1311,7 +1329,11 @@ fn generate_longform_scene_markdown(
         content.push_str("<!-- kindling: beats -->\n");
         for beat in beats {
             content.push_str(&format!("- {}\n", beat.content.trim()));
-            if let Some(ref prose) = beat.prose {
+            if let Some(prose) = beat
+                .prose
+                .as_ref()
+                .filter(|_| !uses_page_prose(scene, beats))
+            {
                 let clean_prose = strip_html(prose);
                 if !clean_prose.trim().is_empty() {
                     for line in clean_prose.lines() {
@@ -2672,6 +2694,14 @@ fn add_scene_to_docx(
     // or if it's after a scene break (no heading/synopsis shown)
     let mut is_first_para = is_first_in_chapter && !options.include_beat_markers;
 
+    if uses_page_prose(scene, beats) {
+        docx = add_prose_to_docx(docx, scene.prose.as_deref(), options, is_first_para).0;
+        for beat in beats {
+            docx = add_beat_marker_to_docx(docx, beat, options);
+        }
+        return docx;
+    }
+
     for beat in beats {
         let (new_docx, added_content) = add_beat_to_docx(docx, beat, options, is_first_para);
         docx = new_docx;
@@ -2696,8 +2726,17 @@ fn add_beat_to_docx(
     options: &DocxExportOptions,
     is_first_para_in_section: bool,
 ) -> (Docx, bool) {
+    let docx = add_beat_marker_to_docx(docx, beat, options);
+    add_prose_to_docx(
+        docx,
+        beat.prose.as_deref(),
+        options,
+        is_first_para_in_section,
+    )
+}
+
+fn add_beat_marker_to_docx(docx: Docx, beat: &Beat, options: &DocxExportOptions) -> Docx {
     let mut docx = docx;
-    let mut added_content = false;
     let font_name = options.font_family.as_str();
     let line_spacing_twips = options.line_spacing.as_twips();
     let line_spacing_u32 = options.line_spacing.as_twips_u32();
@@ -2724,8 +2763,21 @@ fn add_beat_to_docx(
         );
     }
 
-    // Beat prose - parse HTML and preserve formatting (bold, italic, blockquotes)
-    if let Some(ref prose) = beat.prose {
+    docx
+}
+
+/// Render page or beat prose with identical manuscript formatting.
+fn add_prose_to_docx(
+    mut docx: Docx,
+    prose: Option<&str>,
+    options: &DocxExportOptions,
+    is_first_para_in_section: bool,
+) -> (Docx, bool) {
+    let mut added_content = false;
+    let font_name = options.font_family.as_str();
+    let line_spacing_twips = options.line_spacing.as_twips();
+    // Parse HTML and preserve formatting (bold, italic, blockquotes).
+    if let Some(prose) = prose {
         let formatted_paragraphs = parse_html_to_paragraphs(prose);
 
         // Track the index of regular (non-blockquote) paragraphs for first-line indent logic
@@ -3237,46 +3289,11 @@ pub async fn export_to_epub(
                 );
             }
 
-            if options.include_beat_markers {
-                body.push_str(&format!(
-                    "\n  <h2 class=\"scene-title\">{}</h2>",
-                    escape_xml(&scene.title)
-                ));
-            }
-
-            if options.include_synopsis {
-                if let Some(ref synopsis) = scene.synopsis {
-                    if !synopsis.trim().is_empty() {
-                        let synopsis_text = escape_xml(&transform_text(synopsis));
-                        body.push_str(&format!("\n  <p class=\"synopsis\">{}</p>", synopsis_text));
-                    }
-                }
-            }
-
-            if let Some(ref prose) = scene.prose {
-                if !prose.trim().is_empty() {
-                    body.push('\n');
-                    body.push_str(&render_html_to_xhtml(prose));
-                }
-            }
-
             let beats = beats_by_scene
                 .get(&scene.id)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            for beat in beats {
-                if options.include_beat_markers && !beat.content.trim().is_empty() {
-                    let beat_title = escape_xml(&transform_text(&beat.content));
-                    body.push_str(&format!("\n  <h3 class=\"beat-title\">{}</h3>", beat_title));
-                }
-
-                if let Some(ref prose) = beat.prose {
-                    if !prose.trim().is_empty() {
-                        body.push('\n');
-                        body.push_str(&render_html_to_xhtml(prose));
-                    }
-                }
-            }
+            append_scene_to_epub(&mut body, scene, beats, &options);
 
             is_first_scene = false;
         }
@@ -4178,30 +4195,71 @@ fn default_backup() -> bool {
     true
 }
 
-/// Gather beat prose for a scene, concatenated
-fn gather_scene_prose(conn: &rusqlite::Connection, scene: &Scene) -> Result<String, String> {
-    let beats = db::queries::get_beats(conn, &scene.id).map_err(|e| e.to_string())?;
-    let mut parts: Vec<String> = Vec::new();
-
-    if let Some(ref prose) = scene.prose {
-        if !prose.trim().is_empty() {
-            parts.push(prose.clone());
-        }
+/// Append only the active manuscript representation to an EPUB chapter.
+fn append_scene_to_epub(
+    body: &mut String,
+    scene: &Scene,
+    beats: &[Beat],
+    options: &EpubExportOptions,
+) {
+    if options.include_beat_markers {
+        body.push_str(&format!(
+            "\n  <h2 class=\"scene-title\">{}</h2>",
+            escape_xml(&scene.title)
+        ));
     }
 
-    for beat in &beats {
-        if let Some(ref prose) = beat.prose {
-            if !prose.trim().is_empty() {
-                parts.push(prose.clone());
+    if options.include_synopsis {
+        if let Some(ref synopsis) = scene.synopsis {
+            if !synopsis.trim().is_empty() {
+                let synopsis_text = escape_xml(&transform_text(synopsis));
+                body.push_str(&format!("\n  <p class=\"synopsis\">{}</p>", synopsis_text));
             }
         }
     }
 
-    if parts.is_empty() {
-        Ok(String::new())
-    } else {
-        Ok(parts.join("\n"))
+    if let Some(prose) = scene
+        .prose
+        .as_ref()
+        .filter(|_| uses_page_prose(scene, beats))
+    {
+        if !prose.trim().is_empty() {
+            body.push('\n');
+            body.push_str(&render_html_to_xhtml(prose));
+        }
     }
+
+    for beat in beats {
+        if options.include_beat_markers && !beat.content.trim().is_empty() {
+            let beat_title = escape_xml(&transform_text(&beat.content));
+            body.push_str(&format!("\n  <h3 class=\"beat-title\">{}</h3>", beat_title));
+        }
+
+        if let Some(prose) = beat
+            .prose
+            .as_ref()
+            .filter(|_| !uses_page_prose(scene, beats))
+        {
+            if !prose.trim().is_empty() {
+                body.push('\n');
+                body.push_str(&render_html_to_xhtml(prose));
+            }
+        }
+    }
+}
+
+/// Gather the active prose for a scene, excluding the inactive editor cache.
+fn gather_scene_prose(conn: &rusqlite::Connection, scene: &Scene) -> Result<String, String> {
+    let beats = db::queries::get_beats(conn, &scene.id).map_err(|e| e.to_string())?;
+    if uses_page_prose(scene, &beats) {
+        return Ok(scene.prose.clone().unwrap_or_default());
+    }
+    Ok(beats
+        .iter()
+        .filter_map(|beat| beat.prose.as_deref())
+        .filter(|prose| !prose.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
 /// Export project to a Scrivener .scriv bundle
@@ -5321,6 +5379,213 @@ mod tests {
     }
 
     #[test]
+    fn manuscript_exports_use_only_active_prose() {
+        use crate::models::{EditorMode, SourceType};
+        use std::io::Read;
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        let project = Project::new("Novel".into(), SourceType::Blank, None);
+        db::insert_project(&conn, &project).unwrap();
+        let chapter = Chapter::new(project.id, "Chapter".into(), 0);
+        db::insert_chapter(&conn, &chapter).unwrap();
+        let mut scene = Scene::new(chapter.id, "Scene".into(), None, 0);
+        db::insert_scene(&conn, &scene).unwrap();
+        let mut beat = Beat::new(scene.id, "Outline".into(), 0);
+        beat.prose = Some("<p><em>Beat active</em></p>".into());
+        let mut second = Beat::new(scene.id, "Next outline".into(), 1);
+        second.prose = Some("<p>Second beat</p>".into());
+        let epub_options = EpubExportOptions {
+            scope: ExportScope::Project,
+            include_beat_markers: false,
+            include_synopsis: false,
+            output_path: String::new(),
+            create_snapshot: false,
+            metadata: EpubMetadata {
+                title: "Novel".into(),
+                author: "Author".into(),
+                description: None,
+                language: "en".into(),
+            },
+            theme: EpubTheme::default(),
+            include_cover_image: false,
+            cover_image_path: None,
+        };
+        // Includes empty active page text and the legacy no-beats fallback.
+        for (mode, has_beats, page) in [
+            (
+                EditorMode::Page,
+                false,
+                "<p><strong>Page active</strong></p><p>Next paragraph</p>",
+            ),
+            (
+                EditorMode::Page,
+                true,
+                "<p><strong>Page active</strong></p><p>Next paragraph</p>",
+            ),
+            (EditorMode::Beat, true, "<p>Stale page</p>"),
+            (EditorMode::Beat, false, "<p>Page active</p>"),
+            (EditorMode::Page, true, ""),
+        ] {
+            scene.editor_mode = mode;
+            scene.prose = Some(page.into());
+            conn.execute(
+                "UPDATE scenes SET editor_mode = ?1, prose = ?2 WHERE id = ?3",
+                rusqlite::params![
+                    if mode == EditorMode::Page {
+                        "page"
+                    } else {
+                        "beat"
+                    },
+                    page,
+                    scene.id.to_string()
+                ],
+            )
+            .unwrap();
+            conn.execute("DELETE FROM beats", []).unwrap();
+            let beats = if has_beats {
+                vec![beat.clone(), second.clone()]
+            } else {
+                vec![]
+            };
+            for beat in &beats {
+                db::insert_beat(&conn, beat).unwrap();
+            }
+            let page_active = mode == EditorMode::Page || !has_beats;
+            let active = if page_active {
+                if page.is_empty() {
+                    ""
+                } else {
+                    "Page active"
+                }
+            } else {
+                "Beat active"
+            };
+            let inactive = if page_active {
+                "Beat active"
+            } else {
+                "Stale page"
+            };
+            for markers in [false, true] {
+                let mut options = default_test_options();
+                options.include_beat_markers = markers;
+                options.include_synopsis = false;
+                let mut buffer = std::io::Cursor::new(Vec::new());
+                add_scene_to_docx(Docx::new(), &scene, &beats, &options, true)
+                    .build()
+                    .pack(&mut buffer)
+                    .unwrap();
+                buffer.set_position(0);
+                let mut archive = zip::ZipArchive::new(buffer).unwrap();
+                let mut xml = String::new();
+                archive
+                    .by_name("word/document.xml")
+                    .unwrap()
+                    .read_to_string(&mut xml)
+                    .unwrap();
+                let mut epub = String::new();
+                let mut epub_options = epub_options.clone();
+                epub_options.include_beat_markers = markers;
+                append_scene_to_epub(&mut epub, &scene, &beats, &epub_options);
+                let markdown = generate_scene_markdown(&scene, &beats, markers);
+                for output in [&xml, &epub, &markdown] {
+                    assert_eq!(
+                        output.contains("Outline"),
+                        markers && has_beats,
+                        "Beat marker option lost in {output}"
+                    );
+                }
+                let scrivener = gather_scene_prose(&conn, &scene).unwrap();
+                for output in [
+                    xml.clone(),
+                    epub,
+                    scrivener.clone(),
+                    markdown,
+                    generate_longform_scene_markdown(
+                        &project,
+                        &scene,
+                        &beats,
+                        &[],
+                        None,
+                        &Default::default(),
+                    )
+                    .unwrap(),
+                ] {
+                    assert!(!output.contains(inactive), "Inactive copy in {output}");
+                    if !active.is_empty() {
+                        assert_eq!(
+                            output.matches(active).count(),
+                            1,
+                            "Missing or duplicate active prose in {output}"
+                        );
+                    }
+                    if !page_active {
+                        assert_eq!(output.matches("Second beat").count(), 1);
+                    }
+                }
+                assert_eq!(
+                    calculate_project_word_count(&conn, &project.id).unwrap() as i64,
+                    db::writing::count_words(&scrivener)
+                );
+                if page.contains("strong") {
+                    assert!(xml.contains("<w:b"), "Page formatting lost");
+                    assert!(xml.contains("Next paragraph"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn longform_roundtrip_preserves_page_mode_with_outline_beats() {
+        use crate::models::{EditorMode, SourceType};
+        let project = Project::new("Novel".into(), SourceType::Blank, None);
+        let mut scene = Scene::new(Uuid::new_v4(), "Scene".into(), None, 0);
+        scene.editor_mode = EditorMode::Page;
+        scene.prose = Some("<p>Current page manuscript.</p>".into());
+        let mut beat = Beat::new(scene.id, "Outline prompt".into(), 0);
+        beat.prose = Some("<p>Stale beat manuscript.</p>".into());
+        let dir = tempfile::tempdir().unwrap();
+        let index = dir.path().join("Project.md");
+        fs::write(
+            &index,
+            generate_longform_frontmatter("Novel", ".", &["Scene".into()]).unwrap(),
+        )
+        .unwrap();
+        let scene_path = dir.path().join("Scene.md");
+        fs::write(
+            &scene_path,
+            generate_longform_scene_markdown(
+                &project,
+                &scene,
+                &[beat],
+                &[],
+                None,
+                &Default::default(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        for _ in 0..2 {
+            let parsed = crate::parsers::longform::parse_longform_index(&index).unwrap();
+            assert_eq!(parsed.scenes[0].editor_mode, EditorMode::Page);
+            assert_eq!(parsed.beats.len(), 1);
+            assert_eq!(parsed.beats[0].content, "Outline prompt");
+            assert!(parsed.beats[0].prose.is_none());
+            let markdown = generate_longform_scene_markdown(
+                &parsed.project,
+                &parsed.scenes[0],
+                &parsed.beats,
+                &[],
+                None,
+                &Default::default(),
+            )
+            .unwrap();
+            assert_eq!(markdown.matches("Current page manuscript.").count(), 1);
+            assert!(!markdown.contains("Stale beat manuscript."));
+            fs::write(&scene_path, markdown).unwrap();
+        }
+    }
+
+    #[test]
     fn title_page_word_count_matches_active_writing_prose() {
         use crate::models::{Beat, Chapter, EditorMode, Project, Scene, SourceType};
         let conn = rusqlite::Connection::open_in_memory().unwrap();
@@ -5998,7 +6263,7 @@ mod tests {
         assert!(markdown.contains("synopsis=\"Short synopsis\""));
         assert!(markdown.contains("# Scene Title"));
         assert!(markdown.contains("> Short synopsis"));
-        assert!(markdown.contains("Scene prose."));
+        assert!(!markdown.contains("Scene prose."));
         assert!(markdown.contains("<!-- kindling: beats -->"));
         assert!(markdown.contains("- Beat One"));
         assert!(markdown.contains("Beat prose."));

--- a/src-tauri/src/commands/novelwriter_sync.rs
+++ b/src-tauri/src/commands/novelwriter_sync.rs
@@ -50,10 +50,10 @@ fn prose(value: Option<&str>) -> String {
     html_to_nw(value.unwrap_or_default())
 }
 fn scene_prose(scene: &Scene, beats: &[Beat]) -> String {
-    if scene.editor_mode == EditorMode::Page {
+    let mut ordered: Vec<_> = beats.iter().filter(|b| b.scene_id == scene.id).collect();
+    if scene.editor_mode == EditorMode::Page || ordered.is_empty() {
         return prose(scene.prose.as_deref());
     }
-    let mut ordered: Vec<_> = beats.iter().filter(|b| b.scene_id == scene.id).collect();
     ordered.sort_by_key(|b| b.position);
     ordered
         .iter()
@@ -361,6 +361,19 @@ mod tests {
         super::super::import::insert_novelwriter(&conn, &parsed).unwrap();
         (conn, parsed.project, temp)
     }
+    #[test]
+    fn no_beats_use_scene_prose_even_when_other_scenes_have_beats() {
+        let mut scene = Scene::new(Uuid::new_v4(), "Scene".into(), None, 0);
+        scene.prose = Some("<p>Fallback manuscript</p>".into());
+        let unrelated = Beat::new(Uuid::new_v4(), "Other scene".into(), 0);
+        assert_eq!(scene_prose(&scene, &[unrelated]), "Fallback manuscript");
+        let mut beat = Beat::new(scene.id, "Outline".into(), 0);
+        beat.prose = Some("<p>Beat manuscript</p>".into());
+        assert_eq!(scene_prose(&scene, &[beat.clone()]), "Beat manuscript");
+        scene.editor_mode = EditorMode::Page;
+        assert_eq!(scene_prose(&scene, &[beat]), "Fallback manuscript");
+    }
+
     #[test]
     fn selective_prose_sync_and_locks() {
         let (conn, project, _temp) = imported();

--- a/src-tauri/src/commands/snapshot.rs
+++ b/src-tauri/src/commands/snapshot.rs
@@ -38,7 +38,7 @@ fn get_snapshots_dir(app_handle: &AppHandle, project_id: &Uuid) -> Result<PathBu
 fn generate_snapshot_filename(trigger: &SnapshotTrigger) -> String {
     let timestamp = chrono::Utc::now().format("%Y-%m-%d_%H%M%S");
     let trigger_str = trigger.as_str();
-    format!("{}_{}.json.gz", timestamp, trigger_str)
+    format!("{}_{}_{}.json.gz", timestamp, Uuid::new_v4(), trigger_str)
 }
 
 /// Collect all project data for snapshotting
@@ -103,7 +103,7 @@ fn serialize_and_compress(data: &SnapshotData, file_path: &PathBuf) -> Result<(i
     let json = serde_json::to_string(data).map_err(|e| e.to_string())?;
     let uncompressed_size = json.len() as i64;
 
-    let file = File::create(file_path).map_err(|e| e.to_string())?;
+    let file = File::create_new(file_path).map_err(|e| e.to_string())?;
     let mut encoder = GzEncoder::new(file, Compression::default());
     encoder
         .write_all(json.as_bytes())
@@ -660,8 +660,46 @@ mod tests {
         let filename = generate_snapshot_filename(&SnapshotTrigger::Manual);
         assert!(filename.ends_with("_manual.json.gz"));
         let parts: Vec<&str> = filename.split('_').collect();
-        assert_eq!(parts.len(), 3);
-        assert_eq!(parts[2], "manual.json.gz");
+        assert_eq!(parts.len(), 4);
+        assert!(Uuid::parse_str(parts[2]).is_ok());
+        assert_eq!(parts[3], "manual.json.gz");
+    }
+
+    #[test]
+    fn rapid_snapshots_keep_independent_content_and_survive_deletion() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        db::initialize_schema(&conn).unwrap();
+        let project = Project::new("First content".into(), SourceType::Blank, None);
+        db::insert_project(&conn, &project).unwrap();
+        let mut data = collect_project_data(&conn, &project.id).unwrap();
+        let dir = tempdir().unwrap();
+        for trigger in [SnapshotTrigger::Manual, SnapshotTrigger::Export] {
+            // No sleeps: both names may be generated during the same clock tick.
+            let first = dir.path().join(generate_snapshot_filename(&trigger));
+            let second = dir.path().join(generate_snapshot_filename(&trigger));
+            assert_ne!(first, second);
+            data.project.name = "First content".into();
+            serialize_and_compress(&data, &first).unwrap();
+            data.project.name = "Second content".into();
+            serialize_and_compress(&data, &second).unwrap();
+            assert!(
+                serialize_and_compress(&data, &first).is_err(),
+                "Existing files must never be truncated"
+            );
+            assert_eq!(
+                decompress_and_deserialize(&first).unwrap().project.name,
+                "First content"
+            );
+            assert_eq!(
+                decompress_and_deserialize(&second).unwrap().project.name,
+                "Second content"
+            );
+            fs::remove_file(first).unwrap();
+            assert_eq!(
+                decompress_and_deserialize(&second).unwrap().project.name,
+                "Second content"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/db/writing.rs
+++ b/src-tauri/src/db/writing.rs
@@ -28,20 +28,23 @@ pub fn count_words(html: &str) -> i64 {
     text.split_whitespace().count() as i64
 }
 
+/// Scenes without beats expose scene prose as a read-only fallback in Beat View.
+pub fn uses_page_prose(scene: &crate::models::Scene, beats: &[crate::models::Beat]) -> bool {
+    scene.editor_mode == crate::models::EditorMode::Page || beats.is_empty()
+}
+
 pub fn scene_words(conn: &Connection, scene_id: &Uuid) -> Result<i64> {
     let scene =
         super::get_scene_by_id(conn, scene_id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)?;
     let beats = super::get_beats(conn, scene_id)?;
-    Ok(
-        if scene.editor_mode == crate::models::EditorMode::Page || beats.is_empty() {
-            count_words(scene.prose.as_deref().unwrap_or(""))
-        } else {
-            beats
-                .iter()
-                .map(|b| count_words(b.prose.as_deref().unwrap_or("")))
-                .sum()
-        },
-    )
+    Ok(if uses_page_prose(&scene, &beats) {
+        count_words(scene.prose.as_deref().unwrap_or(""))
+    } else {
+        beats
+            .iter()
+            .map(|b| count_words(b.prose.as_deref().unwrap_or("")))
+            .sum()
+    })
 }
 
 pub fn daily_goal(conn: &Connection, project_id: &str) -> Result<i64> {

--- a/src-tauri/src/parsers/longform.rs
+++ b/src-tauri/src/parsers/longform.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 use walkdir::WalkDir;
 
 use crate::models::{
-    Beat, Chapter, Character, Location, Project, ReferenceItem, Scene, SceneStatus, SceneType,
-    SourceType,
+    Beat, Chapter, Character, EditorMode, Location, Project, ReferenceItem, Scene, SceneStatus,
+    SceneType, SourceType,
 };
 
 const LONGFORM_DEFAULT_CHAPTER_SOURCE_ID: &str = "longform:default";
@@ -113,6 +113,7 @@ struct BeatContent {
 }
 
 struct SceneContent {
+    editor_mode: EditorMode,
     synopsis: Option<String>,
     prose: Option<String>,
     scene_type: SceneType,
@@ -1290,6 +1291,7 @@ fn parse_scene_file(path: &Path) -> Result<SceneContent, LongformError> {
 }
 
 fn parse_scene_body(content: &str) -> SceneContent {
+    let mut editor_mode = EditorMode::Beat;
     let mut scene_type = SceneType::Normal;
     let mut scene_status = SceneStatus::Draft;
     let mut synopsis = None;
@@ -1319,6 +1321,9 @@ fn parse_scene_body(content: &str) -> SceneContent {
 
         if !in_beats && !metadata_parsed {
             if let Some(meta) = parse_kindling_comment(trimmed) {
+                if let Some(value) = meta.get("editor_mode") {
+                    editor_mode = EditorMode::parse(value);
+                }
                 if let Some(value) = meta.get("scene_type") {
                     scene_type = SceneType::parse(value);
                 }
@@ -1390,6 +1395,7 @@ fn parse_scene_body(content: &str) -> SceneContent {
     let beats = parse_beats_block(&beat_lines.join("\n"));
 
     SceneContent {
+        editor_mode,
         synopsis,
         prose,
         scene_type,
@@ -2025,6 +2031,7 @@ fn add_scene_from_entry(
         scene_position,
     )
     .with_source_id(Some(scene_source_id));
+    scene.editor_mode = scene_content.editor_mode;
     scene.prose = scene_content.prose;
     scene.scene_type = scene_content.scene_type;
     scene.scene_status = scene_content.scene_status;

--- a/src-tauri/src/parsers/novelwriter/tests.rs
+++ b/src-tauri/src/parsers/novelwriter/tests.rs
@@ -465,3 +465,21 @@ fn export_allows_os_metadata_but_rejects_hidden_user_content() {
         );
     }
 }
+
+#[test]
+fn export_scene_prose_fallback_without_beats() {
+    let (conn, project) = fixture();
+    conn.execute("DELETE FROM beats", []).unwrap();
+    conn.execute(
+        "UPDATE scenes SET editor_mode = 'beat', prose = '<p>Fallback manuscript</p>'",
+        [],
+    )
+    .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    export_novelwriter_project(&conn, &project.id, dir.path(), &Default::default()).unwrap();
+    let parsed = parse_novelwriter_project(dir.path()).unwrap();
+    assert!(parsed.scenes.iter().all(|scene| scene
+        .prose
+        .as_deref()
+        .is_some_and(|text| text.contains("Fallback manuscript"))));
+}

--- a/src-tauri/src/parsers/novelwriter/writer.rs
+++ b/src-tauri/src/parsers/novelwriter/writer.rs
@@ -316,7 +316,7 @@ pub fn export_novelwriter_project(
                 .filter(|beat| beat.scene_id == scene.id)
                 .collect();
             scene_beats.sort_by_key(|beat| beat.position);
-            if scene.editor_mode == EditorMode::Page {
+            if scene.editor_mode == EditorMode::Page || scene_beats.is_empty() {
                 // Page prose has no defensible beat boundaries.
                 body.push_str(&format!(
                     "\n{}\n",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -185,6 +185,32 @@
 
   let quitConfirmation: HTMLDialogElement | undefined = $state();
 
+  let finishQuitFocus: ((restore: boolean) => void) | undefined;
+
+  function captureCurrentWritingFocus(isTemporaryFocus?: (target: Event["target"]) => boolean) {
+    const projectId = currentProject.value?.id;
+    const sceneId = currentProject.currentScene?.id;
+    return captureWritingFocus(
+      () => currentProject.value?.id === projectId && currentProject.currentScene?.id === sceneId,
+      isTemporaryFocus
+    );
+  }
+
+  async function keepEditing() {
+    if (closePending) return;
+    const finish = finishQuitFocus;
+    finishQuitFocus = undefined;
+    quitConfirmation?.close();
+    discardQuitDrafts = null;
+    await tick();
+    finish?.(true);
+  }
+
+  function releaseQuitFocus() {
+    finishQuitFocus?.(false);
+    finishQuitFocus = undefined;
+  }
+
   function focusQuitConfirmation(node: HTMLDialogElement) {
     node.showModal();
     node.querySelector<HTMLElement>("button")?.focus();
@@ -219,7 +245,7 @@
       }
       event.preventDefault();
       event.stopImmediatePropagation();
-      if (event.key === "Escape" && !closePending && !updatePending) discardQuitDrafts = null;
+      if (event.key === "Escape" && !closePending && !updatePending) void keepEditing();
     };
     window.addEventListener("keydown", guardKeyboard, true);
     return () => window.removeEventListener("keydown", guardKeyboard, true);
@@ -228,10 +254,14 @@
   function flushBeforeClose() {
     if (discardQuitDrafts || updatePending) return Promise.resolve(false);
     if (closeRequest) return closeRequest;
+    finishQuitFocus = captureCurrentWritingFocus(
+      (target) => target instanceof Node && !!quitConfirmation?.contains(target)
+    );
     closePending = true;
     closeRequest = saveBeforeClose().finally(() => {
       closePending = false;
       closeRequest = null;
+      if (!discardQuitDrafts) releaseQuitFocus();
     });
     return closeRequest;
   }
@@ -289,6 +319,7 @@
   async function quitAndDiscard() {
     const approved = discardQuitDrafts;
     if (!approved || closePending) return;
+    releaseQuitFocus();
     closePending = true;
     try {
       if (editorialQuitFailed) editorial?.discardForQuit();
@@ -313,6 +344,7 @@
       if (!(await flushBeforeClose())) event.preventDefault();
     });
     return () => {
+      releaseQuitFocus();
       void unlisten.then((stop) => stop());
     };
   });
@@ -545,13 +577,7 @@
   disabled={closePending || discardQuitDrafts !== null}
   bind:restarting={updatePending}
   prepare={flushProseBeforeExit}
-  captureFocus={() => {
-    const projectId = currentProject.value?.id;
-    const sceneId = currentProject.currentScene?.id;
-    return captureWritingFocus(
-      () => currentProject.value?.id === projectId && currentProject.currentScene?.id === sceneId
-    );
-  }}
+  captureFocus={() => captureCurrentWritingFocus()}
 />
 
 {#if discardQuitDrafts}
@@ -560,7 +586,10 @@
     aria-labelledby="quit-confirmation-title"
     bind:this={quitConfirmation}
     use:focusQuitConfirmation
-    oncancel={(event) => event.preventDefault()}
+    oncancel={(event) => {
+      event.preventDefault();
+      void keepEditing();
+    }}
     class="border-0 p-0 max-w-none max-h-none backdrop:bg-transparent"
   >
     <ConfirmDialog
@@ -579,9 +608,7 @@
       confirmLabel="Quit and discard"
       cancelLabel="Keep editing"
       onConfirm={quitAndDiscard}
-      onCancel={() => {
-        if (!closePending) discardQuitDrafts = null;
-      }}
+      onCancel={keepEditing}
     />
     {@render errorToast()}
   </dialog>

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1209,3 +1209,87 @@ it("preserves paste-as-plain-text and allows Quit from Settings when not recordi
   await fireEvent.keyDown(window, { key: "q", ctrlKey: true });
   await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
 });
+
+it.each(["menu", "native"])(
+  "restores quit selection through both dismissal actions for %s",
+  async (path) => {
+    vi.useFakeTimers();
+    currentProject.setChapters(mockChapters);
+    render(App);
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+    const editor = screen.getByPlaceholderText(
+      "Write a brief synopsis for this scene..."
+    ) as HTMLTextAreaElement;
+    await fireEvent.input(editor, { target: { value: "My unsaved writing" } });
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_scene_synopsis") throw new Error("disk full");
+      return [];
+    });
+    for (const action of ["button", "Escape", "cancel"]) {
+      editor.focus();
+      editor.setSelectionRange(3, 7, "backward");
+      if (path === "menu") await menu("quit");
+      else
+        await vi
+          .mocked(getCurrentWindow().onCloseRequested)
+          .mock.calls[0][0]({ preventDefault: vi.fn() } as never);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(document.activeElement?.closest("[data-quit-confirmation]")).toBeTruthy();
+      editor.setSelectionRange(0, 0);
+      if (action === "button")
+        await fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+      else if (action === "Escape") await fireEvent.keyDown(window, { key: "Escape" });
+      else
+        await fireEvent(
+          document.querySelector("[data-quit-confirmation]")!,
+          new Event("cancel", { cancelable: true })
+        );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(document.activeElement).toBe(editor);
+      expect([editor.selectionStart, editor.selectionEnd, editor.selectionDirection]).toEqual([
+        3,
+        7,
+        "backward",
+      ]);
+      expect(editor.value).toBe("My unsaved writing");
+    }
+  }
+);
+
+it.each(["scene", "project", "other control", "unmount"])(
+  "does not restore quit focus after %s changes",
+  async (target) => {
+    vi.useFakeTimers();
+    currentProject.setChapters(mockChapters);
+    const app = render(App);
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByRole("button", { name: "Edit synopsis" }));
+    const editor = screen.getByPlaceholderText(
+      "Write a brief synopsis for this scene..."
+    ) as HTMLTextAreaElement;
+    await fireEvent.input(editor, { target: { value: "My unsaved writing" } });
+    editor.focus();
+    editor.setSelectionRange(3, 7);
+    vi.mocked(invoke).mockImplementation(async (cmd) => {
+      if (cmd === "save_scene_synopsis") throw new Error("disk full");
+      return [];
+    });
+    await menu("quit");
+    await vi.advanceTimersByTimeAsync(0);
+    const other = document.createElement("button");
+    if (target === "scene")
+      currentProject.setCurrentScene({ ...mockScenes[1], planning_status: "undefined" });
+    if (target === "project") currentProject.setProject(null);
+    if (target === "other control") {
+      document.body.append(other);
+      other.focus();
+      other.blur();
+    }
+    if (target === "unmount") app.unmount();
+    else await fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.activeElement).not.toBe(editor);
+    other.remove();
+  }
+);

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -14,6 +14,11 @@
     onChange: (value: string | null) => void;
   } = $props();
 
+  const fieldId = $props.id();
+  const isMultiselect = $derived(
+    definition.field_type === "multiselect" || definition.field_type === "multi_select"
+  );
+
   let selectOptions = $derived.by<string[]>(() => {
     if (!definition.options) return [];
     try {
@@ -82,13 +87,25 @@
 </script>
 
 <div>
-  <label class="block text-press-ui text-press-muted mb-1">
-    {definition.name}
-    {#if definition.required}<span class="text-press-error">*</span>{/if}
-  </label>
+  {#if isMultiselect}
+    <div id={`${fieldId}-label`} class="block text-press-ui text-press-muted mb-1">
+      {definition.name}
+      {#if definition.required}<span class="text-press-error" aria-hidden="true">*</span>{/if}
+    </div>
+    {#if definition.required}<span id={`${fieldId}-required`} class="sr-only"
+        >Choose at least one option (required).</span
+      >{/if}
+  {:else}
+    <div class="flex gap-1 text-press-ui text-press-muted mb-1">
+      <label for={fieldId}>{definition.name}</label>
+      {#if definition.required}<span class="text-press-error" aria-hidden="true">*</span>{/if}
+    </div>
+  {/if}
 
   {#if definition.field_type === "text"}
     <input
+      id={fieldId}
+      aria-required={definition.required}
       type="text"
       value={value ?? ""}
       oninput={handleTextInput}
@@ -98,6 +115,8 @@
     />
   {:else if definition.field_type === "number"}
     <input
+      id={fieldId}
+      aria-required={definition.required}
       type="number"
       value={value ?? ""}
       oninput={handleNumberInput}
@@ -107,6 +126,8 @@
     />
   {:else if definition.field_type === "date"}
     <input
+      id={fieldId}
+      aria-required={definition.required}
       type="date"
       value={value ?? ""}
       oninput={handleDateInput}
@@ -116,6 +137,8 @@
   {:else if definition.field_type === "url"}
     <div class="flex gap-2 items-center">
       <input
+        id={fieldId}
+        aria-required={definition.required}
         type="url"
         value={value ?? ""}
         oninput={handleTextInput}
@@ -136,14 +159,26 @@
       {/if}
     </div>
   {:else if definition.field_type === "select"}
-    <select value={value ?? ""} onchange={handleSelectInput} class={inputClass} {disabled}>
+    <select
+      id={fieldId}
+      aria-required={definition.required}
+      value={value ?? ""}
+      onchange={handleSelectInput}
+      class={inputClass}
+      {disabled}
+    >
       <option value="">— Select —</option>
       {#each selectOptions as option}
         <option value={option}>{option}</option>
       {/each}
     </select>
   {:else if definition.field_type === "multiselect" || definition.field_type === "multi_select"}
-    <div class="flex flex-wrap gap-2">
+    <div
+      role="group"
+      aria-labelledby={`${fieldId}-label`}
+      aria-describedby={definition.required ? `${fieldId}-required` : undefined}
+      class="flex flex-wrap gap-2"
+    >
       {#each selectOptions as option}
         <label
           class="inline-flex items-center gap-1.5 text-press-ui text-press-text cursor-pointer"
@@ -160,18 +195,21 @@
       {/each}
     </div>
   {:else if definition.field_type === "checkbox"}
-    <label class="inline-flex items-center gap-2 text-press-ui text-press-text cursor-pointer">
+    <div class="inline-flex items-center gap-2 text-press-ui text-press-text">
       <input
+        id={fieldId}
+        aria-required={definition.required}
         type="checkbox"
         class="accent-accent"
         checked={value === "true"}
         onchange={handleCheckboxInput}
         {disabled}
       />
-      {definition.name}
-    </label>
+    </div>
   {:else}
     <input
+      id={fieldId}
+      aria-required={definition.required}
       type="text"
       value={value ?? ""}
       oninput={handleTextInput}

--- a/src/lib/components/FieldRenderer.test.ts
+++ b/src/lib/components/FieldRenderer.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import FieldRenderer from "./FieldRenderer.svelte";
+import NewProjectDialog from "./NewProjectDialog.svelte";
+import TagManager from "./TagManager.svelte";
+import type { FieldDefinition, FieldType } from "../types";
+
+vi.hoisted(() => {
+  vi.stubGlobal("localStorage", { getItem: () => null, setItem: vi.fn(), removeItem: vi.fn() });
+});
+afterEach(cleanup);
+const definition: FieldDefinition = {
+  id: "field",
+  project_id: "project",
+  entity_type: "character",
+  name: "Motivation",
+  field_type: "text",
+  options: '["First", "Second"]',
+  default_value: null,
+  position: 0,
+  required: true,
+  visible: true,
+  created_at: "2026-09-10",
+};
+
+it.each(["text", "number", "date", "url", "select", "checkbox", "unknown"])(
+  "associates the %s control with its field name and required state",
+  (type) => {
+    render(FieldRenderer, {
+      definition: { ...definition, field_type: type as FieldType },
+      value: null,
+      onChange: vi.fn(),
+    });
+    const control = screen.getByLabelText(definition.name);
+    expect(control.id).toBeTruthy();
+    expect(control.getAttribute("aria-required")).toBe("true");
+    expect(document.querySelector("label")?.htmlFor).toBe(control.id);
+  }
+);
+
+it("assigns unique labels when the same definition appears twice", () => {
+  for (let i = 0; i < 2; i++) render(FieldRenderer, { definition, value: null, onChange: vi.fn() });
+  const controls = screen.getAllByLabelText(definition.name);
+  expect(controls).toHaveLength(2);
+  expect(controls[0].id).not.toBe(controls[1].id);
+});
+
+it.each(["multiselect", "multi_select"])(
+  "names the %s group and describes its required constraint",
+  async (type) => {
+    const onChange = vi.fn();
+    render(FieldRenderer, {
+      definition: { ...definition, field_type: type as FieldType },
+      value: null,
+      onChange,
+    });
+    const group = screen.getByRole("group", { name: definition.name });
+    expect(document.getElementById(group.getAttribute("aria-describedby")!)?.textContent).toContain(
+      "required"
+    );
+    await fireEvent.click(within(group).getByRole("checkbox", { name: "First" }));
+    expect(onChange).toHaveBeenCalledWith('["First"]');
+    expect(within(group).getByRole("checkbox", { name: "Second" }).hasAttribute("required")).toBe(
+      false
+    );
+  }
+);
+
+it("preserves optional and disabled control semantics", async () => {
+  const onChange = vi.fn();
+  render(FieldRenderer, {
+    definition: { ...definition, required: false },
+    value: "Text",
+    disabled: true,
+    onChange,
+  });
+  const control = screen.getByLabelText(definition.name) as HTMLInputElement;
+  expect(control.disabled).toBe(true);
+  expect(control.getAttribute("aria-required")).toBe("false");
+  expect(control.value).toBe("Text");
+});
+
+it("names the project type and template groups", () => {
+  render(NewProjectDialog, { onClose: vi.fn() });
+  expect(
+    within(screen.getByRole("group", { name: "Project type" })).getByRole("button", {
+      name: "Novel",
+    })
+  ).toBeTruthy();
+  expect(
+    within(screen.getByRole("group", { name: "Structure template" })).getByRole("button", {
+      name: "Browse templates...",
+    })
+  ).toBeTruthy();
+});
+
+it("names the tag color group", async () => {
+  vi.mocked(invoke).mockResolvedValue([]);
+  render(TagManager, { projectId: "project" });
+  await fireEvent.click(await screen.findByRole("button", { name: /New tag/i }));
+  expect(
+    within(screen.getByRole("group", { name: "Color" })).getByRole("button", { name: "No color" })
+  ).toBeTruthy();
+});

--- a/src/lib/components/NewProjectDialog.svelte
+++ b/src/lib/components/NewProjectDialog.svelte
@@ -127,8 +127,8 @@
     </div>
 
     <div class="p-4 space-y-4">
-      <div>
-        <label class="block text-press-ui font-medium text-press-muted mb-2">Project type</label>
+      <fieldset>
+        <legend class="block text-press-ui font-medium text-press-muted mb-2">Project type</legend>
         <div class="flex gap-2">
           <button
             type="button"
@@ -153,7 +153,7 @@
             <span class="text-press-text font-medium">Screenplay</span>
           </button>
         </div>
-      </div>
+      </fieldset>
 
       <div>
         <label for="new-project-name" class="block text-press-ui font-medium text-press-muted mb-2">
@@ -183,9 +183,9 @@
         </div>
       {/if}
 
-      <div>
-        <label class="block text-press-ui font-medium text-press-muted mb-2"
-          >Structure template</label
+      <fieldset>
+        <legend class="block text-press-ui font-medium text-press-muted mb-2"
+          >Structure template</legend
         >
         {#if selectedTemplate}
           <div
@@ -214,7 +214,7 @@
             Browse templates...
           </button>
         {/if}
-      </div>
+      </fieldset>
 
       {#if error}
         <p class="text-press-ui text-press-error">{error}</p>

--- a/src/lib/components/TagManager.svelte
+++ b/src/lib/components/TagManager.svelte
@@ -334,8 +334,8 @@
         />
       </div>
 
-      <div>
-        <label class="block text-press-eyebrow text-press-muted mb-1">Color</label>
+      <fieldset>
+        <legend class="block text-press-eyebrow text-press-muted mb-1">Color</legend>
         <div class="flex flex-wrap gap-1.5">
           <button
             onclick={() => {
@@ -369,7 +369,7 @@
             </button>
           {/each}
         </div>
-      </div>
+      </fieldset>
 
       <div class="flex justify-end gap-2">
         <button

--- a/src/lib/utils/writingFocus.ts
+++ b/src/lib/utils/writingFocus.ts
@@ -1,5 +1,8 @@
 /** Preserve a live writing selection while an exit attempt temporarily makes it inert. */
-export function captureWritingFocus(isCurrent: () => boolean): (restore: boolean) => void {
+export function captureWritingFocus(
+  isCurrent: () => boolean,
+  isTemporaryFocus: (target: EventTarget | null) => boolean = () => false
+): (restore: boolean) => void {
   const editor = document.activeElement;
   if (
     !(editor instanceof HTMLElement) ||
@@ -21,7 +24,12 @@ export function captureWritingFocus(isCurrent: () => boolean): (restore: boolean
     !textarea && domSelection?.rangeCount ? domSelection.getRangeAt(0).cloneRange() : null;
   let movedFocus = false;
   const trackFocus = (event: FocusEvent) => {
-    if (event.target !== editor && event.target !== document.body) movedFocus = true;
+    if (
+      event.target !== editor &&
+      event.target !== document.body &&
+      !isTemporaryFocus(event.target)
+    )
+      movedFocus = true;
   };
   document.addEventListener("focusin", trackFocus, true);
 


### PR DESCRIPTION
## Summary

Fix four writing, accessibility, export, and snapshot bugs:

- Restore the original editor and selection when a failed-save quit confirmation is dismissed, while respecting navigation, unmounting, and deliberate focus changes outside the prompt.
- Associate custom reference fields with their labels and required state, and name the color, project-type, and template groups for assistive technology.
- Export each scene's active prose exactly once across DOCX, Markdown, Longform, EPUB, Scrivener, and novelWriter. Preserve optional outline headings, align DOCX body/count selection, and retain Page View through Longform roundtrips.
- Give rapid snapshots independent backing files and prevent accidental file truncation.

## Related Issues

Closes #280
Closes #281
Closes #283
Closes #285

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed
- [x] I have added relevant labels to this PR

## Screenshots/Recordings

Native custom-field and tag components were inspected in light and dark themes; the new-project dialog was inspected in dark theme. The final light-theme new-project screenshot was inconclusive after the machine locked, including a retry after focusing the window. Its live DOM checks confirmed named groups and no horizontal overflow. No Press tokens were changed.

## Testing Instructions

1. Edit a synopsis with a selection, make its save fail, and quit through both the menu and native window close. Choose **Keep editing** or press **Escape**: the original selection should return. Navigation or deliberate focus elsewhere must prevent restoration.
2. Focus custom reference controls and verify their field names and required state. Inspect the Color, Project type, and Structure template groups.
3. Export Page View scenes with no beats and with stale beat prose, then Beat View scenes with stale page prose. Active prose should appear once; optional beat headings should remain available. Check DOCX word counts and export/import a Longform Page View scene twice.
4. Create two same-trigger snapshots in rapid succession with different content, delete the first, and preview/restore the second. Each must retain its own content.

## Additional Notes

Validation for commit `6bf7661`:

- 654 frontend tests across 50 files passed. Coverage: statements 98.59%, branches 94.42%, functions 98.75%, lines 99.20%; all gates passed.
- 466 Rust tests passed with all features.
- Type checking, Prettier, ESLint, cargo fmt, all-target/all-feature Clippy with `-D warnings`, Press checks, QA harness tests, and production frontend build passed.
- Independent review-agent and Claude code-review at high effort both finished with **No findings**. Review findings about Longform roundtrips and optional beat headings were fixed and covered by regression tests before the final reviews.
- Native WKWebView checks confirmed exact backward-selection restoration for menu/native close and button/Escape dismissal. Real Rust locked-scene responses supplied the save-failure case.
- Native manual/export snapshots created 4–7 ms apart retained distinct contents and survived sibling deletion and restoration. A native DOCX export contained Page View prose once and matched the five-word manuscript count.
- QA used a separate app identifier and scratch database; all owned projects and snapshots were removed afterward.

Existing unrelated Svelte/ESLint warnings and the Vite bundle-size advisory remain. Existing snapshots whose contents were already overwritten by a filename collision cannot recover that history. Pre-existing DOCX first-line indentation, screenplay page-estimate counting, and focus loss after a rejected process-exit API call were kept out of scope; no external bug reports were filed. CI results are separate from the local validation above.
